### PR TITLE
fix: scope shell and filesystem permissions in Tauri capabilities

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -5,10 +5,32 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "shell:allow-execute",
     "shell:allow-spawn",
+    "shell:allow-stdin-write",
+    "shell:allow-kill",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "starlib-backend",
+          "sidecar": true
+        }
+      ]
+    },
     "updater:default",
     "dialog:default",
-    "fs:default"
+    {
+      "identifier": "fs:allow-read-text-file",
+      "allow": [
+        { "path": "$APPCONFIG/**" },
+        { "path": "$AUDIO/**" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [
+        { "path": "$APPCONFIG/**" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Restrict shell and filesystem permissions to minimum required access.

## Changes
- Scope `shell:allow-execute` to only the `starlib-backend` sidecar binary
- Replace broad `fs:default` with scoped `fs:allow-read-text-file` (APPCONFIG + AUDIO) and `fs:allow-write-text-file` (APPCONFIG only)
- Retain `shell:allow-spawn`, `shell:allow-stdin-write`, and `shell:allow-kill` for sidecar lifecycle management

## Impact
XSS can no longer escalate to arbitrary command execution or broad file system access.

Closes #36