### PR TITLE
fix: resolve root_folder in path validation, validate base64 artwork

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -56,9 +56,10 @@ def validate_file_path(file_path: str, root_folder: Path) -> Path:
 
     path = path.resolve()
 
-    # Security check: must be within root folder
+    # Security check: must be within root folder (resolve root too to handle symlinks)
+    resolved_root = root_folder.resolve()
     try:
-        path.relative_to(root_folder)
+        path.relative_to(resolved_root)
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/api/metadata.py
+++ b/backend/api/metadata.py
@@ -407,7 +407,20 @@ def update_file_info(
 
     # Download and embed artwork from URL if provided
     if updates.artwork_data:
-        artwork_bytes = base64.b64decode(updates.artwork_data)
+        # Limit artwork payload to 10 MB
+        max_artwork_bytes = 10 * 1024 * 1024
+        try:
+            artwork_bytes = base64.b64decode(updates.artwork_data)
+        except Exception as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid base64 artwork data.",
+            ) from e
+        if len(artwork_bytes) > max_artwork_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Artwork data exceeds 10 MB limit.",
+            )
         metadata.add_artwork_to_track(new_path, root_folder, artwork_bytes)
 
     collection.invalidate_cache()


### PR DESCRIPTION
## Summary
Fix path traversal risk and add artwork payload validation.

## Changes
- Resolve `root_folder` before `relative_to` check in `validate_file_path()` to prevent symlink-based directory traversal
- Add error handling for invalid base64 artwork data (returns 400)
- Add 10 MB size limit on decoded artwork (returns 413)

Closes #39