### PR TITLE
feat: add error boundaries and use next-themes ThemeProvider

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Unhandled error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
+      <h2 className="text-lg font-semibold">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground max-w-md text-center">
+        An unexpected error occurred. You can try again or reload the page.
+      </p>
+      <button
+        onClick={reset}
+        className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { PlayerProvider } from "@/lib/player-context";
 import { LayoutShell } from "@/components/layout-shell";
 import { WaveformPlayer } from "@/components/waveform-player";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { ThemeProvider } from "next-themes";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -34,28 +35,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){var t=localStorage.getItem('theme');if(t==='light'){document.documentElement.classList.remove('dark')}else{document.documentElement.classList.add('dark')}})();`,
-          }}
-        />
-      </head>
       <body
         className={`${inter.variable} ${geistMono.variable} antialiased h-screen flex flex-row bg-background text-foreground overflow-hidden`}
       >
-        <NuqsAdapter>
-          <PlayerProvider>
-            <Sidebar />
-            <LayoutShell>
-              <SetupGate>
-                {children}
-                </SetupGate>
-                </LayoutShell>
-            <WaveformPlayer />
-            <Toaster />
-          </PlayerProvider>
-        </NuqsAdapter>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          <NuqsAdapter>
+            <PlayerProvider>
+              <Sidebar />
+              <LayoutShell>
+                <SetupGate>
+                  {children}
+                  </SetupGate>
+                  </LayoutShell>
+              <WaveformPlayer />
+              <Toaster />
+            </PlayerProvider>
+          </NuqsAdapter>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/meta-editor/error.tsx
+++ b/frontend/src/app/meta-editor/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function MetaEditorError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Meta editor error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
+      <h2 className="text-lg font-semibold">Meta Editor Error</h2>
+      <p className="text-sm text-muted-foreground max-w-md text-center">
+        Something went wrong loading the meta editor. Your files are safe.
+      </p>
+      <button
+        onClick={reset}
+        className="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Music2, FilePen, Moon, Sun } from "lucide-react";
 import { clearTokens } from "@/lib/auth";
+import { useTheme } from "next-themes";
 
 interface User {
   id: number;
@@ -21,16 +22,10 @@ export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
-  const [dark, setDark] = useState(true);
-
-  useEffect(() => {
-    setDark(document.documentElement.classList.contains('dark'));
-  }, []);
+  const { theme, setTheme } = useTheme();
 
   function toggleTheme() {
-    const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    setDark(isDark);
+    setTheme(theme === 'dark' ? 'light' : 'dark');
   }
 
   useEffect(() => {
@@ -100,12 +95,12 @@ export function Sidebar() {
       <div className="px-2 pb-1 shrink-0">
         <button
           onClick={toggleTheme}
-          title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
           className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
         >
-          {dark ? <Sun className="size-4 shrink-0" /> : <Moon className="size-4 shrink-0" />}
+          {theme === 'dark' ? <Sun className="size-4 shrink-0" /> : <Moon className="size-4 shrink-0" />}
           <span className="text-xs opacity-0 group-hover/sidebar:opacity-100 transition-opacity duration-150 whitespace-nowrap overflow-hidden">
-            {dark ? 'Light mode' : 'Dark mode'}
+            {theme === 'dark' ? 'Light mode' : 'Dark mode'}
           </span>
         </button>
       </div>


### PR DESCRIPTION
- Replace `dangerouslySetInnerHTML` theme script with `next-themes` `ThemeProvider` (eliminates inline script CSP violation)
- Update sidebar to use `useTheme()` hook instead of manual DOM class manipulation
- Add `error.tsx` at app root and meta-editor route for graceful crash recovery

Closes #47