### PR TITLE
fix: auto-restart sidecar on crash with retry limit

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ use tauri_plugin_shell::ShellExt;
 const BACKEND_URL: &str = "http://127.0.0.1:8000";
 const HEALTH_MAX_RETRIES: u32 = 30;
 const HEALTH_RETRY_INTERVAL_MS: u64 = 500;
+const MAX_RESTART_ATTEMPTS: u32 = 3;
+const RESTART_DELAY_MS: u64 = 2000;
 
 /// Poll the backend /health endpoint until it responds or retries are exhausted.
 async fn wait_for_backend_ready() -> bool {
@@ -29,35 +31,98 @@ async fn wait_for_backend_ready() -> bool {
     false
 }
 
-/// Start the Python backend sidecar and keep a reference to the child process
-/// so it can be killed when the app window is closed.
-fn start_backend(app: &tauri::AppHandle) {
+/// Spawn the sidecar and forward its output. Returns the child handle.
+fn spawn_sidecar(
+    app: &tauri::AppHandle,
+) -> Result<tauri_plugin_shell::process::CommandChild, String> {
     let shell = app.shell();
-    match shell
+    let (mut rx, child) = shell
         .sidecar("starlib-backend")
         .expect("starlib-backend sidecar not found in bundle")
         .spawn()
-    {
-        Ok((mut rx, child)) => {
-            // Store the child so it lives as long as the app.
-            app.manage(std::sync::Mutex::new(Some(child)));
+        .map_err(|e| format!("Failed to spawn sidecar: {e}"))?;
 
-            // Forward stdout/stderr from the sidecar to the Tauri log.
+    let handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        use tauri_plugin_shell::process::CommandEvent;
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line) => {
+                    eprintln!("[backend] {}", String::from_utf8_lossy(&line));
+                }
+                CommandEvent::Stderr(line) => {
+                    eprintln!("[backend:err] {}", String::from_utf8_lossy(&line));
+                }
+                CommandEvent::Terminated(status) => {
+                    eprintln!("[backend] process exited: {:?}", status);
+                    let _ = handle.emit("backend-disconnected", "Backend process exited");
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(child)
+}
+
+/// Start the Python backend sidecar with automatic restart on crash.
+/// Keeps a reference to the child process so it can be killed on app close.
+fn start_backend(app: &tauri::AppHandle) {
+    match spawn_sidecar(app) {
+        Ok(child) => {
+            app.manage(std::sync::Mutex::new(Some(child)));
+            // Spawn a watchdog that monitors and restarts on crash.
+            let handle = app.clone();
             tauri::async_runtime::spawn(async move {
-                use tauri_plugin_shell::process::CommandEvent;
-                while let Some(event) = rx.recv().await {
-                    match event {
-                        CommandEvent::Stdout(line) => {
-                            eprintln!("[backend] {}", String::from_utf8_lossy(&line));
+                let mut attempts = 0u32;
+                loop {
+                    // Sleep before checking — give the sidecar time to run.
+                    tokio::time::sleep(std::time::Duration::from_millis(RESTART_DELAY_MS)).await;
+
+                    // Check if the child is still held (None means it exited/was taken).
+                    let needs_restart = {
+                        if let Some(mutex) = handle.try_state::<std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>>() {
+                            if let Ok(guard) = mutex.lock() {
+                                guard.is_none()
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
                         }
-                        CommandEvent::Stderr(line) => {
-                            eprintln!("[backend:err] {}", String::from_utf8_lossy(&line));
+                    };
+
+                    if !needs_restart {
+                        // Still running — reset attempt counter and keep watching.
+                        attempts = 0;
+                        continue;
+                    }
+
+                    attempts += 1;
+                    if attempts > MAX_RESTART_ATTEMPTS {
+                        eprintln!(
+                            "[backend] exceeded {MAX_RESTART_ATTEMPTS} restart attempts — giving up"
+                        );
+                        let _ = handle.emit(
+                            "backend-error",
+                            "Backend crashed repeatedly and could not be restarted",
+                        );
+                        break;
+                    }
+
+                    eprintln!("[backend] restarting sidecar (attempt {attempts}/{MAX_RESTART_ATTEMPTS})");
+                    match spawn_sidecar(&handle) {
+                        Ok(child) => {
+                            if let Some(mutex) = handle.try_state::<std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>>() {
+                                if let Ok(mut guard) = mutex.lock() {
+                                    *guard = Some(child);
+                                }
+                            }
                         }
-                        CommandEvent::Terminated(status) => {
-                            eprintln!("[backend] process exited: {:?}", status);
-                            break;
+                        Err(e) => {
+                            eprintln!("[backend] restart failed: {e}");
                         }
-                        _ => {}
                     }
                 }
             });


### PR DESCRIPTION
## Summary
Auto-restart the backend sidecar when it crashes, with a retry limit and user notification.

## Changes
- Extract `spawn_sidecar()` helper for reusable sidecar spawning
- Add watchdog loop that detects sidecar termination and auto-restarts up to 3 times
- Emit `backend-disconnected` event on each crash for UI notification
- Emit `backend-error` event when max retries exhausted
- Add `tokio` dependency for async sleep

Closes #33