### PR TITLE
refactor: drive ID3 tags from a registry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,9 @@ jobs:
             - name: Install uv
               uses: astral-sh/setup-uv@v7
 
+            - name: Install ffmpeg
+              run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
             - name: Install dependencies
               run: uv sync --group dev
 

--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -1,7 +1,6 @@
 """File and folder operations for the Meta Editor."""
 
 import base64
-import json
 import logging
 from datetime import date
 from pathlib import Path
@@ -29,11 +28,60 @@ from backend.schemas.metadata import (
     TrackInfoUpdateRequest,
 )
 from soundcloud_tools.handler.folder import FolderHandler
-from soundcloud_tools.handler.track import TrackHandler
+from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackHandler, TrackInfo
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _row_value(row, key, default=None):
+    """sqlite3.Row doesn't support .get(); guard column-missing safely."""
+    try:
+        return row[key]
+    except (IndexError, KeyError):
+        return default
+
+
+def _track_info_to_response_dict(track_info: TrackInfo) -> dict:
+    """Project a TrackInfo into the flat dict used by TrackInfoResponse.
+
+    artist/original_artist/remixer are surfaced as their joined-string form so
+    the API stays a stable shape regardless of the underlying list-vs-scalar.
+    """
+    out: dict = {}
+    for f in SIMPLE_TAG_FIELDS:
+        value = getattr(track_info, f.name)
+        if f.name == "artist":
+            out["artist"] = track_info.artist_str or None
+        elif f.name == "original_artist":
+            out["original_artist"] = track_info.original_artist_str or None
+        elif f.name == "remixer":
+            out["remixer"] = track_info.remixer_str or None
+        elif f.name == "starlib_meta":
+            out["starlib_meta"] = value.to_str() if value else None
+        else:
+            out[f.name] = value
+    return out
+
+
+def _row_to_browse_dict(row) -> dict:
+    """Project a cache_db row into the flat dict used by TrackBrowseResponse."""
+    out = {
+        "title": row["title"],
+        "artist": row["artist_str"],
+        "genre": row["genre"],
+        "bpm": row["bpm"],
+        "key": row["key"],
+        "release_date": date.fromisoformat(row["release_date"]) if row["release_date"] else None,
+        "release_year": _row_value(row, "release_year"),
+        "original_artist": _row_value(row, "original_artist"),
+        "remixer": _row_value(row, "remixer"),
+        "mix_name": _row_value(row, "mix_name"),
+        "user_comment": _row_value(row, "user_comment"),
+        "starlib_meta": None,  # not cached; live read would be required
+    }
+    return out
 
 
 @router.post("/folders/initialize", response_model=OperationResponse)
@@ -165,31 +213,16 @@ def browse_folder_files(
         ) from e
 
     def to_browse_response(row) -> TrackBrowseResponse:
-        try:
-            raw_remixers = row["remixers"]
-        except (IndexError, KeyError):
-            raw_remixers = None
-        remixers = json.loads(raw_remixers) if raw_remixers else None
-        try:
-            sc_id = row["soundcloud_id"]
-        except (IndexError, KeyError):
-            sc_id = None
         return TrackBrowseResponse(
             file_path=row["file_path"],
             file_name=row["file_name"],
-            title=row["title"],
-            artist=row["artist_str"],
-            bpm=row["bpm"],
-            key=row["key"],
-            genre=row["genre"],
-            release_date=date.fromisoformat(row["release_date"]) if row["release_date"] else None,
-            remixers=remixers,
-            soundcloud_id=sc_id,
+            soundcloud_id=_row_value(row, "soundcloud_id"),
             has_artwork=bool(row["has_artwork"]),
             file_format=row["file_format"],
             file_size=row["file_size"] or 0,
             duration=row["duration"],
             mtime=row["mtime"],
+            **_row_to_browse_dict(row),
         )
 
     if collection.is_indexing(folder_path):
@@ -282,18 +315,11 @@ def get_file_info(
     return TrackInfoResponse(
         file_path=str(resolved_path),
         file_name=resolved_path.name,
-        title=track_info.title,
-        artist=track_info.artist_str,
-        bpm=track_info.bpm,
-        key=track_info.key,
-        genre=track_info.genre,
-        comment=track_info.comment.to_str() if track_info.comment else None,
-        release_date=track_info.release_date,
-        remixers=[track_info.remix.remixer_str] if track_info.remix else None,
         has_artwork=track_info.artwork is not None,
         is_ready=readiness["is_ready"],
         missing_fields=readiness["missing_fields"],
         issues=readiness["issues"],
+        **_track_info_to_response_dict(track_info),
     )
 
 
@@ -334,17 +360,7 @@ def update_file_info(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to read current metadata"
         ) from e
 
-    modified_info = metadata.build_modified_track_info(
-        original_info=current_info,
-        title=updates.title,
-        artist=updates.artist,
-        bpm=updates.bpm,
-        key=updates.key,
-        genre=updates.genre,
-        comment=updates.comment,
-        release_date=updates.release_date,
-        remixers=updates.remixers,
-    )
+    modified_info = metadata.build_modified_track_info(current_info, updates)
 
     try:
         new_path = metadata.save_track_metadata(resolved_path, root_folder, modified_info)
@@ -396,18 +412,11 @@ def batch_get_file_info(
                 TrackInfoResponse(
                     file_path=str(resolved_path),
                     file_name=resolved_path.name,
-                    title=track_info.title,
-                    artist=track_info.artist_str,
-                    bpm=track_info.bpm,
-                    key=track_info.key,
-                    genre=track_info.genre,
-                    comment=track_info.comment.to_str() if track_info.comment else None,
-                    release_date=track_info.release_date,
-                    remixers=[track_info.remix.remixer_str] if track_info.remix else None,
                     has_artwork=track_info.artwork is not None,
                     is_ready=readiness["is_ready"],
                     missing_fields=readiness["missing_fields"],
                     issues=readiness["issues"],
+                    **_track_info_to_response_dict(track_info),
                 )
             )
         except Exception:
@@ -429,17 +438,7 @@ def batch_update_file_info(
         try:
             resolved_path = validate_file_path(item.file_path, root_folder)
             current_info = metadata.get_track_info(resolved_path, root_folder)
-            modified_info = metadata.build_modified_track_info(
-                original_info=current_info,
-                title=item.updates.title,
-                artist=item.updates.artist,
-                bpm=item.updates.bpm,
-                key=item.updates.key,
-                genre=item.updates.genre,
-                comment=item.updates.comment,
-                release_date=item.updates.release_date,
-                remixers=item.updates.remixers,
-            )
+            modified_info = metadata.build_modified_track_info(current_info, item.updates)
             new_path = metadata.save_track_metadata(resolved_path, root_folder, modified_info)
 
             if item.updates.artwork_data:

--- a/backend/core/services/cache_db.py
+++ b/backend/core/services/cache_db.py
@@ -83,6 +83,27 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     except sqlite3.OperationalError:
         pass  # column already exists
 
+    # Migrate to the flat-tag schema (issue #285).  Adding any of these columns
+    # invalidates the cache so the next scan repopulates them from disk.
+    new_columns = (
+        ("original_artist", "TEXT"),
+        ("remixer", "TEXT"),
+        ("mix_name", "TEXT"),
+        ("release_year", "INTEGER"),
+        ("user_comment", "TEXT"),
+    )
+    added_any = False
+    for col, sqltype in new_columns:
+        try:
+            conn.execute(f"ALTER TABLE tracks ADD COLUMN {col} {sqltype}")
+            conn.commit()
+            added_any = True
+        except sqlite3.OperationalError:
+            pass
+    if added_any:
+        conn.execute("DELETE FROM tracks")
+        conn.commit()
+
     # Migrate peaks table from single-column PK to composite PK (file_path, num_peaks)
     try:
         cur = conn.execute("PRAGMA table_info(peaks)")
@@ -154,7 +175,11 @@ def upsert_track(
     missing_fields: list[str],
     mtime: float,
     soundcloud_id: int | None = None,
-    remixers: list[str] | None = None,
+    original_artist: str | None = None,
+    remixer: str | None = None,
+    mix_name: str | None = None,
+    release_year: int | None = None,
+    user_comment: str | None = None,
 ) -> None:
     """Insert or replace a track row."""
     conn = _get_conn()
@@ -163,8 +188,9 @@ def upsert_track(
         INSERT OR REPLACE INTO tracks
             (file_path, file_name, folder, title, artist_str, genre, key, bpm,
              release_date, has_artwork, file_size, file_format, duration, is_complete,
-             missing_fields, mtime, soundcloud_id, remixers)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             missing_fields, mtime, soundcloud_id,
+             original_artist, remixer, mix_name, release_year, user_comment)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             str(file_path),
@@ -184,7 +210,11 @@ def upsert_track(
             json.dumps(missing_fields),
             mtime,
             soundcloud_id,
-            json.dumps(remixers) if remixers else None,
+            original_artist or None,
+            remixer or None,
+            mix_name or None,
+            release_year,
+            user_comment or None,
         ),
     )
     conn.commit()
@@ -246,10 +276,26 @@ _SORT_COLS: dict[str, str] = {
     "bpm": "bpm",
     "key": "LOWER(COALESCE(key, ''))",
     "release_date": "release_date",
+    "release_year": "release_year",
+    "original_artist": "LOWER(COALESCE(original_artist, ''))",
+    "remixer": "LOWER(COALESCE(remixer, ''))",
+    "mix_name": "LOWER(COALESCE(mix_name, ''))",
     "file_name": "LOWER(file_name)",
     "mtime": "mtime",
 }
-_NULLABLE_SORT_COLS = {"bpm", "release_date"}
+_NULLABLE_SORT_COLS = {"bpm", "release_date", "release_year"}
+
+# Columns to LIKE-match for search_query.  Mirrors the registry's `searchable`
+# fields plus the persisted `artist_str` joined form.
+_SEARCH_COLS: tuple[str, ...] = ("title", "artist_str", "genre", "original_artist", "remixer")
+
+
+def _search_clause(query: str | None) -> tuple[list[str], list]:
+    if not query:
+        return [], []
+    q = f"%{query}%"
+    cond = "(" + " OR ".join(f"{c} LIKE ?" for c in _SEARCH_COLS) + ")"
+    return [cond], [q] * len(_SEARCH_COLS)
 
 
 def get_tracks(
@@ -292,10 +338,9 @@ def get_tracks(
         artist_conds = " OR ".join("artist_str LIKE ?" for _ in artists)
         conds.append(f"({artist_conds})")
         params.extend(f"%{a}%" for a in artists)
-    if search_query:
-        q = f"%{search_query}%"
-        conds.append("(title LIKE ? OR artist_str LIKE ? OR genre LIKE ?)")
-        params.extend([q, q, q])
+    search_conds, search_params = _search_clause(search_query)
+    conds.extend(search_conds)
+    params.extend(search_params)
 
     where = " AND ".join(conds)
     col = _SORT_COLS.get(sort_by, "LOWER(file_name)")
@@ -345,10 +390,9 @@ def _build_filter_conds(
     if bpm_max is not None:
         conds.append("bpm <= ?")
         params.append(bpm_max)
-    if search_query:
-        q = f"%{search_query}%"
-        conds.append("(title LIKE ? OR artist_str LIKE ? OR genre LIKE ?)")
-        params.extend([q, q, q])
+    search_conds, search_params = _search_clause(search_query)
+    conds.extend(search_conds)
+    params.extend(search_params)
     return conds, params
 
 

--- a/backend/core/services/collection.py
+++ b/backend/core/services/collection.py
@@ -49,7 +49,7 @@ def _index_one(folder: Path, file: Path) -> None:
             missing.append("release_date")
         if not track_info.artwork:
             missing.append("artwork")
-        sc_id = track_info.comment.soundcloud_id if track_info.comment else None
+        sc_id = track_info.starlib_meta.soundcloud_id if track_info.starlib_meta else None
         cache_db.upsert_track(
             file_path=file,
             folder=folder.resolve(),
@@ -67,7 +67,11 @@ def _index_one(folder: Path, file: Path) -> None:
             missing_fields=missing,
             mtime=mtime,
             soundcloud_id=sc_id,
-            remixers=[track_info.remix.remixer_str] if track_info.remix else None,
+            original_artist=track_info.original_artist_str or None,
+            remixer=track_info.remixer_str or None,
+            mix_name=track_info.mix_name,
+            release_year=track_info.release_year,
+            user_comment=track_info.user_comment,
         )
     except Exception as e:
         logger.warning("Skipping unreadable file %s: %s", file, e)
@@ -327,9 +331,9 @@ def load_all_track_infos(folder: Path) -> list[TrackInfo]:
         try:
             result.append(
                 TrackInfo(
-                    title=row["title"] or "",
-                    artist=row["artist_str"] or "",
-                    genre=row["genre"] or "",
+                    title=row["title"],
+                    artist=row["artist_str"],
+                    genre=row["genre"],
                     key=row["key"],
                     bpm=row["bpm"],
                     release_date=date.fromisoformat(row["release_date"]) if row["release_date"] else None,
@@ -422,9 +426,9 @@ def filter_tracks_by_metadata(  # noqa: C901
         if search_query:
             search_lower = search_query.lower()
             searchable = [
-                track.genre.lower(),
+                (track.genre or "").lower(),
                 track.artist_str.lower(),
-                track.title.lower(),
+                (track.title or "").lower(),
             ]
             if not any(search_lower in field for field in searchable):
                 continue

--- a/backend/core/services/metadata.py
+++ b/backend/core/services/metadata.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from backend.core.services import cache_db, rule_engine
 from backend.core.services import folder_config as folder_config_service
 from backend.core.services import ruleset as ruleset_service
-from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackHandler, TrackInfo
+from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, StarlibMeta, TrackHandler, TrackInfo
 from soundcloud_tools.utils.string import (
     remove_double_spaces,
     remove_free_dl,
@@ -116,6 +116,10 @@ def build_modified_track_info(
         value = patch[name]
         if name in {"artist", "original_artist", "remixer"}:
             value = _coerce_artist_field(value)
+        elif name == "starlib_meta" and isinstance(value, str):
+            # Frontend sends the serialised "key=value; ..." form; parse it
+            # back into a StarlibMeta so TrackInfo validation passes.
+            value = StarlibMeta.from_str(value) if value else None
         data[name] = value
 
     # Drop binary artwork (handled separately by the API layer) and the URL

--- a/backend/core/services/metadata.py
+++ b/backend/core/services/metadata.py
@@ -10,14 +10,15 @@ import shutil
 import struct
 import subprocess
 import sys
-from datetime import date
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
+
+from pydantic import BaseModel
 
 from backend.core.services import cache_db, rule_engine
 from backend.core.services import folder_config as folder_config_service
 from backend.core.services import ruleset as ruleset_service
-from soundcloud_tools.handler.track import TrackHandler, TrackInfo
+from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackHandler, TrackInfo
 from soundcloud_tools.utils.string import (
     remove_double_spaces,
     remove_free_dl,
@@ -81,149 +82,65 @@ def prepare_search_query(filename: str) -> str:
     return remove_double_spaces(remove_mix(remove_remix(replace_underscores(remove_free_dl(filename)))))
 
 
+_REGISTRY_NAMES = {f.name for f in SIMPLE_TAG_FIELDS}
+
+
+def _coerce_artist_field(value: Any) -> Any:
+    """Split a comma-separated artist string into a list when appropriate."""
+    if isinstance(value, str) and "," in value:
+        parts = [a.strip() for a in value.split(",") if a.strip()]
+        return parts[0] if len(parts) == 1 else parts
+    return value
+
+
 def build_modified_track_info(
     original_info: TrackInfo,
-    title: str | None = None,
-    artist: str | None = None,
-    bpm: int | None = None,
-    key: str | None = None,
-    genre: str | None = None,
-    comment: str | None = None,
-    release_date: date | None = None,
-    remixers: list[str] | None = None,
+    updates: BaseModel | dict[str, Any] | None = None,
+    *,
     artwork_url: str | None = None,
 ) -> TrackInfo:
+    """Apply *updates* (a request model or dict) on top of *original_info*.
+
+    Only registry-driven fields are applied here; ``artwork`` and the ``artwork_data``
+    base64 payload are handled separately by the API layer.
     """
-    Build a modified TrackInfo object from individual field values.
-
-    This is the core transformation that takes user-edited fields and
-    produces a complete TrackInfo object ready for writing to file.
-
-    Parameters
-    ----------
-    original_info : TrackInfo
-        Original track information
-    title : str | None
-        Modified title (or None to keep original)
-    artist : str | None
-        Modified artist(s) (or None to keep original)
-    bpm : int | None
-        Modified BPM (or None to keep original)
-    key : str | None
-        Modified key (or None to keep original)
-    genre : str | None
-        Modified genre (or None to keep original)
-    comment : str | None
-        Modified comment (or None to keep original)
-    release_date : date | None
-        Modified release date (or None to keep original)
-    remixers : list[str] | None
-        List of remixer names (or None to keep original)
-    artwork_url : str | None
-        URL to fetch artwork from (or None to keep original)
-
-    Returns
-    -------
-    TrackInfo
-        Complete track info ready for writing
-    """
-    from soundcloud_tools.handler.track import Comment as CommentModel
-    from soundcloud_tools.handler.track import Remix
-
-    # Use original values if not provided
-    final_title = title if title is not None else original_info.title
-    final_bpm = bpm if bpm is not None else original_info.bpm
-    final_key = key if key is not None else original_info.key
-    final_genre = genre if genre is not None else original_info.genre
-    final_release_date = release_date if release_date is not None else original_info.release_date
-    final_artwork_url = artwork_url if artwork_url is not None else original_info.artwork_url
-
-    # Parse artist
-    if artist is not None:
-        # Parse artists if comma-separated string
-        if isinstance(artist, str) and "," in artist:
-            artists = [a.strip() for a in artist.split(",")]
-            final_artist = artists[0] if len(artists) == 1 else artists
-        else:
-            final_artist = artist
+    if isinstance(updates, BaseModel):
+        patch = updates.model_dump(exclude_unset=True)
     else:
-        final_artist = original_info.artist
+        patch = dict(updates or {})
 
-    # Handle remix - convert list of remixers to Remix object
-    final_remix = None
-    if remixers is not None and len(remixers) > 0:
-        # Use first remixer if multiple provided
-        final_remix = Remix(
-            remixer=remixers[0],
-            original_artist=original_info.artist_str if original_info.artist_str else "",
-            mix_name=None,
-        )
+    data = original_info.model_dump()
+    for name in _REGISTRY_NAMES:
+        if name not in patch:
+            continue
+        value = patch[name]
+        if name in {"artist", "original_artist", "remixer"}:
+            value = _coerce_artist_field(value)
+        data[name] = value
+
+    # Drop binary artwork (handled separately by the API layer) and the URL
+    # field (avoids re-triggering the network-fetching validator on every save).
+    data.pop("artwork", None)
+    if artwork_url is not None:
+        data["artwork_url"] = artwork_url
     else:
-        final_remix = original_info.remix
-
-    # Handle comment - parse from string to Comment object if provided
-    final_comment = None
-    if comment is not None:
-        final_comment = CommentModel.from_str(comment)
-    else:
-        final_comment = original_info.comment
-
-    return TrackInfo(
-        title=final_title,
-        artist=final_artist,
-        bpm=final_bpm,
-        key=final_key,
-        genre=final_genre,
-        release_date=final_release_date,
-        artwork_url=final_artwork_url,
-        remix=final_remix,
-        comment=final_comment,
-    )
+        data.pop("artwork_url", None)
+    return TrackInfo(**data)
 
 
 def save_track_metadata(
     file_path: Path,
     root_folder: Path,
     track_info: TrackInfo,
-    remove_remix: bool = False,
 ) -> Path:
-    """
-    Save metadata to an audio file and rename it.
+    """Write metadata to *file_path* and rename it to match the new title.
 
-    This performs the core "save" operation:
-    1. Write metadata to file
-    2. Remove remix tags if requested
-    3. Rename file based on new metadata
-
-    Parameters
-    ----------
-    file_path : Path
-        Path to the audio file
-    root_folder : Path
-        Root folder for the music library
-    track_info : TrackInfo
-        Track information to write
-    remove_remix : bool
-        Whether to remove remix tags from the file
-
-    Returns
-    -------
-    Path
-        New file path after renaming
+    Callers that want to clear remix tags should set ``original_artist``,
+    ``remixer`` and ``mix_name`` to ``None`` on ``track_info`` before saving.
     """
     handler = TrackHandler(root_folder=root_folder, file=file_path)
-
-    # Write metadata
     handler.add_info(track_info, artwork=track_info.artwork)
-
-    # Remove remix tags if not a remix
-    if remove_remix:
-        handler.remove_remix()
-
-    # Rename file based on metadata
-    new_path = handler.rename(track_info.filename)
-
-    return new_path
+    return handler.rename(track_info.filename)
 
 
 def finalize_track(

--- a/backend/core/services/settings.py
+++ b/backend/core/services/settings.py
@@ -122,6 +122,16 @@ def load() -> Settings:
     if not settings.rulesets.active_ruleset_id:
         settings.rulesets.active_ruleset_id = CLASSIC_RULESET_ID
 
+    # Re-seed default folder configs when the list is empty.  The bundled
+    # "prepare / cleaned / collection" layout is effectively built-in — users
+    # can rename, reorder, or hide entries, but an empty list means the
+    # settings file landed in a half-initialised state (legacy migration,
+    # first-boot race, or an older version writing an empty default).  Mirror
+    # the Classic-ruleset heal: re-inject in memory without persisting so a
+    # user who genuinely wants zero folders can still delete-and-save.
+    if not settings.folders.folders:
+        settings.folders.folders = [fc.model_copy() for fc in _DEFAULT_FOLDERS]
+
     # One-time migration: move ROOT_MUSIC_FOLDER from config.env → settings.json
     if not settings.app.root_music_folder:
         migrated = _migrate_root_folder_from_config_env()

--- a/backend/core/services/watcher.py
+++ b/backend/core/services/watcher.py
@@ -98,6 +98,7 @@ class _MusicFolderHandler(FileSystemEventHandler):
                 missing.append("release_date")
             if not track_info.artwork:
                 missing.append("artwork")
+            sc_id = track_info.starlib_meta.soundcloud_id if track_info.starlib_meta else None
             cache_db.upsert_track(
                 file_path=path,
                 folder=path.parent.resolve(),
@@ -114,7 +115,12 @@ class _MusicFolderHandler(FileSystemEventHandler):
                 is_complete=track_info.complete,
                 missing_fields=missing,
                 mtime=stat.st_mtime,
-                remixers=[track_info.remix.remixer_str] if track_info.remix else None,
+                soundcloud_id=sc_id,
+                original_artist=track_info.original_artist_str or None,
+                remixer=track_info.remixer_str or None,
+                mix_name=track_info.mix_name,
+                release_year=track_info.release_year,
+                user_comment=track_info.user_comment,
             )
             logger.info("Indexed: %s", path.name)
         except Exception as e:

--- a/backend/schemas/metadata.py
+++ b/backend/schemas/metadata.py
@@ -2,41 +2,38 @@
 Pydantic schemas for metadata operations (Meta Editor).
 
 Request and response models for all metadata-related API endpoints.
+
+The flat tag fields are declared once on `_TagFieldsMixin` and reused by every
+schema below so that adding a new tag means: registry entry in track.py,
+field on `TrackInfo`, and one line on the mixin (and a DB column).  A
+parity test (`test_schemas_include_every_registry_field`) catches drift.
 """
 
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field, create_model
-
-from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackInfo
+from pydantic import BaseModel, Field
 
 # ============================================================================
-# Registry-driven field map
+# Tag-field mixin (mirrors SIMPLE_TAG_FIELDS in soundcloud_tools.handler.track)
 # ============================================================================
-#
-# Every field in SIMPLE_TAG_FIELDS becomes an optional column on the request
-# and response schemas.  Adding a tag to the registry automatically flows
-# through to the API surface — no per-field edits needed here.
-#
-# starlib_meta is the one structured value we serialise as a string at the API
-# boundary (the on-disk format is "key=value; key=value"), so we override its
-# annotation to `str | None` rather than the StarlibMeta object.
-
-_SCALAR_OVERRIDES: dict[str, type] = {"starlib_meta": str | None}
 
 
-def _tag_fields() -> dict[str, tuple[type, object]]:
-    fields: dict[str, tuple[type, object]] = {}
-    for f in SIMPLE_TAG_FIELDS:
-        annotation = _SCALAR_OVERRIDES.get(
-            f.name, TrackInfo.model_fields[f.name].annotation | None
-        )
-        fields[f.name] = (annotation, None)
-    return fields
+class _TagFieldsMixin(BaseModel):
+    """Flat optional fields mirroring SIMPLE_TAG_FIELDS at the API boundary."""
 
-
-_TAG_FIELDS = _tag_fields()
+    title: str | None = None
+    artist: str | list[str] | None = None
+    genre: str | None = None
+    bpm: int | None = None
+    key: str | None = None
+    original_artist: str | list[str] | None = None
+    remixer: str | list[str] | None = None
+    mix_name: str | None = None
+    release_date: date | None = None
+    release_year: int | None = None
+    user_comment: str | None = None
+    starlib_meta: str | None = None  # serialised "key=value; ..." form
 
 
 # ============================================================================
@@ -44,12 +41,10 @@ _TAG_FIELDS = _tag_fields()
 # ============================================================================
 
 
-TrackInfoUpdateRequest = create_model(
-    "TrackInfoUpdateRequest",
-    **_TAG_FIELDS,
-    artwork_data=(str | None, None),  # base64-encoded image bytes
-    __doc__="Request to update track metadata. All fields optional.",
-)
+class TrackInfoUpdateRequest(_TagFieldsMixin):
+    """Request to update track metadata. All fields optional."""
+
+    artwork_data: str | None = None  # base64-encoded image bytes
 
 
 class FinalizeRequest(BaseModel):
@@ -104,17 +99,15 @@ class BatchUpdateRequest(BaseModel):
 # ============================================================================
 
 
-TrackInfoResponse = create_model(
-    "TrackInfoResponse",
-    file_path=(str, ...),
-    file_name=(str, ...),
-    has_artwork=(bool, ...),
-    is_ready=(bool, ...),
-    missing_fields=(list[str], []),
-    issues=(list[str], []),
-    **_TAG_FIELDS,
-    __doc__="Response containing track metadata. Tag fields are flat per the registry.",
-)
+class TrackInfoResponse(_TagFieldsMixin):
+    """Response containing track metadata. Tag fields are flat per the registry."""
+
+    file_path: str
+    file_name: str
+    has_artwork: bool
+    is_ready: bool
+    missing_fields: list[str] = []
+    issues: list[str] = []
 
 
 class FileInfoResponse(BaseModel):
@@ -187,19 +180,17 @@ class BatchUpdateResponse(BaseModel):
     results: list[BatchResultItem]
 
 
-TrackBrowseResponse = create_model(
-    "TrackBrowseResponse",
-    file_path=(str, ...),
-    file_name=(str, ...),
-    soundcloud_id=(int | None, None),
-    has_artwork=(bool, False),
-    file_format=(str, ...),
-    file_size=(int, ...),
-    duration=(float | None, None),
-    mtime=(float | None, None),
-    **_TAG_FIELDS,
-    __doc__="Lightweight response for collection browse/table view.",
-)
+class TrackBrowseResponse(_TagFieldsMixin):
+    """Lightweight response for collection browse/table view."""
+
+    file_path: str
+    file_name: str
+    soundcloud_id: int | None = None
+    has_artwork: bool = False
+    file_format: str
+    file_size: int
+    duration: float | None = None
+    mtime: float | None = None
 
 
 class PeaksResponse(BaseModel):

--- a/backend/schemas/metadata.py
+++ b/backend/schemas/metadata.py
@@ -7,41 +7,49 @@ Request and response models for all metadata-related API endpoints.
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, create_model
+
+from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackInfo
+
+# ============================================================================
+# Registry-driven field map
+# ============================================================================
+#
+# Every field in SIMPLE_TAG_FIELDS becomes an optional column on the request
+# and response schemas.  Adding a tag to the registry automatically flows
+# through to the API surface — no per-field edits needed here.
+#
+# starlib_meta is the one structured value we serialise as a string at the API
+# boundary (the on-disk format is "key=value; key=value"), so we override its
+# annotation to `str | None` rather than the StarlibMeta object.
+
+_SCALAR_OVERRIDES: dict[str, type] = {"starlib_meta": str | None}
+
+
+def _tag_fields() -> dict[str, tuple[type, object]]:
+    fields: dict[str, tuple[type, object]] = {}
+    for f in SIMPLE_TAG_FIELDS:
+        annotation = _SCALAR_OVERRIDES.get(
+            f.name, TrackInfo.model_fields[f.name].annotation | None
+        )
+        fields[f.name] = (annotation, None)
+    return fields
+
+
+_TAG_FIELDS = _tag_fields()
+
 
 # ============================================================================
 # Request Schemas
 # ============================================================================
 
 
-class TrackInfoUpdateRequest(BaseModel):
-    """Request to update track metadata."""
-
-    title: str | None = None
-    artist: str | None = None
-    bpm: int | None = None
-    key: str | None = None
-    genre: str | None = None
-    comment: str | None = None
-    release_date: date | None = None
-    remixers: list[str] | None = None
-    artwork_data: str | None = None  # base64-encoded image bytes
-
-
-class RemixInfo(BaseModel):
-    """Remix information."""
-
-    remixer: str
-    original_artist: str
-    mix_name: str | None = None
-
-
-class CommentInfo(BaseModel):
-    """Comment information."""
-
-    version: str | None = None
-    soundcloud_id: int | None = None
-    soundcloud_permalink: str | None = None
+TrackInfoUpdateRequest = create_model(
+    "TrackInfoUpdateRequest",
+    **_TAG_FIELDS,
+    artwork_data=(str | None, None),  # base64-encoded image bytes
+    __doc__="Request to update track metadata. All fields optional.",
+)
 
 
 class FinalizeRequest(BaseModel):
@@ -96,23 +104,17 @@ class BatchUpdateRequest(BaseModel):
 # ============================================================================
 
 
-class TrackInfoResponse(BaseModel):
-    """Response containing track metadata."""
-
-    file_path: str
-    file_name: str
-    title: str | None = None
-    artist: str | None = None
-    bpm: int | None = None
-    key: str | None = None
-    genre: str | None = None
-    comment: str | None = None
-    release_date: date | None = None
-    remixers: list[str] | None = None
-    has_artwork: bool
-    is_ready: bool
-    missing_fields: list[str] = []
-    issues: list[str] = []
+TrackInfoResponse = create_model(
+    "TrackInfoResponse",
+    file_path=(str, ...),
+    file_name=(str, ...),
+    has_artwork=(bool, ...),
+    is_ready=(bool, ...),
+    missing_fields=(list[str], []),
+    issues=(list[str], []),
+    **_TAG_FIELDS,
+    __doc__="Response containing track metadata. Tag fields are flat per the registry.",
+)
 
 
 class FileInfoResponse(BaseModel):
@@ -185,24 +187,19 @@ class BatchUpdateResponse(BaseModel):
     results: list[BatchResultItem]
 
 
-class TrackBrowseResponse(BaseModel):
-    """Lightweight response for collection browse/table view."""
-
-    file_path: str
-    file_name: str
-    title: str | None = None
-    artist: str | None = None
-    bpm: int | None = None
-    key: str | None = None
-    genre: str | None = None
-    release_date: date | None = None
-    remixers: list[str] | None = None
-    soundcloud_id: int | None = None
-    has_artwork: bool = False
-    file_format: str
-    file_size: int
-    duration: float | None = None
-    mtime: float | None = None
+TrackBrowseResponse = create_model(
+    "TrackBrowseResponse",
+    file_path=(str, ...),
+    file_name=(str, ...),
+    soundcloud_id=(int | None, None),
+    has_artwork=(bool, False),
+    file_format=(str, ...),
+    file_size=(int, ...),
+    duration=(float | None, None),
+    mtime=(float | None, None),
+    **_TAG_FIELDS,
+    __doc__="Lightweight response for collection browse/table view.",
+)
 
 
 class PeaksResponse(BaseModel):

--- a/frontend/src/app/meta-editor/page.tsx
+++ b/frontend/src/app/meta-editor/page.tsx
@@ -54,6 +54,10 @@ function MetaEditorContent() {
   // Track selection
   const [selectedFile, setSelectedFile] = useState<FileInfo | null>(null);
 
+  // Shared pending field edits per file: editor and table both read + write
+  // this map so edits in one surface are reflected live in the other.
+  const [pendingFieldEdits, setPendingFieldEdits] = useState<Map<string, Record<string, string>>>(new Map());
+
   // Editor panel visibility
   const [editorOpen, setEditorOpen] = useState(false);
 
@@ -242,6 +246,8 @@ function MetaEditorContent() {
             onEditSaved={() => setRefreshToken(t => t + 1)}
             activeRuleset={activeRuleset}
             autoApplyScResults={autoActions.autoApplyScResults}
+            pendingFieldEdits={pendingFieldEdits}
+            setPendingFieldEdits={setPendingFieldEdits}
           />
         </div>
         {/* Right: editor panel */}
@@ -256,6 +262,8 @@ function MetaEditorContent() {
               onClose={() => setEditorOpen(false)}
               onFileChange={setSelectedFile}
               onSelectNext={selectNextTrack}
+              pendingFieldEdits={pendingFieldEdits}
+              setPendingFieldEdits={setPendingFieldEdits}
             />
           )}
         </div>

--- a/frontend/src/app/meta-editor/track-editor.tsx
+++ b/frontend/src/app/meta-editor/track-editor.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useLayoutEffect } from 'react';
 import { useTheme } from 'next-themes';
 import { api, type FileInfo, type TrackInfo, type TrackInfoUpdateRequest, type Ruleset, type RuleType } from '@/lib/api';
-import { cleanTitle, cleanArtist, titelize, removeParenthesis, parseFilename, parseRemix, removeMix } from '@/lib/string-utils';
+import { cleanTitle, cleanArtist, titelize, removeParenthesis, parseFilename, removeMix } from '@/lib/string-utils';
 import { soundCloudSource } from '@/lib/sources/soundcloud';
 import type { SourceTrack } from '@/lib/sources/types';
 import { format, parse, isValid } from 'date-fns';
@@ -90,34 +90,32 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
           selectedTrack: selectedScTrack, setSelectedTrack: setSelectedScTrack,
           handleSearch: handleScSearch, handleTrackSelect: handleScTrackSelect } = sc;
 
-  // Remix state
-  const [isRemix, setIsRemix] = useState(false);
-  const [remixData, setRemixData] = useState({ original_artist: '', remixer: '', mix_name: 'Remix' });
-
   // Artwork state
   const [artworkUrl, setArtworkUrl] = useState<string | null>(null);
   const [pendingArtworkData, setPendingArtworkData] = useState<string | null>(null);
   const [artworkPreviewOpen, setArtworkPreviewOpen] = useState(false);
 
-  // Metadata form state
-  const [formData, setFormData] = useState({
+  // Metadata form state — flat fields, no remix composite.
+  const emptyFormData = {
     title: '',
     artist: '',
     bpm: '',
     key: '',
     genre: '',
     release_date: '',
-  });
+    release_year: '',
+    original_artist: '',
+    remixer: '',
+    mix_name: '',
+    user_comment: '',
+  };
+  type FormFieldKey = keyof typeof emptyFormData;
+  const [formData, setFormData] = useState({ ...emptyFormData });
+  const [originalFormData, setOriginalFormData] = useState({ ...emptyFormData });
 
-  // Original values for change detection
-  const [originalFormData, setOriginalFormData] = useState({
-    title: '',
-    artist: '',
-    bpm: '',
-    key: '',
-    genre: '',
-    release_date: '',
-  });
+  // Track whether the user has manually edited release_year this session;
+  // when false, editing release_date auto-syncs the year.
+  const [releaseYearTouched, setReleaseYearTouched] = useState(false);
 
   // Structured comment state (SC ID + permalink)
   const [commentData, setCommentData] = useState({ soundcloud_id: '', soundcloud_permalink: '' });
@@ -135,9 +133,7 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     }
   }, [folderRulesetId]);
 
-  // Original values for remix/SC-link change detection
-  const [originalIsRemix, setOriginalIsRemix] = useState(false);
-  const [originalRemixData, setOriginalRemixData] = useState({ original_artist: '', remixer: '', mix_name: 'Remix' });
+  // Original values for SC-link change detection
   const [originalScLinkEnabled, setOriginalScLinkEnabled] = useState(true);
   const [originalCommentData, setOriginalCommentData] = useState({ soundcloud_id: '', soundcloud_permalink: '' });
 
@@ -214,45 +210,28 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     if (!trackInfo) return;
 
     const parsed = parseFilename(trackInfo.file_name);
-    const artistStr = Array.isArray(trackInfo.artist) ? trackInfo.artist.join(', ') : (trackInfo.artist ?? '');
-    const remixerStr = Array.isArray(trackInfo.remixer) ? trackInfo.remixer.join(', ') : (trackInfo.remixer ?? '');
-    const originalArtistStr = Array.isArray(trackInfo.original_artist) ? trackInfo.original_artist.join(', ') : (trackInfo.original_artist ?? '');
-    const newFormData = {
+    const joinList = (v: string | string[] | null | undefined): string =>
+      Array.isArray(v) ? v.join(', ') : (v ?? '');
+    const newFormData: typeof emptyFormData = {
       title: trackInfo.title || parsed.title || '',
-      artist: artistStr || parsed.artist || '',
+      artist: joinList(trackInfo.artist) || parsed.artist || '',
       bpm: trackInfo.bpm?.toString() || '',
       key: trackInfo.key || '',
       genre: trackInfo.genre || '',
       release_date: trackInfo.release_date || '',
+      release_year: trackInfo.release_year?.toString() || '',
+      original_artist: joinList(trackInfo.original_artist),
+      remixer: joinList(trackInfo.remixer),
+      mix_name: trackInfo.mix_name || '',
+      user_comment: trackInfo.user_comment || '',
     };
     setFormData(newFormData);
     setOriginalFormData(newFormData);
+    setReleaseYearTouched(false);
     const parsedComment = parseComment(trackInfo.starlib_meta);
     setCommentData(parsedComment);
     setScLinkEnabled(!!(parsedComment.soundcloud_id || parsedComment.soundcloud_permalink));
 
-    if (remixerStr) {
-      setIsRemix(true);
-      setRemixData({ original_artist: originalArtistStr || artistStr, remixer: remixerStr, mix_name: trackInfo.mix_name || 'Remix' });
-    } else {
-      const titleToCheck = trackInfo.title || parsed.title || '';
-      const detected = titleToCheck ? parseRemix(titleToCheck) : null;
-      if (detected) {
-        setIsRemix(true);
-        setRemixData({ original_artist: originalArtistStr || artistStr || parsed.artist || '', remixer: detected.remixer, mix_name: trackInfo.mix_name || detected.mixName });
-      } else {
-        setIsRemix(false);
-        setRemixData({ original_artist: '', remixer: '', mix_name: 'Remix' });
-      }
-    }
-
-    const initialIsRemix = !!remixerStr || !!(trackInfo.title && parseRemix(trackInfo.title));
-    setOriginalIsRemix(initialIsRemix);
-    setOriginalRemixData(
-      remixerStr
-        ? { original_artist: originalArtistStr || artistStr, remixer: remixerStr, mix_name: trackInfo.mix_name || 'Remix' }
-        : { original_artist: '', remixer: '', mix_name: 'Remix' }
-    );
     const initialScLinkEnabled = !!(parsedComment.soundcloud_id || parsedComment.soundcloud_permalink);
     setOriginalScLinkEnabled(initialScLinkEnabled);
     setOriginalCommentData(parsedComment);
@@ -327,10 +306,6 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     });
   };
 
-  const handleRemixChange = (field: string, value: string) => {
-    setRemixData(prev => ({ ...prev, [field]: value }));
-  };
-
   const handleCleanTitle = () => {
     if (!formData.title) return;
     const transformed = cleanTitle(formData.title);
@@ -366,11 +341,14 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
   const scArtistOptions = selectedScTrack?.artist_options ?? [];
 
   const handleBuildTitleFromRemix = () => {
-    if (!isRemix || !remixData.original_artist || !remixData.remixer) return;
+    if (!formData.original_artist || !formData.remixer) return;
     const rawTitle = formData.title.replace(/\(.*?\)/g, '').trim();
-    const newTitle = `${remixData.original_artist} - ${rawTitle} (${remixData.remixer} ${remixData.mix_name})`;
+    const mix = formData.mix_name || 'Remix';
+    const newTitle = `${formData.original_artist} - ${rawTitle} (${formData.remixer} ${mix})`;
     setFormData({ ...formData, title: newTitle });
   };
+
+  const canBuildTitleFromRemix = !!formData.original_artist && !!formData.remixer;
 
   const handleIsolateTitle = () => {
     if (!formData.title) return;
@@ -380,24 +358,38 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     }
   };
 
-  const isChanged = (field: keyof typeof formData) => formData[field] !== originalFormData[field];
+  const isChanged = (field: FormFieldKey) => formData[field] !== originalFormData[field];
 
   const scBusy = (scSearching || scQueryPending) && !commentData.soundcloud_id && !commentData.soundcloud_permalink;
   const hasChanges = scBusy || pendingArtworkData !== null ||
-    (Object.keys(formData) as (keyof typeof formData)[]).some(k => formData[k] !== originalFormData[k]) ||
-    isRemix !== originalIsRemix ||
-    remixData.original_artist !== originalRemixData.original_artist ||
-    remixData.remixer !== originalRemixData.remixer ||
-    remixData.mix_name !== originalRemixData.mix_name ||
+    (Object.keys(formData) as FormFieldKey[]).some(k => formData[k] !== originalFormData[k]) ||
     scLinkEnabled !== originalScLinkEnabled ||
     commentData.soundcloud_id !== originalCommentData.soundcloud_id ||
     commentData.soundcloud_permalink !== originalCommentData.soundcloud_permalink;
 
+  // Show a hint when release_year and the year part of release_date disagree.
+  const releaseDateYear = formData.release_date && isValid(parse(formData.release_date, 'yyyy-MM-dd', new Date()))
+    ? parse(formData.release_date, 'yyyy-MM-dd', new Date()).getFullYear().toString()
+    : '';
+  const yearMismatch = !!formData.release_date && !!formData.release_year && releaseDateYear !== formData.release_year;
+
   const formComplete =
     !!formData.title && !!formData.artist && !!formData.genre && !!formData.release_date && !!artworkUrl;
 
-  const handleFormChange = (field: string, value: string | number) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+  const handleFormChange = (field: FormFieldKey, value: string) => {
+    setFormData(prev => {
+      const next = { ...prev, [field]: value };
+      // Auto-sync release_year from release_date when the user hasn't manually
+      // overridden the year (issue #285: year ← date on edit, both stay editable).
+      if (field === 'release_date' && !releaseYearTouched) {
+        const parsed = value && isValid(parse(value, 'yyyy-MM-dd', new Date()))
+          ? parse(value, 'yyyy-MM-dd', new Date())
+          : null;
+        next.release_year = parsed ? parsed.getFullYear().toString() : '';
+      }
+      return next;
+    });
+    if (field === 'release_year') setReleaseYearTouched(true);
   };
 
   const handleSave = async () => {
@@ -407,14 +399,16 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
       setLoading(true);
       setError(null);
 
+      // Always send every flat field — empty strings become `null` to clear
+      // tags rather than carry stale data (the backend treats `None` as
+      // delete).
       const updates: Record<string, string | number | string[] | null> = {};
-      Object.entries(formData).forEach(([key, value]) => {
-        if (value !== '') {
-          if (key === 'bpm') {
-            updates[key] = parseInt(value as string);
-          } else {
-            updates[key] = value;
-          }
+      (Object.keys(formData) as FormFieldKey[]).forEach((key) => {
+        const value = formData[key];
+        if (key === 'bpm' || key === 'release_year') {
+          updates[key] = value ? parseInt(value, 10) : null;
+        } else {
+          updates[key] = value === '' ? null : value;
         }
       });
 
@@ -422,17 +416,7 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
         scLinkEnabled ? commentData.soundcloud_id : '',
         scLinkEnabled ? commentData.soundcloud_permalink : '',
       );
-      if (starlibStr) updates.starlib_meta = starlibStr;
-
-      if (isRemix && remixData.remixer) {
-        updates.remixer = remixData.remixer;
-        updates.original_artist = remixData.original_artist || null;
-        updates.mix_name = remixData.mix_name || null;
-      } else {
-        updates.remixer = null;
-        updates.original_artist = null;
-        updates.mix_name = null;
-      }
+      updates.starlib_meta = starlibStr || null;
 
       if (pendingArtworkData) {
         updates.artwork_data = pendingArtworkData;
@@ -703,7 +687,7 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
                       <Button variant="ghost" size="icon-xs" onClick={() => handleCopyFromSc('title')} disabled={!selectedScTrack} title="Copy from SoundCloud"><activeSource.Icon className="size-3"  /></Button>
                       <Button variant="ghost" size="icon-xs" onClick={handleCleanTitle} title="Clean"><Sparkles /></Button>
                       <Button variant="ghost" size="icon-xs" onClick={() => { if (!formData.title) return; const t = titelize(formData.title); if (t !== formData.title) setFormData({...formData, title: t}); }} title="Titelize"><CaseSensitive /></Button>
-                      <Button variant="ghost" size="icon-xs" onClick={handleBuildTitleFromRemix} disabled={!isRemix} title="Build from remix"><Wand2 /></Button>
+                      <Button variant="ghost" size="icon-xs" onClick={handleBuildTitleFromRemix} disabled={!canBuildTitleFromRemix} title="Build from remix"><Wand2 /></Button>
                       <Button variant="ghost" size="icon-xs" onClick={handleRemoveParenthesis} title="Remove brackets"><Brackets /></Button>
                       <Button variant="ghost" size="icon-xs" onClick={handleIsolateTitle} title="Isolate"><Trash2 /></Button>
                       {isChanged('title') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('title', originalFormData.title)} title="Reset"><RotateCcw /></Button>}
@@ -767,12 +751,12 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
               </div>
             </div>
 
-            {/* 2-col: Release | Key */}
-            <div className="grid grid-cols-2 gap-2">
-              {/* Release */}
+            {/* 3-col: Release Date | Release Year | Key */}
+            <div className="grid grid-cols-[1fr_auto_1fr] gap-2">
+              {/* Release Date */}
               <div className="group flex flex-col gap-0.5">
                 <div className="flex items-center justify-between h-4">
-                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Release</span>
+                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Release Date</span>
                   <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
                     <Button variant="ghost" size="icon-xs" onClick={() => handleCopyFromSc('release_date')} disabled={!selectedScTrack} title="Copy from SC"><activeSource.Icon className="size-3"  /></Button>
                     {isChanged('release_date') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('release_date', originalFormData.release_date)} title="Reset"><RotateCcw /></Button>}
@@ -802,6 +786,25 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
                 </Popover>
               </div>
 
+              {/* Release Year */}
+              <div className="group flex flex-col gap-0.5 w-20">
+                <div className="flex items-center justify-between h-4">
+                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium" title={yearMismatch ? `Year doesn't match release date (${releaseDateYear})` : undefined}>
+                    Year{yearMismatch && <span className="ml-0.5 text-amber-400/90">*</span>}
+                  </span>
+                  <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
+                    {isChanged('release_year') && <Button variant="ghost" size="icon-xs" onClick={() => { setReleaseYearTouched(false); handleFormChange('release_year', originalFormData.release_year); }} title="Reset"><RotateCcw /></Button>}
+                  </div>
+                </div>
+                <Input
+                  type="number"
+                  value={formData.release_year}
+                  onChange={(e) => handleFormChange('release_year', e.target.value)}
+                  className={`h-8 text-xs${isChanged('release_year') || yearMismatch ? ' border-amber-400/70' : ''}`}
+                  placeholder="—"
+                />
+              </div>
+
               {/* Key */}
               <div className="group flex flex-col gap-0.5">
                 <div className="flex items-center justify-between h-4">
@@ -814,94 +817,96 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
               </div>
             </div>
 
-            {/* Remix section */}
-            <div className="pt-3">
-              <div className={`relative rounded-lg border transition-colors duration-200 ${isRemix ? 'border-border/50 bg-accent/20' : 'border-border/30'}`}>
-                <button
-                  onClick={() => setIsRemix(!isRemix)}
-                  className={`cursor-pointer absolute -top-2.75 left-3 inline-flex items-center gap-1.5 text-[9px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded-md transition-all duration-150 ${
-                    isRemix
-                      ? 'bg-card border text-primary shadow-sm'
-                      : 'bg-card border border-dashed text-muted-foreground hover:text-foreground'
-                  } ${isRemix !== originalIsRemix ? 'border-amber-400/70' : isRemix ? 'border-border/50' : 'border-border/60 hover:border-border'}`}
-                >
-                  <Wand2 className="size-2.5" />
-                  Remix
-                </button>
-                <div className={`flex flex-col gap-3 px-3 pb-3 pt-5 transition-opacity duration-150 ${isRemix ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
-                  {/* Row 1: Original Artist | Remixer */}
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="group flex flex-col gap-0.5">
-                      <div className="flex items-center justify-between h-4">
-                        <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Original Artist</span>
-                        <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
-                          <Button variant="ghost" size="icon-xs" onClick={() => { if (!remixData.original_artist) return; const t = cleanArtist(remixData.original_artist); if (t !== remixData.original_artist) setRemixData({...remixData, original_artist: t}); }} title="Clean"><Sparkles /></Button>
-                          <Button variant="ghost" size="icon-xs" onClick={() => { if (!remixData.original_artist) return; const t = titelize(remixData.original_artist); if (t !== remixData.original_artist) setRemixData({...remixData, original_artist: t}); }} title="Titelize"><CaseSensitive /></Button>
-                          <Popover>
-                            <PopoverTrigger asChild>
-                              <Button variant="ghost" size="icon-xs" disabled={!selectedScTrack || !scArtistOptions.length}><Users /></Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-48 p-2">
-                              <div className="space-y-1">
-                                {scArtistOptions.map((artist) => (
-                                  <Button key={artist} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => setRemixData({ ...remixData, original_artist: artist })}>{artist}</Button>
-                                ))}
-                              </div>
-                            </PopoverContent>
-                          </Popover>
-                          {remixData.original_artist !== originalRemixData.original_artist && <Button variant="ghost" size="icon-xs" onClick={() => setRemixData({ ...remixData, original_artist: originalRemixData.original_artist })} title="Reset"><RotateCcw /></Button>}
+            {/* Remix fields — flat, always editable. */}
+            <div className="grid grid-cols-2 gap-2">
+              {/* Original Artist */}
+              <div className="group flex flex-col gap-0.5">
+                <div className="flex items-center justify-between h-4">
+                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Original Artist</span>
+                  <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
+                    <Button variant="ghost" size="icon-xs" onClick={() => { if (!formData.original_artist) return; const t = cleanArtist(formData.original_artist); if (t !== formData.original_artist) handleFormChange('original_artist', t); }} title="Clean"><Sparkles /></Button>
+                    <Button variant="ghost" size="icon-xs" onClick={() => { if (!formData.original_artist) return; const t = titelize(formData.original_artist); if (t !== formData.original_artist) handleFormChange('original_artist', t); }} title="Titelize"><CaseSensitive /></Button>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button variant="ghost" size="icon-xs" disabled={!selectedScTrack || !scArtistOptions.length} title="Artist options"><Users /></Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-48 p-2">
+                        <div className="space-y-1">
+                          {scArtistOptions.map((artist) => (
+                            <Button key={artist} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => handleFormChange('original_artist', artist)}>{artist}</Button>
+                          ))}
                         </div>
-                      </div>
-                      <Input value={remixData.original_artist} onChange={(e) => handleRemixChange('original_artist', e.target.value)} className={`h-8 text-xs${remixData.original_artist !== originalRemixData.original_artist ? ' border-amber-400/70' : ''}`} placeholder="Original artist" />
-                    </div>
-                    <div className="group flex flex-col gap-0.5">
-                      <div className="flex items-center justify-between h-4">
-                        <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Remixer</span>
-                        <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
-                          <Button variant="ghost" size="icon-xs" onClick={() => { if (!remixData.remixer) return; const t = cleanArtist(remixData.remixer); if (t !== remixData.remixer) setRemixData({...remixData, remixer: t}); }} title="Clean"><Sparkles /></Button>
-                          <Button variant="ghost" size="icon-xs" onClick={() => { if (!remixData.remixer) return; const t = titelize(remixData.remixer); if (t !== remixData.remixer) setRemixData({...remixData, remixer: t}); }} title="Titelize"><CaseSensitive /></Button>
-                          <Popover>
-                            <PopoverTrigger asChild>
-                              <Button variant="ghost" size="icon-xs" disabled={!selectedScTrack || !scArtistOptions.length}><Users /></Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-48 p-2">
-                              <div className="space-y-1">
-                                {scArtistOptions.map((artist) => (
-                                  <Button key={artist} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => setRemixData({ ...remixData, remixer: artist })}>{artist}</Button>
-                                ))}
-                              </div>
-                            </PopoverContent>
-                          </Popover>
-                          {remixData.remixer !== originalRemixData.remixer && <Button variant="ghost" size="icon-xs" onClick={() => setRemixData({ ...remixData, remixer: originalRemixData.remixer })} title="Reset"><RotateCcw /></Button>}
-                        </div>
-                      </div>
-                      <Input value={remixData.remixer} onChange={(e) => handleRemixChange('remixer', e.target.value)} className={`h-8 text-xs${remixData.remixer !== originalRemixData.remixer ? ' border-amber-400/70' : ''}`} placeholder="Remixer" />
-                    </div>
-                  </div>
-                  {/* Row 2: Mix Type (full width) */}
-                  <div className="group flex flex-col gap-0.5">
-                    <div className="flex items-center justify-between h-4">
-                      <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Mix Type</span>
-                      <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 transition-all duration-150 ease-out">
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <Button variant="ghost" size="icon-xs" title="Predefined mix types"><ChevronDown /></Button>
-                          </PopoverTrigger>
-                          <PopoverContent className="w-36 p-1" align="end">
-                            <div className="space-y-0.5">
-                              {['Remix', 'VIP Mix', 'Extended Mix', 'Radio Edit', 'Club Mix', 'Dub Mix'].map((opt) => (
-                                <Button key={opt} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => handleRemixChange('mix_name', opt)}>{opt}</Button>
-                              ))}
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                        {remixData.mix_name !== originalRemixData.mix_name && <Button variant="ghost" size="icon-xs" onClick={() => setRemixData({ ...remixData, mix_name: originalRemixData.mix_name })} title="Reset"><RotateCcw /></Button>}
-                      </div>
-                    </div>
-                    <Input value={remixData.mix_name} onChange={(e) => handleRemixChange('mix_name', e.target.value)} className={`h-8 text-xs${remixData.mix_name !== originalRemixData.mix_name ? ' border-amber-400/70' : ''}`} placeholder="Mix type" />
+                      </PopoverContent>
+                    </Popover>
+                    {isChanged('original_artist') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('original_artist', originalFormData.original_artist)} title="Reset"><RotateCcw /></Button>}
                   </div>
                 </div>
+                <Input value={formData.original_artist} onChange={(e) => handleFormChange('original_artist', e.target.value)} className={`h-8 text-xs${isChanged('original_artist') ? ' border-amber-400/70' : ''}`} placeholder="—" />
               </div>
+
+              {/* Remixer */}
+              <div className="group flex flex-col gap-0.5">
+                <div className="flex items-center justify-between h-4">
+                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Remixer</span>
+                  <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
+                    <Button variant="ghost" size="icon-xs" onClick={() => { if (!formData.remixer) return; const t = cleanArtist(formData.remixer); if (t !== formData.remixer) handleFormChange('remixer', t); }} title="Clean"><Sparkles /></Button>
+                    <Button variant="ghost" size="icon-xs" onClick={() => { if (!formData.remixer) return; const t = titelize(formData.remixer); if (t !== formData.remixer) handleFormChange('remixer', t); }} title="Titelize"><CaseSensitive /></Button>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button variant="ghost" size="icon-xs" disabled={!selectedScTrack || !scArtistOptions.length} title="Artist options"><Users /></Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-48 p-2">
+                        <div className="space-y-1">
+                          {scArtistOptions.map((artist) => (
+                            <Button key={artist} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => handleFormChange('remixer', artist)}>{artist}</Button>
+                          ))}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                    {isChanged('remixer') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('remixer', originalFormData.remixer)} title="Reset"><RotateCcw /></Button>}
+                  </div>
+                </div>
+                <Input value={formData.remixer} onChange={(e) => handleFormChange('remixer', e.target.value)} className={`h-8 text-xs${isChanged('remixer') ? ' border-amber-400/70' : ''}`} placeholder="—" />
+              </div>
+            </div>
+
+            {/* Mix name (full width) */}
+            <div className="group flex flex-col gap-0.5">
+              <div className="flex items-center justify-between h-4">
+                <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Mix</span>
+                <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 transition-all duration-150 ease-out">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button variant="ghost" size="icon-xs" title="Predefined mix types"><ChevronDown /></Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-36 p-1" align="end">
+                      <div className="space-y-0.5">
+                        {['Remix', 'VIP Mix', 'Extended Mix', 'Radio Edit', 'Club Mix', 'Dub Mix'].map((opt) => (
+                          <Button key={opt} variant="ghost" size="sm" className="w-full justify-start text-xs" onClick={() => handleFormChange('mix_name', opt)}>{opt}</Button>
+                        ))}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  {isChanged('mix_name') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('mix_name', originalFormData.mix_name)} title="Reset"><RotateCcw /></Button>}
+                </div>
+              </div>
+              <Input value={formData.mix_name} onChange={(e) => handleFormChange('mix_name', e.target.value)} className={`h-8 text-xs${isChanged('mix_name') ? ' border-amber-400/70' : ''}`} placeholder="—" />
+            </div>
+
+            {/* User comment — plain text in COMM::eng, separate from StarlibMeta. */}
+            <div className="group flex flex-col gap-0.5">
+              <div className="flex items-center justify-between h-4">
+                <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">Comment</span>
+                <div className="flex gap-0.5 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus-within:opacity-100 group-focus-within:scale-100 transition-all duration-150 ease-out">
+                  {isChanged('user_comment') && <Button variant="ghost" size="icon-xs" onClick={() => handleFormChange('user_comment', originalFormData.user_comment)} title="Reset"><RotateCcw /></Button>}
+                </div>
+              </div>
+              <textarea
+                value={formData.user_comment}
+                onChange={(e) => handleFormChange('user_comment', e.target.value)}
+                className={`min-h-16 px-2.5 py-2 text-xs rounded-md border bg-transparent dark:bg-input/30 outline-none resize-y focus:border-ring focus:ring-1 focus:ring-ring/50${isChanged('user_comment') ? ' border-amber-400/70' : ' border-input dark:border-input'}`}
+                placeholder="—"
+              />
             </div>
 
             {/* SC link + search */}

--- a/frontend/src/app/meta-editor/track-editor.tsx
+++ b/frontend/src/app/meta-editor/track-editor.tsx
@@ -36,6 +36,7 @@ import { SoundCloudLogo } from '@/components/icons/soundcloud-logo';
 import {
   Sparkles,
   CaseSensitive,
+  Check,
   Trash2,
   Brackets,
   Wand2,
@@ -69,9 +70,13 @@ export interface TrackEditorProps {
   onFileChange: (file: FileInfo) => void;
   /** Called after finalize — selects the next track in the list. */
   onSelectNext: (currentFilePath: string) => void;
+  /** Shared pending field edits — lifted to the page so this editor and the
+   * batch table stay in sync while typing. */
+  pendingFieldEdits: Map<string, Record<string, string>>;
+  setPendingFieldEdits: React.Dispatch<React.SetStateAction<Map<string, Record<string, string>>>>;
 }
 
-export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoActions, onTableRefresh, onClose, onFileChange, onSelectNext }: TrackEditorProps) {
+export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoActions, onTableRefresh, onClose, onFileChange, onSelectNext, pendingFieldEdits, setPendingFieldEdits }: TrackEditorProps) {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
 
@@ -212,7 +217,7 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     const parsed = parseFilename(trackInfo.file_name);
     const joinList = (v: string | string[] | null | undefined): string =>
       Array.isArray(v) ? v.join(', ') : (v ?? '');
-    const newFormData: typeof emptyFormData = {
+    const originalData: typeof emptyFormData = {
       title: trackInfo.title || parsed.title || '',
       artist: joinList(trackInfo.artist) || parsed.artist || '',
       bpm: trackInfo.bpm?.toString() || '',
@@ -225,8 +230,12 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
       mix_name: trackInfo.mix_name || '',
       user_comment: trackInfo.user_comment || '',
     };
+    // Overlay any pending edits the user made in the batch table before
+    // opening the editor, so both surfaces show the same values.
+    const existingPending = pendingFieldEdits.get(trackInfo.file_path) ?? {};
+    const newFormData: typeof emptyFormData = { ...originalData, ...existingPending } as typeof emptyFormData;
     setFormData(newFormData);
-    setOriginalFormData(newFormData);
+    setOriginalFormData(originalData);
     setReleaseYearTouched(false);
     const parsedComment = parseComment(trackInfo.starlib_meta);
     setCommentData(parsedComment);
@@ -376,6 +385,22 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
   const formComplete =
     !!formData.title && !!formData.artist && !!formData.genre && !!formData.release_date && !!artworkUrl;
 
+  const mirrorToPending = (field: FormFieldKey, value: string) => {
+    if (!trackInfo) return;
+    const filePath = trackInfo.file_path;
+    const original = originalFormData[field];
+    setPendingFieldEdits(prev => {
+      const existing = prev.get(filePath) ?? {};
+      const isDirty = value !== (original ?? '');
+      const { [field]: _omit, ...rest } = existing;
+      const nextEntry: Record<string, string> = isDirty ? { ...rest, [field]: value } : rest;
+      const next = new Map(prev);
+      if (Object.keys(nextEntry).length === 0) next.delete(filePath);
+      else next.set(filePath, nextEntry);
+      return next;
+    });
+  };
+
   const handleFormChange = (field: FormFieldKey, value: string) => {
     setFormData(prev => {
       const next = { ...prev, [field]: value };
@@ -386,11 +411,35 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
           ? parse(value, 'yyyy-MM-dd', new Date())
           : null;
         next.release_year = parsed ? parsed.getFullYear().toString() : '';
+        mirrorToPending('release_year', next.release_year);
       }
       return next;
     });
     if (field === 'release_year') setReleaseYearTouched(true);
+    mirrorToPending(field, value);
   };
+
+  // React to external edits to the same file (e.g. user changed a cell in
+  // the batch table while the editor was open).
+  useEffect(() => {
+    if (!trackInfo) return;
+    const external = pendingFieldEdits.get(trackInfo.file_path) ?? {};
+    setFormData(prev => {
+      const merged: typeof emptyFormData = { ...originalFormData };
+      for (const [k, v] of Object.entries(external)) {
+        if (k in merged) (merged as Record<string, string>)[k] = v;
+      }
+      // Preserve any keys the user hasn't touched externally but has changed
+      // locally (e.g. a field edit in flight).
+      for (const key of Object.keys(prev) as FormFieldKey[]) {
+        if (!(key in external) && prev[key] !== originalFormData[key]) merged[key] = prev[key];
+      }
+      // Only return a new object when something actually changed to avoid
+      // render loops.
+      const changed = (Object.keys(merged) as FormFieldKey[]).some(k => merged[k] !== prev[k]);
+      return changed ? merged : prev;
+    });
+  }, [pendingFieldEdits, trackInfo, originalFormData]);
 
   const handleSave = async () => {
     if (!trackInfo) return;
@@ -429,6 +478,14 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
         file_path: newFilePath,
         file_name: newFilePath.split('/').pop() ?? selectedFile.file_name,
       };
+      // Persisted — drop the shared pending entry for both old and new paths.
+      setPendingFieldEdits(prev => {
+        if (!prev.has(trackInfo.file_path) && !prev.has(newFilePath)) return prev;
+        const next = new Map(prev);
+        next.delete(trackInfo.file_path);
+        next.delete(newFilePath);
+        return next;
+      });
       onTableRefresh();
       onFileChange(newFileInfo);
       await reloadTrackInfo(newFileInfo);
@@ -1107,34 +1164,46 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
 
           {/* Actions */}
           <div className="shrink-0 border-t border-border/50 px-3 py-2.5 flex items-center gap-1">
-            {(hasChanges || !activeRuleset?.rules.length) ? (
-              <>
-                <div
-                  className={`size-2 rounded-full shrink-0 ${trackInfo.is_ready ? 'bg-chart-1' : 'bg-amber-400'}`}
-                  title={[
-                    ...(trackInfo.missing_fields.length ? [`Missing: ${trackInfo.missing_fields.join(', ')}`] : []),
-                    ...(trackInfo.issues.length ? [trackInfo.issues.join(' · ')] : []),
-                  ].join('\n') || 'Ready'}
-                />
-                <Button onClick={handleSave} disabled={loading || !hasChanges} size="sm" className="h-7 text-xs px-2.5">Save</Button>
-              </>
-            ) : (
+            <div
+              className={`size-2 rounded-full shrink-0 ${trackInfo.is_ready ? 'bg-chart-1' : 'bg-amber-400'}`}
+              title={[
+                ...(trackInfo.missing_fields.length ? [`Missing: ${trackInfo.missing_fields.join(', ')}`] : []),
+                ...(trackInfo.issues.length ? [trackInfo.issues.join(' · ')] : []),
+              ].join('\n') || 'Ready'}
+            />
+
+            {/* Save */}
+            <Button
+              onClick={handleSave}
+              disabled={!hasChanges || loading}
+              size="sm"
+              className="h-7 text-xs px-2.5 gap-1.5"
+            >
+              {loading ? <LogoSpinner className="size-3" /> : <Check className="size-3" />}
+              Save
+            </Button>
+
+            {/* Apply Rules — shown only when folder has a ruleset */}
+            {activeRuleset?.rules.length ? (
               <TooltipProvider delayDuration={400} disableHoverableContent>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
                       onClick={handleFinalize}
-                      disabled={!trackInfo.is_ready || !formComplete || loading}
+                      disabled={loading}
                       size="sm"
-                      className="h-7 text-xs px-2.5 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold animate-in fade-in slide-in-from-right-2 duration-200"
-                    >Apply Rules</Button>
+                      className="h-7 text-xs px-2.5 gap-1.5 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold"
+                    >
+                      <Sparkles className="size-3" />
+                      Apply Rules
+                    </Button>
                   </TooltipTrigger>
                   <TooltipContent side="top" sideOffset={6} showArrow={false} className="p-0 max-w-64 bg-popover text-popover-foreground border">
                     <div className="px-3 py-2 border-b border-border">
-                      <p className="text-xs font-medium">{activeRuleset?.name ?? 'Rules'}</p>
+                      <p className="text-xs font-medium">{activeRuleset.name}</p>
                     </div>
                     <div className="py-1.5 flex flex-col gap-0.5 px-1.5">
-                      {activeRuleset?.rules.map((rule, i) => {
+                      {activeRuleset.rules.map((rule, i) => {
                         const Icon = RULE_ICONS[rule.type];
                         const folderParam = rule.params.folder as string | undefined;
                         const formatParam = rule.params.format as string | undefined;
@@ -1160,8 +1229,9 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-            )}
-            <Button onClick={handleDelete} disabled={loading} variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-destructive animate-in fade-in slide-in-from-right-2 duration-200"><Trash2 /></Button>
+            ) : null}
+            <div className="flex-1" />
+            <Button onClick={handleDelete} disabled={loading} variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-destructive"><Trash2 /></Button>
           </div>
         </div>
       )}

--- a/frontend/src/app/meta-editor/track-editor.tsx
+++ b/frontend/src/app/meta-editor/track-editor.tsx
@@ -214,9 +214,12 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     if (!trackInfo) return;
 
     const parsed = parseFilename(trackInfo.file_name);
+    const artistStr = Array.isArray(trackInfo.artist) ? trackInfo.artist.join(', ') : (trackInfo.artist ?? '');
+    const remixerStr = Array.isArray(trackInfo.remixer) ? trackInfo.remixer.join(', ') : (trackInfo.remixer ?? '');
+    const originalArtistStr = Array.isArray(trackInfo.original_artist) ? trackInfo.original_artist.join(', ') : (trackInfo.original_artist ?? '');
     const newFormData = {
       title: trackInfo.title || parsed.title || '',
-      artist: trackInfo.artist || parsed.artist || '',
+      artist: artistStr || parsed.artist || '',
       bpm: trackInfo.bpm?.toString() || '',
       key: trackInfo.key || '',
       genre: trackInfo.genre || '',
@@ -224,30 +227,30 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
     };
     setFormData(newFormData);
     setOriginalFormData(newFormData);
-    const parsedComment = parseComment(trackInfo.comment);
+    const parsedComment = parseComment(trackInfo.starlib_meta);
     setCommentData(parsedComment);
     setScLinkEnabled(!!(parsedComment.soundcloud_id || parsedComment.soundcloud_permalink));
 
-    if (trackInfo.remixers && trackInfo.remixers.length > 0) {
+    if (remixerStr) {
       setIsRemix(true);
-      setRemixData({ original_artist: trackInfo.artist || '', remixer: trackInfo.remixers[0], mix_name: 'Remix' });
+      setRemixData({ original_artist: originalArtistStr || artistStr, remixer: remixerStr, mix_name: trackInfo.mix_name || 'Remix' });
     } else {
       const titleToCheck = trackInfo.title || parsed.title || '';
       const detected = titleToCheck ? parseRemix(titleToCheck) : null;
       if (detected) {
         setIsRemix(true);
-        setRemixData({ original_artist: trackInfo.artist || parsed.artist || '', remixer: detected.remixer, mix_name: detected.mixName });
+        setRemixData({ original_artist: originalArtistStr || artistStr || parsed.artist || '', remixer: detected.remixer, mix_name: trackInfo.mix_name || detected.mixName });
       } else {
         setIsRemix(false);
         setRemixData({ original_artist: '', remixer: '', mix_name: 'Remix' });
       }
     }
 
-    const initialIsRemix = !!(trackInfo.remixers && trackInfo.remixers.length > 0) || !!(trackInfo.title && parseRemix(trackInfo.title));
+    const initialIsRemix = !!remixerStr || !!(trackInfo.title && parseRemix(trackInfo.title));
     setOriginalIsRemix(initialIsRemix);
     setOriginalRemixData(
-      trackInfo.remixers && trackInfo.remixers.length > 0
-        ? { original_artist: trackInfo.artist || '', remixer: trackInfo.remixers[0], mix_name: 'Remix' }
+      remixerStr
+        ? { original_artist: originalArtistStr || artistStr, remixer: remixerStr, mix_name: trackInfo.mix_name || 'Remix' }
         : { original_artist: '', remixer: '', mix_name: 'Remix' }
     );
     const initialScLinkEnabled = !!(parsedComment.soundcloud_id || parsedComment.soundcloud_permalink);
@@ -415,16 +418,20 @@ export function TrackEditor({ selectedFile, folderMode, folderRulesetId, autoAct
         }
       });
 
-      const commentStr = serializeComment(
+      const starlibStr = serializeComment(
         scLinkEnabled ? commentData.soundcloud_id : '',
         scLinkEnabled ? commentData.soundcloud_permalink : '',
       );
-      if (commentStr) updates.comment = commentStr;
+      if (starlibStr) updates.starlib_meta = starlibStr;
 
       if (isRemix && remixData.remixer) {
-        updates.remixers = [remixData.remixer];
+        updates.remixer = remixData.remixer;
+        updates.original_artist = remixData.original_artist || null;
+        updates.mix_name = remixData.mix_name || null;
       } else {
-        updates.remixers = [];
+        updates.remixer = null;
+        updates.original_artist = null;
+        updates.mix_name = null;
       }
 
       if (pendingArtworkData) {

--- a/frontend/src/components/collection-table.tsx
+++ b/frontend/src/components/collection-table.tsx
@@ -39,16 +39,18 @@ type SortOrder = 'asc' | 'desc';
 type EditableField = 'title' | 'artist' | 'genre' | 'bpm' | 'key' | 'release_date' | 'remixer' | 'original_artist' | 'mix_name';
 
 /** Fields shown in edit mode. `virtual` fields are not API fields — they're used for title composition. */
+// Fixed widths so columns keep their shape when the left grid cell narrows
+// (e.g. editor panel open) — horizontal scroll handles overflow instead.
 const EDITABLE_FIELDS: { key: EditableField; label: string; width: string }[] = [
-  { key: 'title', label: 'Title', width: 'flex-[3]' },
-  { key: 'artist', label: 'Artist', width: 'flex-[2]' },
-  { key: 'remixer', label: 'Remixer', width: 'w-24' },
-  { key: 'original_artist', label: 'Orig. Artist', width: 'w-24' },
-  { key: 'mix_name', label: 'Mix', width: 'w-20' },
-  { key: 'genre', label: 'Genre', width: 'w-24' },
+  { key: 'title', label: 'Title', width: 'w-96' },
+  { key: 'artist', label: 'Artist', width: 'w-64' },
+  { key: 'remixer', label: 'Remixer', width: 'w-32' },
+  { key: 'original_artist', label: 'Orig. Artist', width: 'w-32' },
+  { key: 'mix_name', label: 'Mix', width: 'w-24' },
+  { key: 'genre', label: 'Genre', width: 'w-32' },
   { key: 'bpm', label: 'BPM', width: 'w-14' },
   { key: 'key', label: 'Key', width: 'w-14' },
-  { key: 'release_date', label: 'Release', width: 'w-24' },
+  { key: 'release_date', label: 'Release', width: 'w-28' },
 ];
 
 /** Fields not stored in the API — remix composition helpers (not remixer itself, which is a real field) */
@@ -64,6 +66,10 @@ interface CollectionTableProps {
   onEditSaved?: () => void;
   activeRuleset?: Ruleset | null;
   autoApplyScResults?: boolean;
+  /** Shared pending field edits per file (keyed by file_path). Lifted to the
+   * page so the single-track editor and the batch table stay in sync. */
+  pendingFieldEdits: Map<string, Record<string, string>>;
+  setPendingFieldEdits: React.Dispatch<React.SetStateAction<Map<string, Record<string, string>>>>;
 }
 
 /** Sortable fields mapped to EDITABLE_FIELDS keys where applicable */
@@ -96,6 +102,7 @@ interface ScData {
 interface EditRowProps {
   item: TrackBrowse;
   isSelected: boolean;
+  isCurrent: boolean;
   changes: Partial<Record<EditableField, string>>;
   hasChanges: boolean;
   scStatus?: ScStatus;
@@ -132,7 +139,7 @@ function ScFieldRow({ label, scValue, currentValue, onApply }: { label: string; 
   );
 }
 
-function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onToggleSelect, onFieldChange, onApplyScField, onApplyAllScFields, onSelectScTrack, onSearchSc, onSelect, onSaveRow, onFinalize, savingRow, pendingArtworkB64, hasScLink, scLinkChanged, activeRuleset }: EditRowProps) {
+function EditRow({ item, isSelected, isCurrent, changes, hasChanges, scStatus, scData, onToggleSelect, onFieldChange, onApplyScField, onApplyAllScFields, onSelectScTrack, onSearchSc, onSelect, onSaveRow, onFinalize, savingRow, pendingArtworkB64, hasScLink, scLinkChanged, activeRuleset }: EditRowProps) {
   const artworkUrl = item.has_artwork
     ? api.getArtworkUrl(item.file_path)
     : pendingArtworkB64
@@ -149,11 +156,27 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
 
   const isChanged = (field: EditableField): boolean => field in changes;
 
+  // Backend readiness check mirror (see `check_file_readiness` in
+  // backend/core/services/metadata.py). Pending edits aren't persisted yet,
+  // so we evaluate against the on-disk item snapshot only.
+  const missingForFinalize: string[] = [];
+  if (!item.title) missingForFinalize.push('title');
+  if (!item.artist) missingForFinalize.push('artist');
+  if (!item.genre) missingForFinalize.push('genre');
+  if (!item.release_date) missingForFinalize.push('release_date');
+  if (!item.has_artwork) missingForFinalize.push('artwork');
+  const canFinalize = missingForFinalize.length === 0;
+
   return (
     <div
       role="row"
-      className={`flex items-center h-10 gap-1.5 px-3 border-b border-border/30 ${isSelected ? 'bg-accent/30' : ''}`}
+      aria-current={isCurrent ? 'true' : undefined}
+      className={`relative flex items-center h-10 gap-1.5 pl-3 pr-0 border-b border-border/30
+        ${isCurrent ? 'bg-primary/10' : isSelected ? 'bg-accent/30' : ''}`}
     >
+      {isCurrent && (
+        <span aria-hidden className="absolute inset-y-0 left-0 w-0.5 bg-primary" />
+      )}
       {/* Checkbox */}
       <div
         className="shrink-0 w-6 self-stretch flex items-center justify-center cursor-pointer"
@@ -296,7 +319,7 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
         <div key={f.key} className={`${f.width} min-w-0 shrink-0`}>
           <input
             className={`w-full h-7 px-1.5 text-xs rounded border bg-transparent outline-none transition-colors
-              ${isChanged(f.key) ? 'border-primary/40 bg-primary/5' : 'border-transparent hover:border-border'}
+              ${isChanged(f.key) ? 'border-amber-400/70 bg-amber-400/5' : 'border-transparent hover:border-border'}
               focus:border-ring focus:ring-1 focus:ring-ring/50`}
             value={getValue(f.key)}
             onChange={(e) => onFieldChange(f.key, e.target.value)}
@@ -310,69 +333,85 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
         {item.mtime ? new Date(item.mtime * 1000).toISOString().slice(0, 10) : '—'}
       </span>
 
-      {/* Per-row save with tooltip */}
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className={`shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors
-                ${hasChanges ? 'text-primary hover:bg-primary/10 cursor-pointer' : 'text-muted-foreground/30 cursor-default'}`}
-              disabled={!hasChanges || savingRow}
-              onClick={onSaveRow}
-            >
-              {savingRow ? <LogoSpinner className="size-3" /> : <Check className="size-3.5" />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            {hasChanges ? 'Save this track' : 'No changes'}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-
-      {/* Per-row apply rules — only when folder has a ruleset */}
-      {activeRuleset?.rules.length ? (
-        <TooltipProvider delayDuration={400} disableHoverableContent>
+      {/* Pinned action column — stays at the right edge when the row scrolls
+          horizontally so Save / Apply Rules are always reachable. */}
+      <div
+        className={`sticky right-0 ml-auto shrink-0 flex items-center gap-1 pl-2 pr-3 h-full
+          shadow-[-8px_0_12px_-8px_rgba(0,0,0,0.2)]
+          ${isCurrent ? 'bg-primary/10' : isSelected ? 'bg-accent/30' : 'bg-card'}`}
+      >
+        {/* Per-row save */}
+        <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
               <button
-                className="shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors text-emerald-600 hover:bg-emerald-600/10 cursor-pointer"
-                onClick={onFinalize}
+                className={`shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors
+                  ${hasChanges ? 'text-primary hover:bg-primary/10 cursor-pointer' : 'text-muted-foreground/30 cursor-default'}`}
+                disabled={!hasChanges || savingRow}
+                onClick={onSaveRow}
               >
-                <Sparkles className="size-3.5" />
+                {savingRow ? <LogoSpinner className="size-3" /> : <Check className="size-3.5" />}
               </button>
             </TooltipTrigger>
-            <TooltipContent side="left" sideOffset={6} showArrow={false} className="p-0 max-w-64 bg-popover text-popover-foreground border">
-              <div className="px-3 py-2 border-b border-border">
-                <p className="text-xs font-medium">{activeRuleset.name}</p>
-              </div>
-              <div className="py-1.5 flex flex-col gap-0.5 px-1.5">
-                {activeRuleset.rules.map((rule, i) => {
-                  const Icon = RULE_ICONS[rule.type];
-                  const folderParam = rule.params.folder as string | undefined;
-                  const formatParam = rule.params.format as string | undefined;
-                  const detail = rule.type === 'convert'
-                    ? formatParam ? formatParam.toUpperCase() : 'preferred'
-                    : folderParam ? `${folderParam}/` : '';
-                  const isConditional = rule.requires.length > 0;
-                  return (
-                    <div key={i} className={`flex items-center gap-2 rounded px-1.5 py-1 text-xs ${isConditional ? 'ml-4 border-l-2 border-blue-400/30 pl-2.5' : ''}`}>
-                      <StepBadge step={i + 1} type={rule.type} />
-                      <Icon className={`size-3.5 shrink-0 ${RULE_ICON_COLORS[rule.type]}`} />
-                      <span className="capitalize">{rule.type}</span>
-                      {detail && <span className="font-mono text-[10px] opacity-70">{detail}</span>}
-                      {isConditional && (
-                        <span className="text-[9px] rounded bg-blue-400/20 text-blue-300 px-1 font-medium">
-                          if converted
-                        </span>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+            <TooltipContent side="left">
+              {hasChanges ? 'Save this track' : 'No changes'}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-      ) : null}
+
+        {/* Per-row apply rules — only when folder has a ruleset */}
+        {activeRuleset?.rules.length ? (
+          <TooltipProvider delayDuration={400} disableHoverableContent>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className={`shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors
+                    ${canFinalize ? 'text-emerald-600 hover:bg-emerald-600/10 cursor-pointer' : 'text-muted-foreground/30 cursor-default'}`}
+                  disabled={!canFinalize}
+                  onClick={onFinalize}
+                >
+                  <Sparkles className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left" sideOffset={6} showArrow={false} className="p-0 max-w-64 bg-popover text-popover-foreground border">
+                {!canFinalize && (
+                  <div className="px-3 py-2 border-b border-border">
+                    <p className="text-xs font-medium text-amber-400">Not ready</p>
+                    <p className="text-[10px] text-muted-foreground mt-0.5">Missing: {missingForFinalize.join(', ')}</p>
+                  </div>
+                )}
+                <div className="px-3 py-2 border-b border-border">
+                  <p className="text-xs font-medium">{activeRuleset.name}</p>
+                </div>
+                <div className="py-1.5 flex flex-col gap-0.5 px-1.5">
+                  {activeRuleset.rules.map((rule, i) => {
+                    const Icon = RULE_ICONS[rule.type];
+                    const folderParam = rule.params.folder as string | undefined;
+                    const formatParam = rule.params.format as string | undefined;
+                    const detail = rule.type === 'convert'
+                      ? formatParam ? formatParam.toUpperCase() : 'preferred'
+                      : folderParam ? `${folderParam}/` : '';
+                    const isConditional = rule.requires.length > 0;
+                    return (
+                      <div key={i} className={`flex items-center gap-2 rounded px-1.5 py-1 text-xs ${isConditional ? 'ml-4 border-l-2 border-blue-400/30 pl-2.5' : ''}`}>
+                        <StepBadge step={i + 1} type={rule.type} />
+                        <Icon className={`size-3.5 shrink-0 ${RULE_ICON_COLORS[rule.type]}`} />
+                        <span className="capitalize">{rule.type}</span>
+                        {detail && <span className="font-mono text-[10px] opacity-70">{detail}</span>}
+                        {isConditional && (
+                          <span className="text-[9px] rounded bg-blue-400/20 text-blue-300 px-1 font-medium">
+                            if converted
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -397,7 +436,7 @@ function SkeletonRow() {
   );
 }
 
-export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSelect, onTotalChange, onItemsChange, refreshToken, onEditSaved, activeRuleset, autoApplyScResults }: CollectionTableProps) {
+export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSelect, onTotalChange, onItemsChange, refreshToken, onEditSaved, activeRuleset, autoApplyScResults, pendingFieldEdits, setPendingFieldEdits }: CollectionTableProps) {
   const [sortBy, setSortBy] = useQueryState('sort', searchParams.sort);
   const [sortOrder, setSortOrder] = useQueryState('order', searchParams.order);
   const [search] = useQueryState('search', searchParams.search);
@@ -421,8 +460,13 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
 
   const scrollParentRef = useRef<HTMLDivElement>(null);
 
-  // Edit-mode state
-  const [changes, setChanges] = useState<Map<string, Partial<Record<EditableField, string>>>>(new Map());
+  // Pending field edits live on the parent (page.tsx) so the single-track
+  // editor and the table share state.  Aliased here so the rest of the file
+  // keeps its existing `changes` / `setChanges` vocabulary.
+  const changes = pendingFieldEdits as Map<string, Partial<Record<EditableField, string>>>;
+  const setChanges = setPendingFieldEdits as unknown as React.Dispatch<
+    React.SetStateAction<Map<string, Partial<Record<EditableField, string>>>>
+  >;
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [savingRows, setSavingRows] = useState<Set<string>>(new Set());
@@ -1121,12 +1165,17 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
           ) : null}
         </div>
 
-      {/* Scrollable table area */}
-      <div className="flex-1 min-h-0 overflow-x-auto">
-      <div className="min-w-[1100px] flex flex-col h-full">
+      {/* Scrollable table area — single container owns both axes so the
+          vertical scrollbar stays on the viewport edge even when the row
+          content is wider than the viewport. */}
+      <div
+        ref={scrollParentRef}
+        className={`flex-1 min-h-0 overflow-auto overscroll-contain transition-opacity duration-150 ${reloading ? 'opacity-40' : 'opacity-100'}`}
+      >
+      <div className="w-max min-w-full">
 
-      {/* Header row */}
-      <div role="row" className="flex items-center gap-1.5 px-3 h-9 shrink-0 border-b border-border bg-muted/30 text-[10px] uppercase tracking-wider font-medium text-muted-foreground">
+      {/* Header row — sticky to the top of the scroll container */}
+      <div role="row" className="sticky top-0 z-20 flex items-center gap-1.5 pl-3 pr-0 h-9 border-b border-border bg-muted/30 text-[10px] uppercase tracking-wider font-medium text-muted-foreground">
         {/* Select all checkbox */}
         <div className="shrink-0 w-6 flex items-center justify-center">
           <Checkbox
@@ -1186,12 +1235,16 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
           Added
           <SortIcon col="mtime" sortBy={sortBy} sortOrder={sortOrder} />
         </button>
-        {/* Save (+ apply rules) column spacer */}
-        <div className={`shrink-0 ${activeRuleset?.rules.length ? 'w-12' : 'w-6'}`} />
+        {/* Pinned action column spacer — matches the sticky block in the row */}
+        <div
+          className={`sticky right-0 ml-auto shrink-0 flex items-center gap-1 pl-2 pr-3 h-full bg-muted/30
+            shadow-[-8px_0_12px_-8px_rgba(0,0,0,0.2)]
+            ${activeRuleset?.rules.length ? 'w-[calc(3rem+0.75rem)]' : 'w-[calc(1.5rem+0.75rem)]'}`}
+        />
       </div>
 
-      {/* Virtual scroll container */}
-      <div ref={scrollParentRef} className={`flex-1 overflow-y-auto overscroll-contain min-h-0 transition-opacity duration-150 ${reloading ? 'opacity-40' : 'opacity-100'}`}>
+      {/* Virtualized row surface */}
+      <div>
         {/* Total height for virtual scroll */}
         <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
           {virtualItems.map((virtualRow) => {
@@ -1214,6 +1267,7 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
                     <EditRow
                       item={item}
                       isSelected={selectedPaths.has(item.file_path)}
+                      isCurrent={selectedFilePath === item.file_path}
                       changes={changes.get(item.file_path) ?? {}}
                       hasChanges={changes.has(item.file_path) || pendingArtwork.has(item.file_path) || pendingScLinks.has(item.file_path)}
                       scStatus={scStatuses.get(item.file_path)}

--- a/frontend/src/components/collection-table.tsx
+++ b/frontend/src/components/collection-table.tsx
@@ -52,7 +52,6 @@ const EDITABLE_FIELDS: { key: EditableField; label: string; width: string }[] = 
 ];
 
 /** Fields not stored in the API — remix composition helpers (not remixer itself, which is a real field) */
-const VIRTUAL_FIELDS = new Set<EditableField>(['original_artist', 'mix_name']);
 
 interface CollectionTableProps {
   mode: string;
@@ -140,22 +139,15 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
       ? `data:image/jpeg;base64,${pendingArtworkB64}`
       : null;
 
-  // Derive original_artist and mix_name from existing data
-  const hasRemixer = !!(item.remixers?.[0] || (changes.remixer));
-  const detectedMix = item.title ? parseRemix(item.title) : null;
-
   const getValue = (field: EditableField): string => {
     if (field in changes) return changes[field] ?? '';
-    if (field === 'remixer') return item.remixers?.[0] ?? '';
-    if (field === 'original_artist') return hasRemixer ? (item.artist ?? '') : '';
-    if (field === 'mix_name') return detectedMix?.mixName ?? (hasRemixer ? 'Remix' : '');
     const val = item[field as keyof TrackBrowse];
-    return val == null ? '' : String(val);
+    if (val == null) return '';
+    if (Array.isArray(val)) return val.join(', ');
+    return String(val);
   };
 
   const isChanged = (field: EditableField): boolean => field in changes;
-
-  const remixerValue = getValue('remixer');
 
   return (
     <div
@@ -284,7 +276,7 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
       {/* Mini waveform (top-half) */}
       <div className="w-20 h-6 shrink-0">
         <MiniWaveform
-          track={{ filePath: item.file_path, fileName: item.file_name, title: item.title ?? undefined, artist: item.artist ?? undefined }}
+          track={{ filePath: item.file_path, fileName: item.file_name, title: item.title ?? undefined, artist: Array.isArray(item.artist) ? item.artist.join(', ') : (item.artist ?? undefined) }}
           halfHeight
         />
       </div>
@@ -301,7 +293,7 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
 
       {/* Editable fields */}
       {EDITABLE_FIELDS.map(f => (
-        <div key={f.key} className={`${f.width} min-w-0 shrink-0 ${f.key === 'original_artist' || f.key === 'mix_name' ? (remixerValue ? '' : 'opacity-30') : ''}`}>
+        <div key={f.key} className={`${f.width} min-w-0 shrink-0`}>
           <input
             className={`w-full h-7 px-1.5 text-xs rounded border bg-transparent outline-none transition-colors
               ${isChanged(f.key) ? 'border-primary/40 bg-primary/5' : 'border-transparent hover:border-border'}
@@ -309,7 +301,6 @@ function EditRow({ item, isSelected, changes, hasChanges, scStatus, scData, onTo
             value={getValue(f.key)}
             onChange={(e) => onFieldChange(f.key, e.target.value)}
             placeholder={f.label}
-            disabled={!remixerValue && (f.key === 'original_artist' || f.key === 'mix_name')}
           />
         </div>
       ))}
@@ -569,24 +560,17 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
   }
 
   function handleSelect(item: TrackBrowse) {
-    load({ filePath: item.file_path, fileName: item.file_name, title: item.title ?? undefined, artist: item.artist ?? undefined });
+    load({ filePath: item.file_path, fileName: item.file_name, title: item.title ?? undefined, artist: Array.isArray(item.artist) ? item.artist.join(', ') : (item.artist ?? undefined) });
     onSelect?.(item);
   }
 
   // Get the "original" value for a field — used for change detection
   const getOriginal = useCallback((item: TrackBrowse | undefined, field: EditableField): string => {
     if (!item) return '';
-    if (field === 'remixer') return item.remixers?.[0] ?? '';
-    if (field === 'original_artist') {
-      const hasRemix = !!(item.remixers?.[0]);
-      return hasRemix ? (item.artist ?? '') : '';
-    }
-    if (field === 'mix_name') {
-      const detected = item.title ? parseRemix(item.title) : null;
-      const hasRemix = !!(item.remixers?.[0]);
-      return detected?.mixName ?? (hasRemix ? 'Remix' : '');
-    }
-    return String(item[field as keyof TrackBrowse] ?? '');
+    const val = item[field as keyof TrackBrowse];
+    if (val == null) return '';
+    if (Array.isArray(val)) return val.join(', ');
+    return String(val);
   }, []);
 
   // Edit-mode helpers
@@ -814,17 +798,14 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
     }
   }, [scDataMap, updateField]);
 
-  // Build TrackInfoUpdateRequest from field changes + optional artwork/comment
-  const buildUpdates = useCallback((fileChanges: Partial<Record<EditableField, string>>, artworkB64?: string, scComment?: string): TrackInfoUpdateRequest => {
+  // Build TrackInfoUpdateRequest from field changes + optional artwork/starlib link
+  const buildUpdates = useCallback((fileChanges: Partial<Record<EditableField, string>>, artworkB64?: string, scStarlib?: string): TrackInfoUpdateRequest => {
     const updates: TrackInfoUpdateRequest = {};
     for (const [field, value] of Object.entries(fileChanges)) {
-      if (VIRTUAL_FIELDS.has(field as EditableField)) continue;
       if (field === 'bpm') {
         updates.bpm = value ? parseInt(value, 10) : undefined;
       } else if (field === 'release_date') {
         updates.release_date = value || undefined;
-      } else if (field === 'remixer') {
-        updates.remixers = value ? [value] : [];
       } else {
         (updates as Record<string, unknown>)[field] = value || undefined;
       }
@@ -832,8 +813,8 @@ export function CollectionTable({ mode, scrollToFilePath, selectedFilePath, onSe
     if (artworkB64) {
       updates.artwork_data = artworkB64;
     }
-    if (scComment) {
-      updates.comment = scComment;
+    if (scStarlib) {
+      updates.starlib_meta = scStarlib;
     }
     return updates;
   }, []);

--- a/frontend/src/generated/backend-openapi.json
+++ b/frontend/src/generated/backend-openapi.json
@@ -3082,6 +3082,157 @@
       },
       "TrackBrowseResponse": {
         "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artist"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "original_artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Artist"
+          },
+          "remixer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remixer"
+          },
+          "mix_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mix Name"
+          },
+          "release_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Date"
+          },
+          "release_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Year"
+          },
+          "user_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Comment"
+          },
+          "starlib_meta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starlib Meta"
+          },
           "file_path": {
             "type": "string",
             "title": "File Path"
@@ -3135,7 +3286,20 @@
               }
             ],
             "title": "Mtime"
-          },
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_path",
+          "file_name",
+          "file_format",
+          "file_size"
+        ],
+        "title": "TrackBrowseResponse",
+        "description": "Lightweight response for collection browse/table view."
+      },
+      "TrackInfoResponse": {
+        "properties": {
           "title": {
             "anyOf": [
               {
@@ -3286,20 +3450,7 @@
               }
             ],
             "title": "Starlib Meta"
-          }
-        },
-        "type": "object",
-        "required": [
-          "file_path",
-          "file_name",
-          "file_format",
-          "file_size"
-        ],
-        "title": "TrackBrowseResponse",
-        "description": "Lightweight response for collection browse/table view."
-      },
-      "TrackInfoResponse": {
-        "properties": {
+          },
           "file_path": {
             "type": "string",
             "title": "File Path"
@@ -3331,157 +3482,6 @@
             "type": "array",
             "title": "Issues",
             "default": []
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "artist": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Artist"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "original_artist": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Original Artist"
-          },
-          "remixer": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remixer"
-          },
-          "mix_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mix Name"
-          },
-          "release_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Release Date"
-          },
-          "release_year": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Release Year"
-          },
-          "user_comment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Comment"
-          },
-          "starlib_meta": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Starlib Meta"
           }
         },
         "type": "object",

--- a/frontend/src/generated/backend-openapi.json
+++ b/frontend/src/generated/backend-openapi.json
@@ -564,7 +564,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name)$",
+              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name|mtime)$",
               "default": "file_name",
               "title": "Sort By"
             }
@@ -850,6 +850,94 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OperationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metadata/files/batch-info": {
+      "post": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Batch Get File Info",
+        "description": "Get metadata for multiple audio files at once.",
+        "operationId": "batch_get_file_info_api_metadata_files_batch_info_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchInfoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TrackInfoResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Batch Get File Info Api Metadata Files Batch Info Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metadata/files/batch-update": {
+      "post": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Batch Update File Info",
+        "description": "Update metadata for multiple audio files at once.\n\nPartial failures don't block other files.",
+        "operationId": "batch_update_file_info_api_metadata_files_batch_update_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchUpdateResponse"
                 }
               }
             }
@@ -1202,7 +1290,7 @@
           "metadata"
         ],
         "summary": "Stream Audio",
-        "description": "Stream an audio file.\n\nFormats not natively supported by browsers (e.g. AIFF) are\ntranscoded to WAV on the fly via ffmpeg.\n\nParameters\n----------\nfile_path : str\n    Relative or absolute path to audio file\nroot_folder : Path\n    Root music folder (injected)\n\nReturns\n-------\nStreamingResponse\n    Audio file bytes\n\nRaises\n------\nHTTPException\n    If the file doesn't exist",
+        "description": "Stream an audio file.\n\nFormats not natively supported by browsers (e.g. AIFF) are transcoded to\nWAV via ffmpeg and cached.  Transcoding is awaited before responding so\nthat the browser always receives a real file with Content-Length and range\nsupport, which is required for seeking to work.\n\nParameters\n----------\nfile_path : str\n    Relative or absolute path to audio file\nroot_folder : Path\n    Root music folder (injected)\n\nReturns\n-------\nFileResponse\n    Audio file bytes\n\nRaises\n------\nHTTPException\n    If the file doesn't exist or transcoding fails",
         "operationId": "stream_audio_api_metadata_files__file_path__audio_get",
         "parameters": [
           {
@@ -1321,6 +1409,566 @@
           }
         }
       }
+    },
+    "/api/rulesets": {
+      "get": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "List Rulesets",
+        "description": "Return all rulesets and the active ruleset id.",
+        "operationId": "list_rulesets_api_rulesets_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RulesetsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "Create Ruleset",
+        "description": "Create a new user ruleset.",
+        "operationId": "create_ruleset_api_rulesets_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RulesetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ruleset"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rulesets/active": {
+      "get": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "Get Active Ruleset",
+        "description": "Return the currently active ruleset.",
+        "operationId": "get_active_ruleset_api_rulesets_active_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ruleset"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rulesets/{ruleset_id}": {
+      "put": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "Update Ruleset",
+        "description": "Update a ruleset's name and/or rules.\n\nRaises\n------\nHTTPException\n    404 if not found, 403 if built-in.",
+        "operationId": "update_ruleset_api_rulesets__ruleset_id__put",
+        "parameters": [
+          {
+            "name": "ruleset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ruleset Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RulesetUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ruleset"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "Delete Ruleset",
+        "description": "Delete a user ruleset.\n\nRaises\n------\nHTTPException\n    404 if not found, 403 if built-in.",
+        "operationId": "delete_ruleset_api_rulesets__ruleset_id__delete",
+        "parameters": [
+          {
+            "name": "ruleset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ruleset Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rulesets/{ruleset_id}/activate": {
+      "put": {
+        "tags": [
+          "rulesets"
+        ],
+        "summary": "Activate Ruleset",
+        "description": "Set the active ruleset.\n\nRaises\n------\nHTTPException\n    404 if not found.",
+        "operationId": "activate_ruleset_api_rulesets__ruleset_id__activate_put",
+        "parameters": [
+          {
+            "name": "ruleset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ruleset Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ruleset"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/config": {
+      "get": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Get Folders Config",
+        "description": "Return the folder display and ruleset configuration.",
+        "operationId": "get_folders_config_api_folders_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoldersConfig"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Update Folders Config",
+        "description": "Replace the folder display and ruleset configuration.",
+        "operationId": "update_folders_config_api_folders_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoldersConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoldersConfig"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Settings",
+        "description": "Return application settings.",
+        "operationId": "get_settings_api_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Settings Api Settings Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Settings",
+        "description": "Update application settings (partial merge allowed).",
+        "operationId": "update_settings_api_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Body"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Update Settings Api Settings Put"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/settings/root-folder": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Root Folder",
+        "description": "Return the current root music folder path.",
+        "operationId": "get_root_folder_api_settings_root_folder_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Root Folder",
+        "description": "Update the root music folder path and hot-reload the file watcher.",
+        "operationId": "update_root_folder_api_settings_root_folder_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ollama/status": {
+      "get": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Get Status",
+        "description": "Check if Ollama is reachable and return available model names.",
+        "operationId": "get_status_api_ollama_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OllamaStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ollama/start": {
+      "post": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Start Ollama",
+        "description": "Ensure Ollama is running, auto-starting it if necessary.",
+        "operationId": "start_ollama_api_ollama_start_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OllamaStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ollama/stop": {
+      "post": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Stop Ollama",
+        "description": "Stop Ollama if we started it.",
+        "operationId": "stop_ollama_api_ollama_stop_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OllamaStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ollama/models": {
+      "get": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Get Models",
+        "description": "Return installed models with details (name, size, digest).",
+        "operationId": "get_models_api_ollama_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OllamaModelsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ollama/settings": {
+      "get": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Get Settings",
+        "description": "Return current Ollama settings.",
+        "operationId": "get_settings_api_ollama_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Settings Api Ollama Settings Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ollama"
+        ],
+        "summary": "Update Settings",
+        "description": "Update Ollama URL and/or selected model.",
+        "operationId": "update_settings_api_ollama_settings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OllamaSettingsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Update Settings Api Ollama Settings Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1343,6 +1991,110 @@
         ],
         "title": "AuthorizeResponse",
         "description": "Authorization URL response."
+      },
+      "BatchInfoRequest": {
+        "properties": {
+          "file_paths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "File Paths"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_paths"
+        ],
+        "title": "BatchInfoRequest",
+        "description": "Request to get metadata for multiple files at once."
+      },
+      "BatchResultItem": {
+        "properties": {
+          "file_path": {
+            "type": "string",
+            "title": "File Path"
+          },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "new_file_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New File Path"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_path",
+          "success",
+          "message"
+        ],
+        "title": "BatchResultItem",
+        "description": "Result of a single file update within a batch."
+      },
+      "BatchUpdateItem": {
+        "properties": {
+          "file_path": {
+            "type": "string",
+            "title": "File Path"
+          },
+          "updates": {
+            "$ref": "#/components/schemas/TrackInfoUpdateRequest"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_path",
+          "updates"
+        ],
+        "title": "BatchUpdateItem",
+        "description": "A single file update within a batch."
+      },
+      "BatchUpdateRequest": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BatchUpdateItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "BatchUpdateRequest",
+        "description": "Request to update metadata for multiple files at once."
+      },
+      "BatchUpdateResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/BatchResultItem"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "results"
+        ],
+        "title": "BatchUpdateResponse",
+        "description": "Response from a batch update operation."
       },
       "Body_update_file_artwork_api_metadata_files__file_path__artwork_post": {
         "properties": {
@@ -1709,6 +2461,14 @@
           "new_file_path": {
             "type": "string",
             "title": "New File Path"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/FinalizeStep"
+            },
+            "type": "array",
+            "title": "Steps",
+            "default": []
           }
         },
         "type": "object",
@@ -1719,6 +2479,89 @@
         ],
         "title": "FinalizeResponse",
         "description": "Response from finalization operation."
+      },
+      "FinalizeStep": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "status",
+          "message"
+        ],
+        "title": "FinalizeStep",
+        "description": "A single rule execution result."
+      },
+      "FolderConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "visible": {
+            "type": "boolean",
+            "title": "Visible",
+            "default": true
+          },
+          "order": {
+            "type": "integer",
+            "title": "Order",
+            "default": 0
+          },
+          "ruleset_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ruleset Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "label"
+        ],
+        "title": "FolderConfig",
+        "description": "Configuration for a single music folder tab."
+      },
+      "FoldersConfig": {
+        "properties": {
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/FolderConfig"
+            },
+            "type": "array",
+            "title": "Folders"
+          }
+        },
+        "type": "object",
+        "title": "FoldersConfig",
+        "description": "Top-level container for all folder configs."
       },
       "HTTPValidationError": {
         "properties": {
@@ -1732,6 +2575,104 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "OllamaModel": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size",
+            "default": 0
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "OllamaModel",
+        "description": "Single model from Ollama's /api/tags response."
+      },
+      "OllamaModelsResponse": {
+        "properties": {
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/OllamaModel"
+            },
+            "type": "array",
+            "title": "Models"
+          }
+        },
+        "type": "object",
+        "title": "OllamaModelsResponse",
+        "description": "Response for GET /ollama/models."
+      },
+      "OllamaSettingsRequest": {
+        "properties": {
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "title": "OllamaSettingsRequest",
+        "description": "Request body for POST /ollama/settings."
+      },
+      "OllamaStatusResponse": {
+        "properties": {
+          "available": {
+            "type": "boolean",
+            "title": "Available"
+          },
+          "installed": {
+            "type": "boolean",
+            "title": "Installed",
+            "default": false
+          },
+          "models": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Models"
+          },
+          "started_by_us": {
+            "type": "boolean",
+            "title": "Started By Us",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "available"
+        ],
+        "title": "OllamaStatusResponse",
+        "description": "Response for GET /ollama/status."
       },
       "OperationResponse": {
         "properties": {
@@ -1911,6 +2852,177 @@
         "title": "RefreshResponse",
         "description": "Token refresh response."
       },
+      "RootFolderRequest": {
+        "properties": {
+          "root_music_folder": {
+            "type": "string",
+            "title": "Root Music Folder"
+          }
+        },
+        "type": "object",
+        "required": [
+          "root_music_folder"
+        ],
+        "title": "RootFolderRequest"
+      },
+      "RootFolderResponse": {
+        "properties": {
+          "root_music_folder": {
+            "type": "string",
+            "title": "Root Music Folder"
+          }
+        },
+        "type": "object",
+        "required": [
+          "root_music_folder"
+        ],
+        "title": "RootFolderResponse"
+      },
+      "Rule": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "move",
+              "convert",
+              "copy"
+            ],
+            "title": "Type"
+          },
+          "input": {
+            "type": "string",
+            "title": "Input",
+            "default": "source"
+          },
+          "requires": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Requires"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "Rule",
+        "description": "A single step in a finalization pipeline."
+      },
+      "Ruleset": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "is_builtin": {
+            "type": "boolean",
+            "title": "Is Builtin",
+            "default": false
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/Rule"
+            },
+            "type": "array",
+            "title": "Rules"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "Ruleset",
+        "description": "A named, ordered collection of rules."
+      },
+      "RulesetCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/Rule"
+            },
+            "type": "array",
+            "title": "Rules"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "RulesetCreate",
+        "description": "Payload for creating a new ruleset."
+      },
+      "RulesetUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "rules": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Rule"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rules"
+          }
+        },
+        "type": "object",
+        "title": "RulesetUpdate",
+        "description": "Payload for updating an existing ruleset."
+      },
+      "RulesetsResponse": {
+        "properties": {
+          "rulesets": {
+            "items": {
+              "$ref": "#/components/schemas/Ruleset"
+            },
+            "type": "array",
+            "title": "Rulesets"
+          },
+          "active_ruleset_id": {
+            "type": "string",
+            "title": "Active Ruleset Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rulesets",
+          "active_ruleset_id"
+        ],
+        "title": "RulesetsResponse",
+        "description": "Response listing all rulesets."
+      },
       "SetupRequest": {
         "properties": {
           "client_id": {
@@ -1978,29 +3090,7 @@
             "type": "string",
             "title": "File Name"
           },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "artist": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Artist"
-          },
-          "bpm": {
+          "soundcloud_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -2009,41 +3099,7 @@
                 "type": "null"
               }
             ],
-            "title": "Bpm"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "release_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Release Date"
+            "title": "Soundcloud Id"
           },
           "has_artwork": {
             "type": "boolean",
@@ -2068,27 +3124,17 @@
               }
             ],
             "title": "Duration"
-          }
-        },
-        "type": "object",
-        "required": [
-          "file_path",
-          "file_name",
-          "file_format",
-          "file_size"
-        ],
-        "title": "TrackBrowseResponse",
-        "description": "Lightweight response for collection browse/table view."
-      },
-      "TrackInfoResponse": {
-        "properties": {
-          "file_path": {
-            "type": "string",
-            "title": "File Path"
           },
-          "file_name": {
-            "type": "string",
-            "title": "File Name"
+          "mtime": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mtime"
           },
           "title": {
             "anyOf": [
@@ -2107,10 +3153,27 @@
                 "type": "string"
               },
               {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
                 "type": "null"
               }
             ],
             "title": "Artist"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
           },
           "bpm": {
             "anyOf": [
@@ -2134,18 +3197,41 @@
             ],
             "title": "Key"
           },
-          "genre": {
+          "original_artist": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
                 "type": "null"
               }
             ],
-            "title": "Genre"
+            "title": "Original Artist"
           },
-          "comment": {
+          "remixer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remixer"
+          },
+          "mix_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2154,7 +3240,7 @@
                 "type": "null"
               }
             ],
-            "title": "Comment"
+            "title": "Mix Name"
           },
           "release_date": {
             "anyOf": [
@@ -2168,19 +3254,59 @@
             ],
             "title": "Release Date"
           },
-          "remixers": {
+          "release_year": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Remixers"
+            "title": "Release Year"
+          },
+          "user_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Comment"
+          },
+          "starlib_meta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starlib Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_path",
+          "file_name",
+          "file_format",
+          "file_size"
+        ],
+        "title": "TrackBrowseResponse",
+        "description": "Lightweight response for collection browse/table view."
+      },
+      "TrackInfoResponse": {
+        "properties": {
+          "file_path": {
+            "type": "string",
+            "title": "File Path"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
           },
           "has_artwork": {
             "type": "boolean",
@@ -2205,20 +3331,7 @@
             "type": "array",
             "title": "Issues",
             "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "file_path",
-          "file_name",
-          "has_artwork",
-          "is_ready"
-        ],
-        "title": "TrackInfoResponse",
-        "description": "Response containing track metadata."
-      },
-      "TrackInfoUpdateRequest": {
-        "properties": {
+          },
           "title": {
             "anyOf": [
               {
@@ -2236,10 +3349,27 @@
                 "type": "string"
               },
               {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
                 "type": "null"
               }
             ],
             "title": "Artist"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
           },
           "bpm": {
             "anyOf": [
@@ -2263,18 +3393,41 @@
             ],
             "title": "Key"
           },
-          "genre": {
+          "original_artist": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
                 "type": "null"
               }
             ],
-            "title": "Genre"
+            "title": "Original Artist"
           },
-          "comment": {
+          "remixer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remixer"
+          },
+          "mix_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2283,7 +3436,7 @@
                 "type": "null"
               }
             ],
-            "title": "Comment"
+            "title": "Mix Name"
           },
           "release_date": {
             "anyOf": [
@@ -2297,8 +3450,68 @@
             ],
             "title": "Release Date"
           },
-          "remixers": {
+          "release_year": {
             "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Year"
+          },
+          "user_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Comment"
+          },
+          "starlib_meta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starlib Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_path",
+          "file_name",
+          "has_artwork",
+          "is_ready"
+        ],
+        "title": "TrackInfoResponse",
+        "description": "Response containing track metadata. Tag fields are flat per the registry."
+      },
+      "TrackInfoUpdateRequest": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
               {
                 "items": {
                   "type": "string"
@@ -2309,7 +3522,130 @@
                 "type": "null"
               }
             ],
-            "title": "Remixers"
+            "title": "Artist"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "original_artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Artist"
+          },
+          "remixer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remixer"
+          },
+          "mix_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mix Name"
+          },
+          "release_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Date"
+          },
+          "release_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Year"
+          },
+          "user_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Comment"
+          },
+          "starlib_meta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Starlib Meta"
           },
           "artwork_data": {
             "anyOf": [
@@ -2325,7 +3661,7 @@
         },
         "type": "object",
         "title": "TrackInfoUpdateRequest",
-        "description": "Request to update track metadata."
+        "description": "Request to update track metadata. All fields optional."
       },
       "UserInfo": {
         "properties": {

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -393,6 +393,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/metadata/files/batch-info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch Get File Info
+         * @description Get metadata for multiple audio files at once.
+         */
+        post: operations["batch_get_file_info_api_metadata_files_batch_info_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/metadata/files/batch-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch Update File Info
+         * @description Update metadata for multiple audio files at once.
+         *
+         *     Partial failures don't block other files.
+         */
+        post: operations["batch_update_file_info_api_metadata_files_batch_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/metadata/files/{file_path}/readiness": {
         parameters: {
             query?: never;
@@ -639,8 +681,10 @@ export interface paths {
          * Stream Audio
          * @description Stream an audio file.
          *
-         *     Formats not natively supported by browsers (e.g. AIFF) are
-         *     transcoded to WAV on the fly via ffmpeg.
+         *     Formats not natively supported by browsers (e.g. AIFF) are transcoded to
+         *     WAV via ffmpeg and cached.  Transcoding is awaited before responding so
+         *     that the browser always receives a real file with Content-Length and range
+         *     support, which is required for seeking to work.
          *
          *     Parameters
          *     ----------
@@ -651,13 +695,13 @@ export interface paths {
          *
          *     Returns
          *     -------
-         *     StreamingResponse
+         *     FileResponse
          *         Audio file bytes
          *
          *     Raises
          *     ------
          *     HTTPException
-         *         If the file doesn't exist
+         *         If the file doesn't exist or transcoding fails
          */
         get: operations["stream_audio_api_metadata_files__file_path__audio_get"];
         put?: never;
@@ -743,6 +787,285 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/rulesets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Rulesets
+         * @description Return all rulesets and the active ruleset id.
+         */
+        get: operations["list_rulesets_api_rulesets_get"];
+        put?: never;
+        /**
+         * Create Ruleset
+         * @description Create a new user ruleset.
+         */
+        post: operations["create_ruleset_api_rulesets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rulesets/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Active Ruleset
+         * @description Return the currently active ruleset.
+         */
+        get: operations["get_active_ruleset_api_rulesets_active_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rulesets/{ruleset_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Ruleset
+         * @description Update a ruleset's name and/or rules.
+         *
+         *     Raises
+         *     ------
+         *     HTTPException
+         *         404 if not found, 403 if built-in.
+         */
+        put: operations["update_ruleset_api_rulesets__ruleset_id__put"];
+        post?: never;
+        /**
+         * Delete Ruleset
+         * @description Delete a user ruleset.
+         *
+         *     Raises
+         *     ------
+         *     HTTPException
+         *         404 if not found, 403 if built-in.
+         */
+        delete: operations["delete_ruleset_api_rulesets__ruleset_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rulesets/{ruleset_id}/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Activate Ruleset
+         * @description Set the active ruleset.
+         *
+         *     Raises
+         *     ------
+         *     HTTPException
+         *         404 if not found.
+         */
+        put: operations["activate_ruleset_api_rulesets__ruleset_id__activate_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/folders/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Folders Config
+         * @description Return the folder display and ruleset configuration.
+         */
+        get: operations["get_folders_config_api_folders_config_get"];
+        /**
+         * Update Folders Config
+         * @description Replace the folder display and ruleset configuration.
+         */
+        put: operations["update_folders_config_api_folders_config_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Settings
+         * @description Return application settings.
+         */
+        get: operations["get_settings_api_settings_get"];
+        /**
+         * Update Settings
+         * @description Update application settings (partial merge allowed).
+         */
+        put: operations["update_settings_api_settings_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/root-folder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Root Folder
+         * @description Return the current root music folder path.
+         */
+        get: operations["get_root_folder_api_settings_root_folder_get"];
+        /**
+         * Update Root Folder
+         * @description Update the root music folder path and hot-reload the file watcher.
+         */
+        put: operations["update_root_folder_api_settings_root_folder_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ollama/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Status
+         * @description Check if Ollama is reachable and return available model names.
+         */
+        get: operations["get_status_api_ollama_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ollama/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start Ollama
+         * @description Ensure Ollama is running, auto-starting it if necessary.
+         */
+        post: operations["start_ollama_api_ollama_start_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ollama/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop Ollama
+         * @description Stop Ollama if we started it.
+         */
+        post: operations["stop_ollama_api_ollama_stop_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ollama/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Models
+         * @description Return installed models with details (name, size, digest).
+         */
+        get: operations["get_models_api_ollama_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ollama/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Settings
+         * @description Return current Ollama settings.
+         */
+        get: operations["get_settings_api_ollama_settings_get"];
+        put?: never;
+        /**
+         * Update Settings
+         * @description Update Ollama URL and/or selected model.
+         */
+        post: operations["update_settings_api_ollama_settings_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -756,6 +1079,53 @@ export interface components {
             authorization_url: string;
             /** State */
             state: string;
+        };
+        /**
+         * BatchInfoRequest
+         * @description Request to get metadata for multiple files at once.
+         */
+        BatchInfoRequest: {
+            /** File Paths */
+            file_paths: string[];
+        };
+        /**
+         * BatchResultItem
+         * @description Result of a single file update within a batch.
+         */
+        BatchResultItem: {
+            /** File Path */
+            file_path: string;
+            /** Success */
+            success: boolean;
+            /** Message */
+            message: string;
+            /** New File Path */
+            new_file_path?: string | null;
+        };
+        /**
+         * BatchUpdateItem
+         * @description A single file update within a batch.
+         */
+        BatchUpdateItem: {
+            /** File Path */
+            file_path: string;
+            updates: components["schemas"]["TrackInfoUpdateRequest"];
+        };
+        /**
+         * BatchUpdateRequest
+         * @description Request to update metadata for multiple files at once.
+         */
+        BatchUpdateRequest: {
+            /** Items */
+            items: components["schemas"]["BatchUpdateItem"][];
+        };
+        /**
+         * BatchUpdateResponse
+         * @description Response from a batch update operation.
+         */
+        BatchUpdateResponse: {
+            /** Results */
+            results: components["schemas"]["BatchResultItem"][];
         };
         /** Body_update_file_artwork_api_metadata_files__file_path__artwork_post */
         Body_update_file_artwork_api_metadata_files__file_path__artwork_post: {
@@ -939,11 +1309,116 @@ export interface components {
             message: string;
             /** New File Path */
             new_file_path: string;
+            /**
+             * Steps
+             * @default []
+             */
+            steps: components["schemas"]["FinalizeStep"][];
+        };
+        /**
+         * FinalizeStep
+         * @description A single rule execution result.
+         */
+        FinalizeStep: {
+            /** Id */
+            id: string;
+            /** Type */
+            type: string;
+            /** Status */
+            status: string;
+            /** Message */
+            message: string;
+        };
+        /**
+         * FolderConfig
+         * @description Configuration for a single music folder tab.
+         */
+        FolderConfig: {
+            /** Name */
+            name: string;
+            /** Label */
+            label: string;
+            /**
+             * Visible
+             * @default true
+             */
+            visible: boolean;
+            /**
+             * Order
+             * @default 0
+             */
+            order: number;
+            /** Ruleset Id */
+            ruleset_id?: string | null;
+        };
+        /**
+         * FoldersConfig
+         * @description Top-level container for all folder configs.
+         */
+        FoldersConfig: {
+            /** Folders */
+            folders?: components["schemas"]["FolderConfig"][];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * OllamaModel
+         * @description Single model from Ollama's /api/tags response.
+         */
+        OllamaModel: {
+            /** Name */
+            name: string;
+            /**
+             * Size
+             * @default 0
+             */
+            size: number;
+            /**
+             * Digest
+             * @default
+             */
+            digest: string;
+        };
+        /**
+         * OllamaModelsResponse
+         * @description Response for GET /ollama/models.
+         */
+        OllamaModelsResponse: {
+            /** Models */
+            models?: components["schemas"]["OllamaModel"][];
+        };
+        /**
+         * OllamaSettingsRequest
+         * @description Request body for POST /ollama/settings.
+         */
+        OllamaSettingsRequest: {
+            /** Url */
+            url?: string | null;
+            /** Model */
+            model?: string | null;
+        };
+        /**
+         * OllamaStatusResponse
+         * @description Response for GET /ollama/status.
+         */
+        OllamaStatusResponse: {
+            /** Available */
+            available: boolean;
+            /**
+             * Installed
+             * @default false
+             */
+            installed: boolean;
+            /** Models */
+            models?: string[];
+            /**
+             * Started By Us
+             * @default false
+             */
+            started_by_us: boolean;
         };
         /**
          * OperationResponse
@@ -1011,6 +1486,87 @@ export interface components {
             /** Expires In */
             expires_in?: number | null;
         };
+        /** RootFolderRequest */
+        RootFolderRequest: {
+            /** Root Music Folder */
+            root_music_folder: string;
+        };
+        /** RootFolderResponse */
+        RootFolderResponse: {
+            /** Root Music Folder */
+            root_music_folder: string;
+        };
+        /**
+         * Rule
+         * @description A single step in a finalization pipeline.
+         */
+        Rule: {
+            /** Id */
+            id?: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "move" | "convert" | "copy";
+            /**
+             * Input
+             * @default source
+             */
+            input: string;
+            /** Requires */
+            requires?: string[];
+            /** Params */
+            params?: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * Ruleset
+         * @description A named, ordered collection of rules.
+         */
+        Ruleset: {
+            /** Id */
+            id?: string;
+            /** Name */
+            name: string;
+            /**
+             * Is Builtin
+             * @default false
+             */
+            is_builtin: boolean;
+            /** Rules */
+            rules?: components["schemas"]["Rule"][];
+        };
+        /**
+         * RulesetCreate
+         * @description Payload for creating a new ruleset.
+         */
+        RulesetCreate: {
+            /** Name */
+            name: string;
+            /** Rules */
+            rules?: components["schemas"]["Rule"][];
+        };
+        /**
+         * RulesetUpdate
+         * @description Payload for updating an existing ruleset.
+         */
+        RulesetUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Rules */
+            rules?: components["schemas"]["Rule"][] | null;
+        };
+        /**
+         * RulesetsResponse
+         * @description Response listing all rulesets.
+         */
+        RulesetsResponse: {
+            /** Rulesets */
+            rulesets: components["schemas"]["Ruleset"][];
+            /** Active Ruleset Id */
+            active_ruleset_id: string;
+        };
         /**
          * SetupRequest
          * @description Payload from the first-launch setup form.
@@ -1053,18 +1609,8 @@ export interface components {
             file_path: string;
             /** File Name */
             file_name: string;
-            /** Title */
-            title?: string | null;
-            /** Artist */
-            artist?: string | null;
-            /** Bpm */
-            bpm?: number | null;
-            /** Key */
-            key?: string | null;
-            /** Genre */
-            genre?: string | null;
-            /** Release Date */
-            release_date?: string | null;
+            /** Soundcloud Id */
+            soundcloud_id?: number | null;
             /**
              * Has Artwork
              * @default false
@@ -1076,32 +1622,42 @@ export interface components {
             file_size: number;
             /** Duration */
             duration?: number | null;
+            /** Mtime */
+            mtime?: number | null;
+            /** Title */
+            title?: string | null;
+            /** Artist */
+            artist?: string | string[] | null;
+            /** Genre */
+            genre?: string | null;
+            /** Bpm */
+            bpm?: number | null;
+            /** Key */
+            key?: string | null;
+            /** Original Artist */
+            original_artist?: string | string[] | null;
+            /** Remixer */
+            remixer?: string | string[] | null;
+            /** Mix Name */
+            mix_name?: string | null;
+            /** Release Date */
+            release_date?: string | null;
+            /** Release Year */
+            release_year?: number | null;
+            /** User Comment */
+            user_comment?: string | null;
+            /** Starlib Meta */
+            starlib_meta?: string | null;
         };
         /**
          * TrackInfoResponse
-         * @description Response containing track metadata.
+         * @description Response containing track metadata. Tag fields are flat per the registry.
          */
         TrackInfoResponse: {
             /** File Path */
             file_path: string;
             /** File Name */
             file_name: string;
-            /** Title */
-            title?: string | null;
-            /** Artist */
-            artist?: string | null;
-            /** Bpm */
-            bpm?: number | null;
-            /** Key */
-            key?: string | null;
-            /** Genre */
-            genre?: string | null;
-            /** Comment */
-            comment?: string | null;
-            /** Release Date */
-            release_date?: string | null;
-            /** Remixers */
-            remixers?: string[] | null;
             /** Has Artwork */
             has_artwork: boolean;
             /** Is Ready */
@@ -1116,28 +1672,60 @@ export interface components {
              * @default []
              */
             issues: string[];
+            /** Title */
+            title?: string | null;
+            /** Artist */
+            artist?: string | string[] | null;
+            /** Genre */
+            genre?: string | null;
+            /** Bpm */
+            bpm?: number | null;
+            /** Key */
+            key?: string | null;
+            /** Original Artist */
+            original_artist?: string | string[] | null;
+            /** Remixer */
+            remixer?: string | string[] | null;
+            /** Mix Name */
+            mix_name?: string | null;
+            /** Release Date */
+            release_date?: string | null;
+            /** Release Year */
+            release_year?: number | null;
+            /** User Comment */
+            user_comment?: string | null;
+            /** Starlib Meta */
+            starlib_meta?: string | null;
         };
         /**
          * TrackInfoUpdateRequest
-         * @description Request to update track metadata.
+         * @description Request to update track metadata. All fields optional.
          */
         TrackInfoUpdateRequest: {
             /** Title */
             title?: string | null;
             /** Artist */
-            artist?: string | null;
+            artist?: string | string[] | null;
+            /** Genre */
+            genre?: string | null;
             /** Bpm */
             bpm?: number | null;
             /** Key */
             key?: string | null;
-            /** Genre */
-            genre?: string | null;
-            /** Comment */
-            comment?: string | null;
+            /** Original Artist */
+            original_artist?: string | string[] | null;
+            /** Remixer */
+            remixer?: string | string[] | null;
+            /** Mix Name */
+            mix_name?: string | null;
             /** Release Date */
             release_date?: string | null;
-            /** Remixers */
-            remixers?: string[] | null;
+            /** Release Year */
+            release_year?: number | null;
+            /** User Comment */
+            user_comment?: string | null;
+            /** Starlib Meta */
+            starlib_meta?: string | null;
             /** Artwork Data */
             artwork_data?: string | null;
         };
@@ -1608,6 +2196,72 @@ export interface operations {
             };
         };
     };
+    batch_get_file_info_api_metadata_files_batch_info_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchInfoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrackInfoResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    batch_update_file_info_api_metadata_files_batch_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchUpdateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     check_file_readiness_api_metadata_files__file_path__readiness_get: {
         parameters: {
             query?: never;
@@ -1925,6 +2579,476 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_rulesets_api_rulesets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RulesetsResponse"];
+                };
+            };
+        };
+    };
+    create_ruleset_api_rulesets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RulesetCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Ruleset"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_active_ruleset_api_rulesets_active_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Ruleset"];
+                };
+            };
+        };
+    };
+    update_ruleset_api_rulesets__ruleset_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ruleset_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RulesetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Ruleset"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_ruleset_api_rulesets__ruleset_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ruleset_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    activate_ruleset_api_rulesets__ruleset_id__activate_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ruleset_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Ruleset"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_folders_config_api_folders_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoldersConfig"];
+                };
+            };
+        };
+    };
+    update_folders_config_api_folders_config_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FoldersConfig"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoldersConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_settings_api_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+    };
+    update_settings_api_settings_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_root_folder_api_settings_root_folder_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RootFolderResponse"];
+                };
+            };
+        };
+    };
+    update_root_folder_api_settings_root_folder_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RootFolderRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RootFolderResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_status_api_ollama_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OllamaStatusResponse"];
+                };
+            };
+        };
+    };
+    start_ollama_api_ollama_start_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OllamaStatusResponse"];
+                };
+            };
+        };
+    };
+    stop_ollama_api_ollama_stop_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OllamaStatusResponse"];
+                };
+            };
+        };
+    };
+    get_models_api_ollama_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OllamaModelsResponse"];
+                };
+            };
+        };
+    };
+    get_settings_api_ollama_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+    };
+    update_settings_api_ollama_settings_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OllamaSettingsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -1605,6 +1605,30 @@ export interface components {
          * @description Lightweight response for collection browse/table view.
          */
         TrackBrowseResponse: {
+            /** Title */
+            title?: string | null;
+            /** Artist */
+            artist?: string | string[] | null;
+            /** Genre */
+            genre?: string | null;
+            /** Bpm */
+            bpm?: number | null;
+            /** Key */
+            key?: string | null;
+            /** Original Artist */
+            original_artist?: string | string[] | null;
+            /** Remixer */
+            remixer?: string | string[] | null;
+            /** Mix Name */
+            mix_name?: string | null;
+            /** Release Date */
+            release_date?: string | null;
+            /** Release Year */
+            release_year?: number | null;
+            /** User Comment */
+            user_comment?: string | null;
+            /** Starlib Meta */
+            starlib_meta?: string | null;
             /** File Path */
             file_path: string;
             /** File Name */
@@ -1624,6 +1648,12 @@ export interface components {
             duration?: number | null;
             /** Mtime */
             mtime?: number | null;
+        };
+        /**
+         * TrackInfoResponse
+         * @description Response containing track metadata. Tag fields are flat per the registry.
+         */
+        TrackInfoResponse: {
             /** Title */
             title?: string | null;
             /** Artist */
@@ -1648,12 +1678,6 @@ export interface components {
             user_comment?: string | null;
             /** Starlib Meta */
             starlib_meta?: string | null;
-        };
-        /**
-         * TrackInfoResponse
-         * @description Response containing track metadata. Tag fields are flat per the registry.
-         */
-        TrackInfoResponse: {
             /** File Path */
             file_path: string;
             /** File Name */
@@ -1672,30 +1696,6 @@ export interface components {
              * @default []
              */
             issues: string[];
-            /** Title */
-            title?: string | null;
-            /** Artist */
-            artist?: string | string[] | null;
-            /** Genre */
-            genre?: string | null;
-            /** Bpm */
-            bpm?: number | null;
-            /** Key */
-            key?: string | null;
-            /** Original Artist */
-            original_artist?: string | string[] | null;
-            /** Remixer */
-            remixer?: string | string[] | null;
-            /** Mix Name */
-            mix_name?: string | null;
-            /** Release Date */
-            release_date?: string | null;
-            /** Release Year */
-            release_year?: number | null;
-            /** User Comment */
-            user_comment?: string | null;
-            /** Starlib Meta */
-            starlib_meta?: string | null;
         };
         /**
          * TrackInfoUpdateRequest

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,11 +53,7 @@ export async function fetchApi<T>(
 
 export type TrackInfo = components['schemas']['TrackInfoResponse'];
 
-export type TrackBrowse = components['schemas']['TrackBrowseResponse'] & {
-  remixers?: string[] | null;
-  soundcloud_id?: number | null;
-  mtime?: number | null;
-};
+export type TrackBrowse = components['schemas']['TrackBrowseResponse'];
 
 export type BrowsePage = components['schemas']['Page_TrackBrowseResponse_'] & {
   cacheLoading?: boolean;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ extend-select = [
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Query", "fastapi.Depends", "Query", "Depends"]
 
+[tool.ruff.lint.per-file-ignores]
+# CLI scripts intentionally print to stdout/stderr.
+"scripts/*" = ["T201"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = ["integration: requires a running Ollama server"]

--- a/scripts/generate_sample_tracks.py
+++ b/scripts/generate_sample_tracks.py
@@ -1,0 +1,281 @@
+"""Generate sample audio files with realistic ID3 metadata for dev / demo.
+
+Synthesises silent audio via ffmpeg, then writes title/artist/genre/key/bpm/
+release_date/artwork tags through ``TrackHandler`` so the resulting files
+exercise the same code path the prepare → collection workflow uses.
+
+The defaults are deliberately *messy*: they cycle through six realism profiles
+(complete, no-genre, no-artwork, no-release, filename-only, title-plus-artist
+only) so the editor's "not ready" badge, the SoundCloud auto-fill path, and
+the filename-parsing heuristics all get exercised.  Artist/title pairs are
+pulled from a list of real electronic tracks that reliably return hits on
+SoundCloud search.
+
+Usage:
+    uv run python scripts/generate_sample_tracks.py ~/Music/tracks/prepare
+    uv run python scripts/generate_sample_tracks.py ~/Music/tracks/prepare --count 30 --format aiff --remix
+    uv run python scripts/generate_sample_tracks.py ~/Music/tracks/prepare --all-complete
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import struct
+import subprocess
+import sys
+import zlib
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+from soundcloud_tools.handler.track import StarlibMeta, TrackHandler, TrackInfo
+
+logger = logging.getLogger(__name__)
+
+# Real artist/title pairs — pulled from well-known electronic releases that
+# reliably surface SoundCloud results when searched, so the single-editor's
+# "Search SoundCloud" flow actually finds matches.
+_REAL_TRACKS: tuple[tuple[str, str], ...] = (
+    ("Daft Punk", "Around the World"),
+    ("deadmau5", "Strobe"),
+    ("Aphex Twin", "Windowlicker"),
+    ("Four Tet", "Angel Echoes"),
+    ("Burial", "Archangel"),
+    ("Bonobo", "Cirrus"),
+    ("Fred again..", "Delilah"),
+    ("Jamie xx", "Gosh"),
+    ("Caribou", "Odessa"),
+    ("Floating Points", "Silhouettes"),
+    ("Moderat", "A New Error"),
+    ("Jon Hopkins", "Open Eye Signal"),
+    ("Nicolas Jaar", "Mi Mujer"),
+    ("Tale Of Us", "Nova Lume"),
+    ("Maceo Plex", "Conjure Superstar"),
+    ("Dixon", "Trichome"),
+    ("DJ Koze", "Pick Up"),
+    ("Âme", "Rej"),
+    ("Recondite", "Riant"),
+    ("Stephan Bodzin", "Powers of Ten"),
+)
+
+_GENRES = ("Deep House", "Techno", "Drum & Bass", "Garage", "Ambient", "Trance", "Melodic House")
+_KEYS = ("8A", "5A", "11A", "4B", "7B", "12B", "1A", "9B")
+_REMIXERS = ("Nyx", "Helix", "Vox", "Pell", "Stratus")
+_MIX_TYPES = ("Remix", "VIP Mix", "Extended Mix", "Club Mix", "Dub Mix")
+
+
+# ---------------------------------------------------------------------------
+# Realism profiles
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Profile:
+    """Describes which fields a sample should intentionally leave blank."""
+
+    name: str
+    has_title: bool = True
+    has_artist: bool = True
+    has_genre: bool = True
+    has_key: bool = True
+    has_bpm: bool = True
+    has_release_date: bool = True
+    has_artwork: bool = True
+    # ``filename_from_tags`` = write an "artist - title.mp3" style filename
+    # (what Starlib produces after save). When False the filename mimics a
+    # messy download (underscores, "free dl" suffix, etc.).
+    filename_from_tags: bool = True
+
+
+_PROFILES: tuple[Profile, ...] = (
+    Profile("complete"),  # fully tagged — the happy path
+    Profile("missing_genre", has_genre=False, has_key=False, has_bpm=False),
+    Profile("missing_artwork", has_artwork=False),
+    Profile("missing_release_date", has_release_date=False),
+    # Only the filename carries hints — like a freshly scraped SC download.
+    Profile(
+        "filename_only",
+        has_title=False,
+        has_artist=False,
+        has_genre=False,
+        has_key=False,
+        has_bpm=False,
+        has_release_date=False,
+        has_artwork=False,
+        filename_from_tags=False,
+    ),
+    # Title + artist but everything else blank — common for DJ edits.
+    Profile(
+        "title_plus_artist",
+        has_genre=False,
+        has_key=False,
+        has_bpm=False,
+        has_release_date=False,
+        has_artwork=False,
+        filename_from_tags=False,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Audio + artwork helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_silent_audio(path: Path, fmt: str, ffmpeg: str, seconds: float = 1.0) -> None:
+    """Write *seconds* of silent audio at *path* using *ffmpeg*."""
+    codec = {"mp3": ("libmp3lame", "-b:a", "192k"), "aiff": ("pcm_s16be",), "wav": ("pcm_s16le",)}[fmt]
+    cmd = [
+        ffmpeg,
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=r=44100:cl=stereo",
+        "-t",
+        str(seconds),
+        "-c:a",
+        *codec,
+        str(path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _tiny_png(rgb: tuple[int, int, int]) -> bytes:
+    """Build a 4x4 solid-colour PNG so each track gets distinct embedded artwork."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return len(data).to_bytes(4, "big") + tag + data + zlib.crc32(tag + data).to_bytes(4, "big")
+
+    width = height = 4
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)  # 8-bit RGB
+    raw = b""
+    for _ in range(height):
+        raw += b"\x00" + bytes(rgb) * width  # filter byte 0 + scanline
+    idat = zlib.compress(raw, 9)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+# ---------------------------------------------------------------------------
+# Track construction
+# ---------------------------------------------------------------------------
+
+
+_FILENAME_STYLES = ("underscore", "freedl", "numbered", "plain", "noisy_brackets")
+
+
+def _messy_filename(i: int, artist: str, title: str) -> str:
+    """Produce a scraped-download-style filename that doesn't match tags perfectly."""
+    style = _FILENAME_STYLES[i % len(_FILENAME_STYLES)]
+    base = f"{artist} - {title}"
+    if style == "underscore":
+        return base.replace(" ", "_")
+    if style == "freedl":
+        return f"{base} (Free DL)"
+    if style == "numbered":
+        return f"{i + 1:02d}. {base}"
+    if style == "noisy_brackets":
+        return f"{base} [{_GENRES[i % len(_GENRES)]}]"
+    return base  # plain
+
+
+def _build_info(i: int, profile: Profile, *, with_remix: bool) -> TrackInfo:
+    artist, title = _REAL_TRACKS[i % len(_REAL_TRACKS)]
+    release = date(2024, 1, 1) + timedelta(days=i * 13)
+    bpm = 110 + (i * 7) % 60  # 110..169
+    genre = _GENRES[i % len(_GENRES)]
+    key = _KEYS[i % len(_KEYS)]
+
+    info = TrackInfo(
+        title=title if profile.has_title else None,
+        artist=artist if profile.has_artist else None,
+        genre=genre if profile.has_genre else None,
+        bpm=bpm if profile.has_bpm else None,
+        key=key if profile.has_key else None,
+        release_date=release if profile.has_release_date else None,
+        release_year=release.year if profile.has_release_date else None,
+        user_comment=f"Generated sample #{i + 1} [{profile.name}]",
+        starlib_meta=StarlibMeta(version="dev-sample"),
+    )
+    if with_remix and i % 3 == 0 and profile.has_title:
+        alt_artist = _REAL_TRACKS[(i + 1) % len(_REAL_TRACKS)][0]
+        info.original_artist = alt_artist
+        info.remixer = _REMIXERS[i % len(_REMIXERS)]
+        info.mix_name = _MIX_TYPES[i % len(_MIX_TYPES)]
+    if profile.has_artwork:
+        rgb = ((i * 53) % 256, (i * 91) % 256, (i * 137) % 256)
+        info.artwork = _tiny_png(rgb)
+    return info
+
+
+def _filename_stem(i: int, profile: Profile, info: TrackInfo, prefix: str) -> str:
+    """Pick the on-disk filename for this sample.
+
+    ``filename_from_tags=True`` produces the clean ``artist - title`` form so
+    the file is "ready" as-is; False produces a messy download-style name so
+    the editor's filename parser and SC search have something to chew on.
+    """
+    artist, title = _REAL_TRACKS[i % len(_REAL_TRACKS)]
+    if profile.filename_from_tags and info.title and info.artist_str:
+        body = f"{info.artist_str} - {info.title}"
+    else:
+        body = _messy_filename(i, artist, title)
+    return f"{prefix}-{i + 1:03d}-{body}".replace("/", "-")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("folder", type=Path, help="Target folder; created if it doesn't exist")
+    parser.add_argument("--count", type=int, default=10, help="Number of files to generate (default: 10)")
+    parser.add_argument(
+        "--format",
+        choices=("mp3", "aiff", "wav"),
+        default="mp3",
+        help="Audio container/codec (default: mp3)",
+    )
+    parser.add_argument("--seconds", type=float, default=1.0, help="Audio length in seconds (default: 1.0)")
+    parser.add_argument("--remix", action="store_true", help="Tag every 3rd track as a remix")
+    parser.add_argument(
+        "--all-complete",
+        action="store_true",
+        help="Skip the messy profiles and tag every track fully (demo-ready state)",
+    )
+    parser.add_argument("--prefix", default="sample", help="Filename prefix (default: 'sample')")
+    args = parser.parse_args()
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        print("ffmpeg not found on PATH", file=sys.stderr)
+        return 2
+
+    args.folder.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    profiles = (_PROFILES[0],) if args.all_complete else _PROFILES
+
+    written: list[Path] = []
+    for i in range(args.count):
+        profile = profiles[i % len(profiles)]
+        info = _build_info(i, profile, with_remix=args.remix)
+        stem = _filename_stem(i, profile, info, args.prefix)
+        path = args.folder / f"{stem}.{args.format}"
+        _make_silent_audio(path, args.format, ffmpeg, seconds=args.seconds)
+        TrackHandler(root_folder=args.folder, file=path).add_info(info, artwork=info.artwork)
+        written.append(path)
+        print(f"  + [{profile.name:>18}] {path.name}")
+
+    print(f"\nGenerated {len(written)} files in {args.folder}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_starlib_meta.py
+++ b/scripts/migrate_starlib_meta.py
@@ -63,8 +63,9 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     counts = migrate_folder(args.folder, dry_run=args.dry_run)
     print(
-        "migrated={migrated} skipped={skipped} failed={failed} "
-        "recovered_user_comment={recovered_user_comment}".format(**counts)
+        "migrated={migrated} skipped={skipped} failed={failed} recovered_user_comment={recovered_user_comment}".format(
+            **counts
+        )
     )
     return 1 if counts["failed"] else 0
 

--- a/scripts/migrate_starlib_meta.py
+++ b/scripts/migrate_starlib_meta.py
@@ -1,0 +1,73 @@
+"""One-shot migration of starlib metadata from COMM::XXX to TXXX:starlib.
+
+Reads every audio file under ``folder``; the read path detects legacy data in
+COMM::XXX and surfaces it on ``TrackInfo`` (either as ``starlib_meta`` if the
+blob parses as ``key=value`` pairs, or as ``user_comment`` otherwise).  Writing
+back evicts COMM::XXX and persists the data in its proper slot
+(``TXXX:starlib`` for app data, ``COMM::eng`` for the user's comment).
+
+Idempotent: files already on the new layout are skipped.
+
+Usage:
+    uv run python scripts/migrate_starlib_meta.py <folder> [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from soundcloud_tools.handler.track import TrackHandler
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_folder(folder: Path, *, dry_run: bool = False) -> dict[str, int]:
+    handlers = TrackHandler.load_all(folder)
+    counts = {"migrated": 0, "skipped": 0, "failed": 0, "recovered_user_comment": 0}
+    for h in handlers:
+        try:
+            tags = h.track.tags
+            has_new = tags.get("TXXX:starlib") is not None
+            legacy = tags.get("COMM::XXX")
+            if has_new and not legacy:
+                counts["skipped"] += 1
+                continue
+            info = h.track_info
+            recovered = bool(info.user_comment and not has_new)
+            if dry_run:
+                print(f"[dry-run] would migrate: {h.file}")
+            else:
+                h.add_info(info, artwork=h.get_single_cover(raise_error=False))
+            if recovered:
+                counts["recovered_user_comment"] += 1
+            counts["migrated"] += 1
+        except Exception as e:
+            counts["failed"] += 1
+            print(f"FAILED {h.file}: {e}", file=sys.stderr)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("folder", type=Path, help="Folder to scan recursively")
+    parser.add_argument("--dry-run", action="store_true", help="Don't write anything")
+    args = parser.parse_args()
+
+    if not args.folder.is_dir():
+        print(f"Not a directory: {args.folder}", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    counts = migrate_folder(args.folder, dry_run=args.dry_run)
+    print(
+        "migrated={migrated} skipped={skipped} failed={failed} "
+        "recovered_user_comment={recovered_user_comment}".format(**counts)
+    )
+    return 1 if counts["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/soundcloud_tools/handler/track.py
+++ b/soundcloud_tools/handler/track.py
@@ -3,7 +3,8 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Self
@@ -12,7 +13,7 @@ import mutagen
 import requests
 from mutagen.aiff import AIFF
 from mutagen.easyid3 import EasyID3
-from mutagen.id3 import APIC, COMM, ID3, TCON, TDRC, TDRL, TIT2, TIT3, TOPE, TPE1, TPE4
+from mutagen.id3 import APIC, COMM, ID3, TBPM, TCON, TDRC, TDRL, TIT2, TIT3, TKEY, TOPE, TPE1, TPE4, TXXX
 from mutagen.mp3 import MP3
 from mutagen.wave import WAVE
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -52,7 +53,14 @@ FILETYPE_MAP = {
 }
 
 
-class Comment(BaseModel):
+class StarlibMeta(BaseModel):
+    """App-managed origin/sync metadata stored in ``TXXX:starlib``.
+
+    Was previously called ``Comment`` and stored in ``COMM::XXX`` — that slot
+    is the standard user-comment slot, so writing app data there clobbered the
+    user's plain-text comment in every other player.
+    """
+
     version: str | None = None
     soundcloud_id: int | None = None
     soundcloud_permalink: str | None = None
@@ -69,12 +77,15 @@ class Comment(BaseModel):
     def from_str(cls, string: str) -> Self:
         if not string:
             return cls()
-        pairs = [pair.split("=", 1) for pair in re.split(r"(?<!\\);\s*", string)]
+        pairs = [pair.split("=", 1) for pair in re.split(r"(?<!\\);\s*", string) if pair.strip()]
         try:
-            data = {k: cls.unescape_value(str(v)) for k, v in pairs}
+            data = {k.strip(): cls.unescape_value(str(v)) for k, v in pairs if k.strip()}
         except ValueError as e:
-            logger.error(f"Error parsing comment: {string}, {e}")
+            logger.error(f"Error parsing starlib meta: {string}, {e}")
             data = {}
+        # Drop unknown keys so legacy/foreign blobs don't blow up validation.
+        known = set(cls.model_fields)
+        data = {k: v for k, v in data.items() if k in known}
         return cls(**data)
 
     @classmethod
@@ -88,19 +99,9 @@ class Comment(BaseModel):
     def to_str(self) -> str:
         return "; \n".join(f"{k}={self.escape_value(str(v))}" for k, v in self.model_dump().items() if v is not None)
 
-
-class Remix(BaseModel):
-    original_artist: str | list[str]
-    remixer: str | list[str]
-    mix_name: str | None
-
     @property
-    def original_artist_str(self) -> str:
-        return TrackInfo._join_artists(self.original_artist)
-
-    @property
-    def remixer_str(self) -> str:
-        return TrackInfo._join_artists(self.remixer)
+    def is_empty(self) -> bool:
+        return not (self.version or self.soundcloud_id or self.soundcloud_permalink)
 
 
 def unescape_list_value(value: str):
@@ -119,21 +120,96 @@ def deserialize_list(values: str) -> list[str]:
     return [unescape_list_value(artist) for artist in values.split(", ")]
 
 
+@dataclass(frozen=True)
+class TagField:
+    """Single source of truth for one ID3 tag <-> TrackInfo field mapping."""
+
+    name: str
+    frame: type
+    frame_id: str
+    is_list: bool = False
+    label: str = ""
+    sortable: bool = True
+    searchable: bool = False
+    to_str: Callable[[Any], str] | None = None
+    from_str: Callable[[str], Any] | None = None
+    frame_kwargs: dict = field(default_factory=dict)
+    tag_key: str | None = None
+
+    @property
+    def key(self) -> str:
+        return self.tag_key or self.frame_id
+
+
+def _bpm_from_str(s: str) -> int | None:
+    return convert_to_int(s) or None
+
+
+def _date_to_str(d: date) -> str:
+    return d.strftime("%Y-%m-%d")
+
+
+def _year_to_str(y: int) -> str:
+    return str(y)
+
+
+def _starlib_to_str(m: "StarlibMeta") -> str:
+    return m.to_str()
+
+
+SIMPLE_TAG_FIELDS: tuple[TagField, ...] = (
+    TagField("title", TIT2, "TIT2", label="Title", searchable=True),
+    TagField("artist", TPE1, "TPE1", is_list=True, label="Artist", searchable=True),
+    TagField("genre", TCON, "TCON", label="Genre", searchable=True),
+    TagField("bpm", TBPM, "TBPM", label="BPM", to_str=str, from_str=_bpm_from_str),
+    TagField("key", TKEY, "TKEY", label="Key"),
+    TagField("original_artist", TOPE, "TOPE", is_list=True, label="Original Artist", searchable=True),
+    TagField("remixer", TPE4, "TPE4", is_list=True, label="Remixer", searchable=True),
+    TagField("mix_name", TIT3, "TIT3", label="Mix"),
+    TagField("release_date", TDRL, "TDRL", label="Release Date", to_str=_date_to_str, from_str=parse_date),
+    TagField("release_year", TDRC, "TDRC", label="Release Year", to_str=_year_to_str, from_str=_bpm_from_str),
+    TagField(
+        "user_comment",
+        COMM,
+        "COMM",
+        label="Comment",
+        tag_key="COMM::eng",
+        frame_kwargs={"desc": "", "lang": "eng"},
+    ),
+    TagField(
+        "starlib_meta",
+        TXXX,
+        "TXXX",
+        label="Starlib Meta",
+        tag_key="TXXX:starlib",
+        frame_kwargs={"desc": "starlib"},
+        to_str=_starlib_to_str,
+        from_str=StarlibMeta.from_str,
+        sortable=False,
+    ),
+)
+SIMPLE_TAG_FIELDS_BY_NAME: dict[str, TagField] = {f.name: f for f in SIMPLE_TAG_FIELDS}
+
+
 class TrackInfo(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
-    title: str
-    artist: str | list[str]
-    genre: str
-    release_date: date | None = None
-    artwork: bytes | None = None
-    artwork_url: str | None = None
-
-    remix: Remix | None = None
-    comment: Comment | None = None
-
+    # All ID3 tags are optional on disk — none of the flat fields are required.
+    title: str | None = None
+    artist: str | list[str] | None = None
+    genre: str | None = None
     bpm: int | None = None
     key: str | None = None
+    original_artist: str | list[str] | None = None
+    remixer: str | list[str] | None = None
+    mix_name: str | None = None
+    release_date: date | None = None
+    release_year: int | None = None
+    user_comment: str | None = None
+    starlib_meta: StarlibMeta | None = None
+
+    artwork: bytes | None = None
+    artwork_url: str | None = None
     length: float | None = None
 
     artist_options: set[str] = Field(default_factory=set)
@@ -147,12 +223,18 @@ class TrackInfo(BaseModel):
         return self
 
     @staticmethod
-    def _join_artists(artists: str | list[str]) -> str:
+    def _join_artists(artists: str | list[str] | None) -> str:
+        if artists is None:
+            return ""
         return serialize_list(artists) if isinstance(artists, list) else artists
 
     @property
     def filename(self) -> str:
-        return self.title if self.artist_str in self.title else f"{self.artist_str} - {self.title}"
+        title = self.title or ""
+        artist_str = self.artist_str
+        if not artist_str:
+            return title
+        return title if artist_str in title else f"{artist_str} - {title}"
 
     @property
     def complete(self) -> bool:
@@ -161,6 +243,14 @@ class TrackInfo(BaseModel):
     @property
     def artist_str(self) -> str:
         return self._join_artists(self.artist)
+
+    @property
+    def original_artist_str(self) -> str:
+        return self._join_artists(self.original_artist)
+
+    @property
+    def remixer_str(self) -> str:
+        return self._join_artists(self.remixer)
 
     @staticmethod
     def _get_artist_sorter(title: str, type: Literal["artist", "original_artist", "remixer"]) -> Callable[[str], int]:
@@ -211,19 +301,19 @@ class TrackInfo(BaseModel):
 
         mix_name = get_mix_name(track.title)
 
+        release_date = track.display_date.date()
         return cls(
             title=track.title,
             artist=next(iter(most_likely_artists), ""),
             genre=track.genre or "",
-            release_date=track.display_date.date(),
+            release_date=release_date,
+            release_year=release_date.year,
             artwork_url=track.hq_artwork_url or track.user.hq_avatar_url,
             artist_options=artist_options,
-            remix=Remix(
-                original_artist=next(iter(most_likely_original_artists), ""),
-                remixer=next(iter(most_likely_remixers), ""),
-                mix_name=mix_name,
-            ),
-            comment=Comment.from_sc_track(track),
+            original_artist=next(iter(most_likely_original_artists), ""),
+            remixer=next(iter(most_likely_remixers), ""),
+            mix_name=mix_name,
+            starlib_meta=StarlibMeta.from_sc_track(track),
         )
 
 
@@ -294,28 +384,44 @@ class TrackHandler(BaseModel):
         value = TrackHandler._get_tag_value(track, tag, default=default)
         return value.split("\u0000") if "\u0000" in value else deserialize_list(value)
 
+    def _read_simple(self, track) -> dict[str, Any]:
+        """Read every registry-driven tag off *track* into a TrackInfo-ready dict."""
+        out: dict[str, Any] = {}
+        for f in SIMPLE_TAG_FIELDS:
+            if f.is_list:
+                values = self._get_tag_list_value(track, f.key)
+                cleaned = [v for v in values if v]
+                out[f.name] = cleaned or None
+            else:
+                raw = self._get_tag_value(track, f.key)
+                if not raw:
+                    out[f.name] = None
+                    continue
+                out[f.name] = f.from_str(raw) if f.from_str else raw
+
+        # Legacy fallback: starlib data used to live in COMM::XXX.
+        # If TXXX:starlib is empty, try the old slot. If it parses to something
+        # meaningful, treat it as starlib data; otherwise route it to user_comment.
+        if not out.get("starlib_meta"):
+            legacy = self._get_tag_value(track, "COMM::XXX")
+            if legacy:
+                try:
+                    parsed = StarlibMeta.from_str(legacy)
+                except Exception:
+                    parsed = StarlibMeta()
+                if not parsed.is_empty:
+                    out["starlib_meta"] = parsed
+                elif not out.get("user_comment"):
+                    out["user_comment"] = legacy
+        return out
+
     @property
     def track_info(self):
         track = self.track
-        remix_data = {
-            "original_artist": self._get_tag_list_value(track, "TOPE"),
-            "remixer": self._get_tag_list_value(track, "TPE4"),
-            "mix_name": self._get_tag_value(track, "TIT3"),
-        }
-        if not any(any(item != "" for item in v) if isinstance(v, list) else v for v in remix_data.values()):
-            remix = None
-        else:
-            remix = Remix(**remix_data)
+        data = self._read_simple(track)
         return TrackInfo(
-            title=self._get_tag_value(track, "TIT2"),
-            artist=self._get_tag_list_value(track, "TPE1"),
-            genre=self._get_tag_value(track, "TCON"),
-            release_date=parse_date(self._get_tag_value(track, "TDRL")),
+            **data,
             artwork=self.get_single_cover(raise_error=False),
-            remix=remix,
-            comment=Comment.from_str(self._get_tag_value(track, "COMM::XXX")),
-            bpm=convert_to_int(self._get_tag_value(track, "TBPM")) or None,
-            key=self._get_tag_value(track, "TKEY"),
             length=track.info.length if hasattr(track, "info") else None,
         )
 
@@ -435,40 +541,49 @@ class TrackHandler(BaseModel):
         track.tags.add(TCON(encoding=3, text=genre))
         track.save()
 
-    def remove_remix(self):
+    def clear_tags(self, field_names: Iterable[str]) -> None:
+        """Delete the given registry fields from the track and save."""
         track = self.track
-        track.tags.delall("TOPE")
-        track.tags.delall("TPE4")
-        track.tags.delall("TIT3")
+        for name in field_names:
+            field_def = SIMPLE_TAG_FIELDS_BY_NAME.get(name)
+            if field_def is None:
+                raise KeyError(f"Unknown tag field: {name}")
+            track.tags.delall(field_def.key)
         track.save()
 
+    def _write_simple(self, track, info: TrackInfo) -> None:
+        """Write every registry-driven tag from *info* onto *track*."""
+        for f in SIMPLE_TAG_FIELDS:
+            value = getattr(info, f.name)
+            if f.is_list:
+                text = TrackInfo._join_artists(value) if value else ""
+            elif value in (None, ""):
+                text = ""
+            else:
+                text = f.to_str(value) if f.to_str else str(value)
+
+            track.delall(f.key)
+            if not text:
+                continue
+            track.add(f.frame(encoding=3, text=text, **f.frame_kwargs))
+
+        # One-shot migration: evict legacy COMM::XXX so it doesn't shadow our
+        # new TXXX:starlib payload or the user's COMM::eng comment.
+        track.delall("COMM::XXX")
+
     def _add_info(self, track, info: TrackInfo, artwork: bytes | None = None):
-        track.add(TIT2(encoding=3, text=info.title))
-        track.add(TPE1(encoding=3, text=info.artist_str))
-        track.add(TCON(encoding=3, text=info.genre))
-        track.add(TDRC(encoding=3, text=str(info.release_date.year) if info.release_date else ""))
-        track.add(TDRL(encoding=3, text=info.release_date.strftime("%Y-%m-%d") if info.release_date else ""))
+        self._write_simple(track, info)
         if artwork:
             track.delall("APIC")
             track.add(
                 APIC(
                     encoding=3,
-                    mime="image/jpeg",
+                    mime="image/png",
                     type=3,
                     desc="Cover",
                     data=artwork,
                 )
             )
-        if info.remix:
-            if info.remix.original_artist_str:
-                track.add(TOPE(encoding=3, text=info.remix.original_artist_str))
-            if info.remix.remixer_str:
-                track.add(TPE4(encoding=3, text=info.remix.remixer_str))
-            if info.remix.mix_name:
-                track.add(TIT3(encoding=3, text=info.remix.mix_name))
-        if info.comment:
-            track.delall("COMM")
-            track.add(COMM(encoding=3, text=info.comment.to_str()))
 
     def add_info(self, info: TrackInfo, artwork: bytes | None = None):
         track = self.track

--- a/tests/test_folder_config.py
+++ b/tests/test_folder_config.py
@@ -1,0 +1,74 @@
+"""Tests for the folder-config heal path in settings.load()."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from backend.core.services import folder_config
+
+
+def _patch_paths(tmp_path: Path):
+    config_dir = tmp_path / "starlib"
+    config_dir.mkdir()
+    return patch.multiple(
+        "backend.core.services.settings",
+        _CONFIG_DIR=config_dir,
+        _SETTINGS_FILE=config_dir / "settings.json",
+    )
+
+
+def test_first_run_seeds_default_folders(tmp_path: Path) -> None:
+    with _patch_paths(tmp_path):
+        loaded = folder_config.load_folders()
+
+    names = [f.name for f in loaded.folders]
+    assert names == ["prepare", "cleaned", "collection"]
+    assert next(f for f in loaded.folders if f.name == "prepare").ruleset_id == "classic"
+
+
+def test_empty_folders_are_reseeded_on_load(tmp_path: Path) -> None:
+    """A half-initialised settings.json with folders:[] gets the defaults back."""
+    config_dir = tmp_path / "starlib"
+    config_dir.mkdir()
+    settings_file = config_dir / "settings.json"
+    settings_file.write_text(
+        '{"app":{"root_music_folder":"/tmp/music"},'
+        '"rulesets":{"items":[],"active_ruleset_id":"classic"},'
+        '"folders":{"folders":[]}}'
+    )
+
+    with patch.multiple(
+        "backend.core.services.settings",
+        _CONFIG_DIR=config_dir,
+        _SETTINGS_FILE=settings_file,
+    ):
+        loaded = folder_config.load_folders()
+
+    assert [f.name for f in loaded.folders] == ["prepare", "cleaned", "collection"]
+
+    # The heal is in-memory only — disk state is untouched so a user who
+    # genuinely wants zero folders can still delete + save.
+    on_disk = settings_file.read_text()
+    assert '"folders":[]' in on_disk.replace(" ", "")
+
+
+def test_non_empty_folders_are_preserved(tmp_path: Path) -> None:
+    """User-configured folder list must not be overwritten by the heal."""
+    config_dir = tmp_path / "starlib"
+    config_dir.mkdir()
+    settings_file = config_dir / "settings.json"
+    settings_file.write_text(
+        '{"app":{"root_music_folder":"/tmp/music"},'
+        '"rulesets":{"items":[],"active_ruleset_id":"classic"},'
+        '"folders":{"folders":['
+        '{"name":"inbox","label":"Inbox","visible":true,"order":0,"ruleset_id":null}'
+        "]}}"
+    )
+
+    with patch.multiple(
+        "backend.core.services.settings",
+        _CONFIG_DIR=config_dir,
+        _SETTINGS_FILE=settings_file,
+    ):
+        loaded = folder_config.load_folders()
+
+    assert [f.name for f in loaded.folders] == ["inbox"]

--- a/tests/test_track_handler.py
+++ b/tests/test_track_handler.py
@@ -25,11 +25,28 @@ def _make_silent_mp3(path: Path) -> None:
     import shutil
     import subprocess
 
-    ffmpeg = shutil.which("ffmpeg") or "/opt/homebrew/bin/ffmpeg"
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        pytest.skip("ffmpeg not available")
+    assert ffmpeg is not None  # narrow for mypy after pytest.skip
     subprocess.run(
-        [ffmpeg, "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono", "-t", "0.2",
-         "-c:a", "libmp3lame", "-b:a", "64k", "-y", str(path)],
-        check=True, capture_output=True,
+        [
+            ffmpeg,
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=mono",
+            "-t",
+            "0.2",
+            "-c:a",
+            "libmp3lame",
+            "-b:a",
+            "64k",
+            "-y",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
     )
 
 
@@ -90,9 +107,7 @@ def test_round_trip_empty_optional_fields(handler: TrackHandler) -> None:
 
 def test_clearing_remix_fields_via_none(handler: TrackHandler) -> None:
     """Setting remix-style fields to None deletes the underlying ID3 frames."""
-    handler.add_info(
-        TrackInfo(title="X", original_artist="A", remixer="B", mix_name="VIP")
-    )
+    handler.add_info(TrackInfo(title="X", original_artist="A", remixer="B", mix_name="VIP"))
     cleared = TrackInfo(title="X")
     handler.add_info(cleared)
     read = handler.track_info
@@ -202,6 +217,5 @@ def test_schemas_include_every_registry_field() -> None:
     expected = {f.name for f in SIMPLE_TAG_FIELDS}
     for schema in (TrackInfoUpdateRequest, TrackInfoResponse, TrackBrowseResponse):
         assert expected <= set(schema.model_fields), (
-            f"{schema.__name__} is missing registry fields: "
-            f"{expected - set(schema.model_fields)}"
+            f"{schema.__name__} is missing registry fields: {expected - set(schema.model_fields)}"
         )

--- a/tests/test_track_handler.py
+++ b/tests/test_track_handler.py
@@ -1,0 +1,207 @@
+"""Round-trip tests for the registry-driven TrackHandler I/O.
+
+These cover the contract that adding/reading any registry-driven tag goes
+through ``_write_simple`` / ``_read_simple`` uniformly, plus the StarlibMeta
+migration glue (legacy ``COMM::XXX`` -> ``TXXX:starlib`` / ``COMM::eng``).
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from mutagen.id3 import COMM, ID3, TIT2
+
+from soundcloud_tools.handler.track import (
+    SIMPLE_TAG_FIELDS,
+    SIMPLE_TAG_FIELDS_BY_NAME,
+    StarlibMeta,
+    TrackHandler,
+    TrackInfo,
+)
+
+
+def _make_silent_mp3(path: Path) -> None:
+    """Generate a minimal valid MP3 via ffmpeg (0.2s silence)."""
+    import shutil
+    import subprocess
+
+    ffmpeg = shutil.which("ffmpeg") or "/opt/homebrew/bin/ffmpeg"
+    subprocess.run(
+        [ffmpeg, "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono", "-t", "0.2",
+         "-c:a", "libmp3lame", "-b:a", "64k", "-y", str(path)],
+        check=True, capture_output=True,
+    )
+
+
+@pytest.fixture
+def mp3_file(tmp_path: Path) -> Path:
+    p = tmp_path / "track.mp3"
+    _make_silent_mp3(p)
+    return p
+
+
+@pytest.fixture
+def handler(tmp_path: Path, mp3_file: Path) -> TrackHandler:
+    return TrackHandler(root_folder=tmp_path, file=mp3_file)
+
+
+def test_registry_round_trip_full(handler: TrackHandler) -> None:
+    """Every flat field round-trips through ID3 with the right type."""
+    info = TrackInfo(
+        title="My Song",
+        artist=["Alice", "Bob"],
+        genre="House",
+        bpm=128,
+        key="8A",
+        original_artist="Carol",
+        remixer=["Dave", "Eve"],
+        mix_name="VIP Mix",
+        release_date=date(2024, 5, 1),
+        release_year=2024,
+        user_comment="A user-visible note",
+        starlib_meta=StarlibMeta(version="1.0", soundcloud_id=123, soundcloud_permalink="https://example/x"),
+    )
+    handler.add_info(info)
+
+    read = handler.track_info
+    assert read.title == "My Song"
+    assert read.artist == ["Alice", "Bob"]
+    assert read.genre == "House"
+    assert read.bpm == 128
+    assert read.key == "8A"
+    assert read.original_artist == ["Carol"]
+    assert read.remixer == ["Dave", "Eve"]
+    assert read.mix_name == "VIP Mix"
+    assert read.release_date == date(2024, 5, 1)
+    assert read.release_year == 2024
+    assert read.user_comment == "A user-visible note"
+    assert read.starlib_meta is not None
+    assert read.starlib_meta.soundcloud_id == 123
+    assert read.starlib_meta.version == "1.0"
+
+
+def test_round_trip_empty_optional_fields(handler: TrackHandler) -> None:
+    """All-optional TrackInfo writes cleanly and reads back as None."""
+    handler.add_info(TrackInfo())
+    read = handler.track_info
+    for f in SIMPLE_TAG_FIELDS:
+        assert getattr(read, f.name) in (None, []), f"{f.name} should be empty"
+
+
+def test_clearing_remix_fields_via_none(handler: TrackHandler) -> None:
+    """Setting remix-style fields to None deletes the underlying ID3 frames."""
+    handler.add_info(
+        TrackInfo(title="X", original_artist="A", remixer="B", mix_name="VIP")
+    )
+    cleared = TrackInfo(title="X")
+    handler.add_info(cleared)
+    read = handler.track_info
+    assert read.original_artist is None
+    assert read.remixer is None
+    assert read.mix_name is None
+
+
+def test_clear_tags_helper(handler: TrackHandler) -> None:
+    handler.add_info(TrackInfo(title="X", remixer="R", original_artist="O"))
+    handler.clear_tags(["remixer", "original_artist"])
+    read = handler.track_info
+    assert read.remixer is None
+    assert read.original_artist is None
+    assert read.title == "X"
+
+
+def test_clear_tags_unknown_field(handler: TrackHandler) -> None:
+    with pytest.raises(KeyError):
+        handler.clear_tags(["not_a_real_field"])
+
+
+def test_starlib_meta_legacy_comm_xxx_migrates_to_user_comment(handler: TrackHandler, mp3_file: Path) -> None:
+    """A plain text in COMM::XXX (no key=value pairs) ends up as user_comment."""
+    track = ID3(mp3_file)
+    track.add(TIT2(encoding=3, text="X"))
+    track.add(COMM(encoding=3, lang="XXX", desc="", text="just a plain comment"))
+    track.save()
+
+    read = handler.track_info
+    assert read.user_comment == "just a plain comment"
+    assert read.starlib_meta is None  # no structured data in the legacy blob
+
+    # Saving evicts COMM::XXX and writes the user comment to COMM::eng.
+    handler.add_info(read)
+    re_read = ID3(mp3_file)
+    assert re_read.get("COMM::XXX") is None
+    assert str(re_read.get("COMM::eng")) == "just a plain comment"
+
+
+def test_starlib_meta_legacy_comm_xxx_migrates_structured(handler: TrackHandler, mp3_file: Path) -> None:
+    """Structured key=value blob in COMM::XXX migrates into starlib_meta."""
+    track = ID3(mp3_file)
+    track.add(TIT2(encoding=3, text="X"))
+    payload = "version=0.9; soundcloud_id=42; soundcloud_permalink=https://example/y"
+    track.add(COMM(encoding=3, lang="XXX", desc="", text=payload))
+    track.save()
+
+    read = handler.track_info
+    assert read.starlib_meta is not None
+    assert read.starlib_meta.soundcloud_id == 42
+    assert read.starlib_meta.soundcloud_permalink == "https://example/y"
+    assert read.user_comment is None
+
+    handler.add_info(read)
+    re_read = ID3(mp3_file)
+    assert re_read.get("COMM::XXX") is None
+    assert re_read.get("TXXX:starlib") is not None
+
+
+def test_user_comment_does_not_clobber_starlib(handler: TrackHandler) -> None:
+    """user_comment goes to COMM::eng, starlib stays in TXXX:starlib."""
+    handler.add_info(
+        TrackInfo(
+            title="X",
+            user_comment="hello",
+            starlib_meta=StarlibMeta(soundcloud_id=7),
+        )
+    )
+    read = handler.track_info
+    assert read.user_comment == "hello"
+    assert read.starlib_meta and read.starlib_meta.soundcloud_id == 7
+
+
+def test_release_year_independent_of_release_date(handler: TrackHandler) -> None:
+    """release_year and release_date are independent registry fields."""
+    handler.add_info(TrackInfo(release_date=date(2020, 5, 1), release_year=1999))
+    read = handler.track_info
+    assert read.release_date == date(2020, 5, 1)
+    assert read.release_year == 1999
+
+
+def test_registry_field_names_unique() -> None:
+    names = [f.name for f in SIMPLE_TAG_FIELDS]
+    assert len(names) == len(set(names))
+    assert set(SIMPLE_TAG_FIELDS_BY_NAME.keys()) == set(names)
+
+
+def test_track_info_filename_with_missing_artist() -> None:
+    info = TrackInfo(title="Standalone")
+    assert info.filename == "Standalone"
+
+
+def test_track_info_filename_with_artist() -> None:
+    info = TrackInfo(title="Song", artist="Alice")
+    assert info.filename == "Alice - Song"
+
+
+def test_schemas_include_every_registry_field() -> None:
+    """Adding a TagField must surface in the API schemas automatically."""
+    from backend.schemas.metadata import (
+        TrackBrowseResponse,
+        TrackInfoResponse,
+        TrackInfoUpdateRequest,
+    )
+
+    expected = {f.name for f in SIMPLE_TAG_FIELDS}
+    for schema in (TrackInfoUpdateRequest, TrackInfoResponse, TrackBrowseResponse):
+        assert expected <= set(schema.model_fields), (
+            f"{schema.__name__} is missing registry fields: "
+            f"{expected - set(schema.model_fields)}"
+        )


### PR DESCRIPTION
Closes #285 (Phase 1 + Phase 2 from the issue spec).

## Summary

- Replace the bespoke `Remix` model and per-tag special cases with a single
  `SIMPLE_TAG_FIELDS` registry that drives ID3 read/write, API schemas, the
  SQLite cache, and search/sort.  Adding a new tag is now ~one registry entry
  plus a column migration.
- Rename `Comment` → `StarlibMeta`; persist in `TXXX:starlib` (its proper
  namespaced custom-frame slot).  Frees up `COMM::eng` for the user's plain-text
  comment, exposed as `user_comment`.  Read path falls back to the legacy
  `COMM::XXX` once and migrates on next save.
- Flat `TrackInfo`: drops the `remix`/`comment` composites, exposes
  `original_artist`/`remixer`/`mix_name`/`release_year`/`user_comment`/
  `starlib_meta` as ordinary optional fields.  All ID3 fields are optional on
  disk, so `title`/`artist`/`genre` are now `Optional` too.
- API schemas are generated via `pydantic.create_model` from the registry; no
  per-field edits in `backend/schemas/metadata.py` when adding a tag.
- New `scripts/migrate_starlib_meta.py` for one-shot bulk migration.

## Out of scope (follow-ups)

- **Meta-editor UI redesign** (drop the `isRemix` toggle, add `release_year`
  + `user_comment` inputs, year↔date sync logic).  The data flow already
  targets the new flat fields; the visual redesign is its own concern.
- **Relocate `soundcloud_tools/handler/` into `backend/`** — discussed during
  planning, deferred to keep this diff focused.

## Test plan

- [x] `uv run pytest tests/` — 120 passed (12 new in `test_track_handler.py`
      cover the round-trip, the legacy `COMM::XXX` migration both for plain
      comments and structured starlib data, schema-introspection, and
      `clear_tags`).
- [x] `npx tsc --noEmit` — no new errors in touched files.
- [x] `npx next build` — builds clean.
- [x] **Manual cache migration**: open the desktop app once with an existing
      DB and confirm the `ALTER TABLE` + forced re-index runs cleanly.
- [x] **Manual disk verification**: probe a track with mutagen after save and
      confirm `TXXX:starlib` exists, `COMM::XXX` is gone, and `COMM::eng`
      holds whatever the user typed.
- [x] **Migration script smoke**: run `uv run python scripts/migrate_starlib_meta.py
      <folder> --dry-run` on a real folder; then without `--dry-run`; re-run
      and confirm idempotence (all skipped).