### PR TITLE
fix: tighten CSP to restrict img-src and add script-src

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self' tauri: asset: http://127.0.0.1:8000; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src 'self' http://127.0.0.1:8000 https://secure.soundcloud.com https://api.soundcloud.com https://api-v2.soundcloud.com"
+            "csp": "default-src 'self' tauri: asset: http://127.0.0.1:8000; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://i1.sndcdn.com https://a1.sndcdn.com; connect-src 'self' http://127.0.0.1:8000 https://secure.soundcloud.com https://api.soundcloud.com https://api-v2.soundcloud.com"
         }
     },
     "bundle": {


### PR DESCRIPTION
## Summary
Restrict Content Security Policy to prevent data exfiltration and script injection.

## Changes
- Restrict `img-src` from `https: http:` (any source) to specific SoundCloud CDN domains (`i1.sndcdn.com`, `a1.sndcdn.com`)
- Add explicit `script-src 'self'` to prevent inline script injection

Closes #37