### PR TITLE
fix: Security quick wins (#30, #31, #35, #36, #37)

### DIFF
--- a/backend/api/setup.py
+++ b/backend/api/setup.py
@@ -7,6 +7,7 @@ variables from a .env file. We point it at the user config file via _env_file.
 """
 
 import logging
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, status
@@ -42,6 +43,7 @@ def _write_config(data: dict[str, str]) -> None:
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     lines = [f"{k}={v}" for k, v in data.items()]
     _CONFIG_FILE.write_text("\n".join(lines) + "\n")
+    os.chmod(_CONFIG_FILE, 0o600)
 
 
 @router.get("/status", response_model=SetupStatusResponse)

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -2,13 +2,50 @@
   "$schema": "https://schema.tauri.app/config/2/capability.json",
   "identifier": "default",
   "description": "Default capability for the main window.",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
-    "shell:allow-execute",
-    "shell:allow-spawn",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "starlib-backend"
+        }
+      ]
+    },
+    {
+      "identifier": "shell:allow-spawn",
+      "allow": [
+        {
+          "name": "starlib-backend"
+        }
+      ]
+    },
     "updater:default",
     "dialog:default",
-    "fs:default"
+    {
+      "identifier": "fs:allow-read-file",
+      "allow": [
+        {
+          "path": "$AUDIO/**"
+        },
+        {
+          "path": "$APPCONFIG/**"
+        }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-file",
+      "allow": [
+        {
+          "path": "$AUDIO/**"
+        },
+        {
+          "path": "$APPCONFIG/**"
+        }
+      ]
+    }
   ]
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self' tauri: asset: http://127.0.0.1:8000; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src 'self' http://127.0.0.1:8000 https://secure.soundcloud.com https://api.soundcloud.com https://api-v2.soundcloud.com"
+            "csp": "default-src 'self' tauri: asset: http://127.0.0.1:8000; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://i1.sndcdn.com https://a1.sndcdn.com; connect-src 'self' http://127.0.0.1:8000 https://secure.soundcloud.com https://api.soundcloud.com https://api-v2.soundcloud.com"
         }
     },
     "bundle": {

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Music2, FilePen, Moon, Sun } from "lucide-react";
+import { clearTokens } from "@/lib/auth";
 
 interface User {
   id: number;
@@ -42,8 +43,7 @@ export function Sidebar() {
   }, []);
 
   function handleDisconnect() {
-    localStorage.removeItem("access_token");
-    localStorage.removeItem("sc_user");
+    clearTokens();
     setUser(null);
     router.push("/");
   }

--- a/soundcloud_tools/client.py
+++ b/soundcloud_tools/client.py
@@ -3,7 +3,6 @@ import json
 import logging
 import re
 import urllib.parse as urlparse
-import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -19,7 +18,6 @@ from soundcloud_tools.settings import get_settings
 from soundcloud_tools.utils import chunk_list, generate_random_user_agent, get_default_kwargs
 
 logger = logging.getLogger(__name__)
-warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
 
 
 class SplitParams(BaseModel):
@@ -168,7 +166,7 @@ class Client:
         kwargs["params"] = kwargs.get("params", {}) | self.params
         if self.settings.proxy:
             kwargs.setdefault("proxies", self.proxies)
-        kwargs.setdefault("verify", False)
+
         logger.info(f"Making request {method} {url}")
         response = requests.request(method, url, **kwargs)
         logger.info(f"Response {response.status_code} for {method} {response.url}")


### PR DESCRIPTION
## Security Quick Wins

Addresses five small-effort security issues from code review:

### Changes
- **#30 TLS verification**: Remove `verify=False` and warning suppression from SDK client. All SoundCloud API requests now use proper TLS verification.
- **#31 File permissions**: Set `0o600` permissions on config file after writing credentials, preventing other local processes from reading them.
- **#35 Token cleanup**: Use `clearTokens()` in disconnect handler instead of only removing `access_token`. Now also removes `refresh_token` and `token_expires_at`.
- **#36 Shell/FS scope**: Scope Tauri shell permissions to `starlib-backend` sidecar only. Scope filesystem access to `$AUDIO` and `$APPCONFIG` directories.
- **#37 CSP hardening**: Restrict `img-src` to SoundCloud CDNs (`i1.sndcdn.com`, `a1.sndcdn.com`) instead of all HTTP sources. Add explicit `script-src 'self'`.

Closes #30, closes #31, closes #35, closes #36, closes #37