### PR TITLE
chore(deps): bump UI components (wavesurfer.js, tailwind-merge) in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
                 "react-dom": "19.2.3",
                 "sonner": "^2.0.7",
                 "tailwind-merge": "^3.5.0",
-                "wavesurfer.js": "^7.12.4"
+                "wavesurfer.js": "^7.12.5"
             },
             "devDependencies": {
                 "@tailwindcss/postcss": "^4",
@@ -11657,9 +11657,9 @@
             }
         },
         "node_modules/wavesurfer.js": {
-            "version": "7.12.4",
-            "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.4.tgz",
-            "integrity": "sha512-b/+XnWfJejNdvNUmtm4M5QzQepHhUbTo+62wYybwdV1B/Sn9vHhgb1xckRm0rGY2ZefJwLkE7lYcKnLfIia4cQ==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.5.tgz",
+            "integrity": "sha512-MSZcA13R9ZlxgYpzfakaSYf8dz5tCdZKYbjtN1qnKbCi+UoyfaTuhvjlXHrITi/fgeO3qWfsH7U3BP1AKnwRNg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/web-streams-polyfill": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "wavesurfer.js": "^7.12.4"
+        "wavesurfer.js": "^7.12.5"
     },
     "devDependencies": {
         "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Grouped bump of UI component dependencies:

- wavesurfer.js 7.12.4 → 7.12.5
- tailwind-merge 3.4.0 → 3.5.0

Supersedes #66, #63