### PR TITLE
fix: store PKCE code_verifier server-side and validate state on callback

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth/soundcloud", tags=["authentication"])
 
+# Server-side storage for pending OAuth flows: state -> code_verifier
+_pending_oauth_flows: dict[str, str] = {}
+
 
 @router.get("/authorize", response_model=AuthorizeResponse)
 def get_authorization_url() -> AuthorizeResponse:
@@ -53,7 +56,11 @@ def get_authorization_url() -> AuthorizeResponse:
     }
 
     authorization_url = f"https://secure.soundcloud.com/authorize?{urlencode(params)}"
-    return AuthorizeResponse(authorization_url=authorization_url, state=state, code_verifier=code_verifier)
+
+    # Store code_verifier server-side, keyed by state
+    _pending_oauth_flows[state] = code_verifier
+
+    return AuthorizeResponse(authorization_url=authorization_url, state=state)
 
 
 @router.post("/callback", response_model=CallbackResponse)
@@ -77,6 +84,20 @@ def handle_callback(body: CallbackRequest) -> CallbackResponse:
     """
     settings = get_settings()
 
+    # Validate state and retrieve server-side code_verifier
+    if not body.state:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing state parameter.",
+        )
+
+    code_verifier = _pending_oauth_flows.pop(body.state, None)
+    if code_verifier is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired state parameter.",
+        )
+
     # Exchange code for tokens
     token_resp = requests.post(
         "https://secure.soundcloud.com/oauth/token",
@@ -89,7 +110,7 @@ def handle_callback(body: CallbackRequest) -> CallbackResponse:
             "client_id": settings.client_id,
             "client_secret": settings.client_secret,
             "redirect_uri": settings.soundcloud_redirect_uri,
-            "code_verifier": body.code_verifier,
+            "code_verifier": code_verifier,
             "code": body.code,
         },
         timeout=10,

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -7,8 +7,7 @@ class CallbackRequest(BaseModel):
     """OAuth callback payload from frontend."""
 
     code: str
-    state: str | None = None
-    code_verifier: str
+    state: str
 
 
 class AuthorizeResponse(BaseModel):
@@ -16,7 +15,6 @@ class AuthorizeResponse(BaseModel):
 
     authorization_url: str
     state: str
-    code_verifier: str
 
 
 class UserInfo(BaseModel):

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -8,7 +8,6 @@ import { fetchApi } from "@/lib/api";
 interface AuthorizeResponse {
   authorization_url: string;
   state: string;
-  code_verifier: string;
 }
 
 export default function LoginPage() {
@@ -22,7 +21,6 @@ export default function LoginPage() {
     try {
       const data = await fetchApi<AuthorizeResponse>("/auth/soundcloud/authorize");
       sessionStorage.setItem("oauth_state", data.state);
-      sessionStorage.setItem("oauth_code_verifier", data.code_verifier);
       window.location.href = data.authorization_url;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to initiate login");

--- a/frontend/src/app/auth/soundcloud/callback/page.tsx
+++ b/frontend/src/app/auth/soundcloud/callback/page.tsx
@@ -46,19 +46,12 @@ function CallbackHandler() {
       return;
     }
 
-    const codeVerifier = sessionStorage.getItem("oauth_code_verifier");
-    if (!codeVerifier) {
-      setError("Missing PKCE code verifier. Please try connecting again.");
-      return;
-    }
-
     sessionStorage.removeItem("oauth_state");
-    sessionStorage.removeItem("oauth_code_verifier");
 
     fetchApi<CallbackResponse>("/auth/soundcloud/callback", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code, state, code_verifier: codeVerifier }),
+      body: JSON.stringify({ code, state }),
     })
       .then((data) => {
         storeTokens(data.access_token, data.refresh_token, data.expires_in);


### PR DESCRIPTION
## Summary
Fix the OAuth PKCE flow so code_verifier is stored server-side and state is validated on callback.

## Problem
- `code_verifier` was sent to the frontend and round-tripped back, negating PKCE security
- `state` was not validated server-side, making CSRF attacks possible

## Changes
**Backend:**
- Store `code_verifier` in a server-side dict keyed by `state` token
- Validate `state` on callback — reject missing/invalid/expired state
- Look up `code_verifier` by `state` instead of receiving it from the client
- Remove `code_verifier` from `AuthorizeResponse` and `CallbackRequest` schemas

**Frontend:**
- No longer stores or sends `code_verifier`
- Still stores and validates `state` client-side for immediate UX feedback

Closes #29