### PR TITLE
feat: Rust BPM core (symphonia + spectral-flux tempo detection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,10 +2506,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3118,6 +3148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +3689,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -4228,12 +4281,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "starlib"
 version = "0.3.8"
 dependencies = [
+ "anyhow",
  "dirs",
  "libc",
  "log",
  "reqwest",
+ "rustfft",
  "serde",
  "serde_json",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
@@ -4247,6 +4303,12 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -4318,6 +4380,178 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -5247,6 +5481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1", features = ["time"] }
+symphonia = { version = "0.5", features = ["aac", "isomp4", "mp3", "flac", "wav", "vorbis"] }
+rustfft = "6"
+anyhow = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/desktop/src-tauri/src/bpm/decode.rs
+++ b/desktop/src-tauri/src/bpm/decode.rs
@@ -1,0 +1,121 @@
+//! Audio decoding to mono f32 PCM at a configurable target sample rate.
+//!
+//! Ported from the `bpm_bench_rs` prototype. Uses symphonia for decoding
+//! (fMP4/AAC, MP3, FLAC, WAV, Vorbis) and a simple linear resampler — good
+//! enough for tempo detection, where spectral precision matters less than
+//! onset timing.
+
+use std::fs::File;
+use std::io::Cursor;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::errors::Error as SymphError;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::{MediaSource, MediaSourceStream};
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use super::types::BpmOptions;
+
+/// Decode in-memory audio bytes to mono f32 PCM at `options.target_sr`.
+///
+/// `hint` is an optional file-extension-style hint (e.g. `"mp4"`, `"aac"`,
+/// `"mp3"`) that helps symphonia pick a demuxer when the container is
+/// ambiguous.
+pub fn decode_bytes(bytes: &[u8], hint: Option<&str>, options: &BpmOptions) -> Result<Vec<f32>> {
+    let src: Box<dyn MediaSource> = Box::new(Cursor::new(bytes.to_vec()));
+    decode_from_source(src, hint, options)
+}
+
+/// Decode an audio file from disk to mono f32 PCM at `options.target_sr`.
+pub fn decode_file(path: &Path, options: &BpmOptions) -> Result<Vec<f32>> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let hint = path.extension().and_then(|e| e.to_str()).map(str::to_owned);
+    decode_from_source(Box::new(file), hint.as_deref(), options)
+}
+
+fn decode_from_source(
+    src: Box<dyn MediaSource>,
+    hint: Option<&str>,
+    options: &BpmOptions,
+) -> Result<Vec<f32>> {
+    let mss = MediaSourceStream::new(src, Default::default());
+    let mut probe_hint = Hint::new();
+    if let Some(h) = hint {
+        probe_hint.with_extension(h);
+    }
+    let probed = symphonia::default::get_probe()
+        .format(
+            &probe_hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .context("probe failed")?;
+    let mut format = probed.format;
+    let track = format
+        .default_track()
+        .ok_or_else(|| anyhow!("no default audio track"))?;
+    let track_id = track.id;
+    let src_sr = track.codec_params.sample_rate.unwrap_or(44100);
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .context("decoder init failed")?;
+
+    let mut pcm: Vec<f32> = Vec::new();
+    loop {
+        let packet = match format.next_packet() {
+            Ok(p) => p,
+            Err(SymphError::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(SymphError::ResetRequired) => break,
+            Err(e) => return Err(e.into()),
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        match decoder.decode(&packet) {
+            Ok(decoded) => {
+                let spec = *decoded.spec();
+                let mut buf = SampleBuffer::<f32>::new(decoded.capacity() as u64, spec);
+                buf.copy_interleaved_ref(decoded);
+                let samples = buf.samples();
+                let ch = spec.channels.count().max(1);
+                for frame in samples.chunks(ch) {
+                    let s = frame.iter().sum::<f32>() / ch as f32;
+                    pcm.push(s);
+                }
+            }
+            Err(SymphError::DecodeError(_)) => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    if src_sr == options.target_sr {
+        Ok(pcm)
+    } else {
+        Ok(linear_resample(&pcm, src_sr, options.target_sr))
+    }
+}
+
+/// Linear-interpolation resampler. Not a high-quality resampler — it's fine
+/// for tempo detection where onset timing is what matters.
+pub(crate) fn linear_resample(x: &[f32], src_sr: u32, dst_sr: u32) -> Vec<f32> {
+    if x.is_empty() {
+        return vec![];
+    }
+    let ratio = dst_sr as f64 / src_sr as f64;
+    let n = ((x.len() as f64) * ratio) as usize;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let src_pos = i as f64 / ratio;
+        let idx = src_pos as usize;
+        let frac = (src_pos - idx as f64) as f32;
+        let a = x[idx.min(x.len() - 1)];
+        let b = x[(idx + 1).min(x.len() - 1)];
+        out.push(a * (1.0 - frac) + b * frac);
+    }
+    out
+}

--- a/desktop/src-tauri/src/bpm/mod.rs
+++ b/desktop/src-tauri/src/bpm/mod.rs
@@ -1,0 +1,33 @@
+//! BPM analysis: decode audio bytes/files to mono PCM, run spectral-flux
+//! onset + autocorrelation tempo detection, return a BPM estimate with
+//! confidence.
+//!
+//! This module is pure library code — no Tauri commands, no network.
+//! Command wiring lives in later PRs.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+pub mod decode;
+pub mod tempo;
+pub mod types;
+
+pub use types::{ALGORITHM_VERSION, BpmOptions, BpmResult, Confidence};
+
+/// Decode `bytes` (with optional format `hint`) and return a BPM estimate.
+pub fn analyze_bytes(bytes: &[u8], hint: Option<&str>, options: &BpmOptions) -> Result<BpmResult> {
+    let pcm = decode::decode_bytes(bytes, hint, options)?;
+    tempo::analyze(&pcm, options.target_sr, options)
+}
+
+/// Analyse already-decoded mono PCM samples at the given sample rate.
+pub fn analyze_samples(pcm: &[f32], sr: u32, options: &BpmOptions) -> Result<BpmResult> {
+    tempo::analyze(pcm, sr, options)
+}
+
+/// Decode the audio file at `path` and return a BPM estimate.
+pub fn analyze_file(path: &Path, options: &BpmOptions) -> Result<BpmResult> {
+    let pcm = decode::decode_file(path, options)?;
+    tempo::analyze(&pcm, options.target_sr, options)
+}

--- a/desktop/src-tauri/src/bpm/tempo.rs
+++ b/desktop/src-tauri/src/bpm/tempo.rs
@@ -1,0 +1,228 @@
+//! Tempo (BPM) detection via spectral-flux onset envelope + autocorrelation.
+//!
+//! Ported from the `bpm_bench_rs` prototype. Adds parabolic peak
+//! interpolation on the autocorrelation lag so the estimate isn't quantised
+//! to integer-lag BPMs, and returns a confidence bucket derived from peak
+//! sharpness.
+
+use anyhow::Result;
+use rustfft::FftPlanner;
+use rustfft::num_complex::Complex;
+
+use super::types::{ALGORITHM_VERSION, BpmOptions, BpmResult, Confidence};
+
+/// Analyse PCM samples (mono, at `sr`) and return a BPM estimate.
+pub fn analyze(samples: &[f32], sr: u32, options: &BpmOptions) -> Result<BpmResult> {
+    if samples.len() < 4096 {
+        return Ok(BpmResult {
+            bpm: 0.0,
+            confidence: Confidence::Low,
+            corrected_from: None,
+            algorithm_version: ALGORITHM_VERSION,
+        });
+    }
+
+    let onset = spectral_flux_onset(samples);
+    let (raw_bpm, peak_ratio) = autocorrelate_bpm(&onset, sr, options);
+
+    let confidence = if peak_ratio >= 3.0 {
+        Confidence::High
+    } else if peak_ratio >= 1.5 {
+        Confidence::Medium
+    } else {
+        Confidence::Low
+    };
+
+    let (bpm, corrected_from) = if options.octave_correction {
+        apply_octave_correction(raw_bpm)
+    } else {
+        (raw_bpm, None)
+    };
+
+    Ok(BpmResult {
+        bpm,
+        confidence,
+        corrected_from,
+        algorithm_version: ALGORITHM_VERSION,
+    })
+}
+
+/// Spectral-flux onset envelope: STFT magnitude differences (positive only),
+/// mean-subtracted and half-wave rectified.
+fn spectral_flux_onset(samples: &[f32]) -> Vec<f32> {
+    let win = 2048usize;
+    let hop = 512usize;
+
+    let hann: Vec<f32> = (0..win)
+        .map(|i| 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / win as f32).cos())
+        .collect();
+
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(win);
+
+    let n_frames = (samples.len() - win) / hop + 1;
+    let half = win / 2;
+    let mut mag_prev: Vec<f32> = vec![0.0; half];
+    let mut flux: Vec<f32> = Vec::with_capacity(n_frames);
+
+    let mut buf: Vec<Complex<f32>> = vec![Complex { re: 0.0, im: 0.0 }; win];
+    for f in 0..n_frames {
+        let start = f * hop;
+        for i in 0..win {
+            buf[i] = Complex {
+                re: samples[start + i] * hann[i],
+                im: 0.0,
+            };
+        }
+        fft.process(&mut buf);
+        let mut s = 0.0f32;
+        for i in 0..half {
+            let m = (buf[i].re * buf[i].re + buf[i].im * buf[i].im).sqrt();
+            let diff = m - mag_prev[i];
+            if diff > 0.0 {
+                s += diff;
+            }
+            mag_prev[i] = m;
+        }
+        flux.push(s);
+    }
+
+    let mean = flux.iter().sum::<f32>() / flux.len().max(1) as f32;
+    flux.iter().map(|v| (v - mean).max(0.0)).collect()
+}
+
+/// Autocorrelation over the onset envelope. Returns `(bpm, peak_ratio)` where
+/// `peak_ratio` is the peak autocorrelation score divided by the median over
+/// the searched lag range (used for confidence).
+fn autocorrelate_bpm(onset: &[f32], sr: u32, options: &BpmOptions) -> (f32, f32) {
+    let hop = 512usize;
+    let frame_rate = sr as f32 / hop as f32;
+    let min_lag = (frame_rate * 60.0 / options.max_bpm) as usize;
+    let max_lag = (frame_rate * 60.0 / options.min_bpm) as usize;
+
+    let n = onset.len();
+    if n <= max_lag + 2 || min_lag < 2 {
+        return (0.0, 0.0);
+    }
+
+    // Classic autocorrelation. We need lags [min_lag - 1, max_lag + 1]
+    // available so parabolic interpolation has neighbours.
+    let lo = min_lag - 1;
+    let hi = (max_lag + 1).min(n - 1);
+    let mut acorr = vec![0.0f32; hi + 1];
+    for lag in lo..=hi {
+        let mut s = 0.0f32;
+        for i in 0..(n - lag) {
+            s += onset[i] * onset[i + lag];
+        }
+        acorr[lag] = s;
+    }
+
+    // Find best integer lag in [min_lag, max_lag].
+    let mut best_lag = min_lag;
+    let mut best_score = f32::NEG_INFINITY;
+    for (lag, &score) in acorr.iter().enumerate().take(max_lag + 1).skip(min_lag) {
+        if score > best_score {
+            best_score = score;
+            best_lag = lag;
+        }
+    }
+
+    // Parabolic peak interpolation around best_lag.
+    let offset = parabolic_offset(acorr[best_lag - 1], acorr[best_lag], acorr[best_lag + 1]);
+    let refined_lag = best_lag as f32 + offset;
+
+    let bpm = if refined_lag > 0.0 {
+        frame_rate * 60.0 / refined_lag
+    } else {
+        0.0
+    };
+
+    // Peak sharpness: best score / median of acorr in the search range.
+    let mut search: Vec<f32> = acorr[min_lag..=max_lag].to_vec();
+    search.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = search[search.len() / 2].max(1e-9);
+    let peak_ratio = best_score / median;
+
+    (bpm, peak_ratio)
+}
+
+/// Parabolic peak interpolation for three adjacent samples `y0, y1, y2`
+/// (where `y1` is the integer-lag peak). Returns the sub-sample offset
+/// relative to `y1`, in the range roughly `[-0.5, 0.5]`.
+pub(crate) fn parabolic_offset(y0: f32, y1: f32, y2: f32) -> f32 {
+    let denom = y0 - 2.0 * y1 + y2;
+    if denom.abs() < f32::EPSILON {
+        return 0.0;
+    }
+    let off = 0.5 * (y0 - y2) / denom;
+    // Guard pathological cases where the three points aren't a concave peak.
+    if !off.is_finite() || off.abs() > 1.0 {
+        0.0
+    } else {
+        off
+    }
+}
+
+/// Fold BPMs outside `[90, 180]` into that range by doubling/halving.
+pub(crate) fn apply_octave_correction(bpm: f32) -> (f32, Option<f32>) {
+    if bpm <= 0.0 {
+        return (bpm, None);
+    }
+    if bpm < 90.0 {
+        (bpm * 2.0, Some(bpm))
+    } else if bpm > 180.0 {
+        (bpm / 2.0, Some(bpm))
+    } else {
+        (bpm, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parabolic_interpolation_symmetric_peak() {
+        // Symmetric parabola centred on y1 → offset ~ 0.
+        let off = parabolic_offset(1.0, 2.0, 1.0);
+        assert!(off.abs() < 1e-6, "offset={off}");
+    }
+
+    #[test]
+    fn parabolic_interpolation_shifted_peak() {
+        // Construct y = -(x - 0.25)^2 + 1 sampled at x = -1, 0, 1.
+        // Peak is at x = 0.25, so interpolation should return ~0.25.
+        let f = |x: f32| -(x - 0.25).powi(2) + 1.0;
+        let off = parabolic_offset(f(-1.0), f(0.0), f(1.0));
+        assert!((off - 0.25).abs() < 1e-4, "offset={off}");
+    }
+
+    #[test]
+    fn parabolic_interpolation_zero_denominator() {
+        // Flat line → denominator zero → offset 0.
+        let off = parabolic_offset(1.0, 1.0, 1.0);
+        assert_eq!(off, 0.0);
+    }
+
+    #[test]
+    fn octave_correction_doubles_slow_bpm() {
+        let (corrected, from) = apply_octave_correction(60.0);
+        assert_eq!(corrected, 120.0);
+        assert_eq!(from, Some(60.0));
+    }
+
+    #[test]
+    fn octave_correction_halves_fast_bpm() {
+        let (corrected, from) = apply_octave_correction(200.0);
+        assert_eq!(corrected, 100.0);
+        assert_eq!(from, Some(200.0));
+    }
+
+    #[test]
+    fn octave_correction_leaves_in_range() {
+        let (corrected, from) = apply_octave_correction(128.0);
+        assert_eq!(corrected, 128.0);
+        assert_eq!(from, None);
+    }
+}

--- a/desktop/src-tauri/src/bpm/types.rs
+++ b/desktop/src-tauri/src/bpm/types.rs
@@ -1,0 +1,54 @@
+//! Public types for the BPM analysis module.
+
+/// Current algorithm version. Bump when the analysis pipeline changes
+/// in a way that would produce different BPM values for the same input.
+pub const ALGORITHM_VERSION: u16 = 1;
+
+/// Confidence bucket for a BPM estimate.
+///
+/// Derived from the sharpness of the autocorrelation peak relative to the
+/// median of the search range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Confidence {
+    High,
+    Medium,
+    Low,
+}
+
+/// Result of a BPM analysis run.
+#[derive(Debug, Clone)]
+pub struct BpmResult {
+    /// Estimated tempo in beats per minute.
+    pub bpm: f32,
+    /// Peak-sharpness-derived confidence bucket.
+    pub confidence: Confidence,
+    /// If octave correction kicked in, the pre-correction BPM. Otherwise `None`.
+    pub corrected_from: Option<f32>,
+    /// Version of the algorithm used for this estimate.
+    pub algorithm_version: u16,
+}
+
+/// Tunables for the BPM analysis pipeline.
+#[derive(Debug, Clone)]
+pub struct BpmOptions {
+    /// If true, fold detected BPMs outside `[90, 180]` into that range by
+    /// doubling or halving. Good for electronic music.
+    pub octave_correction: bool,
+    /// Sample rate the signal is resampled to before analysis.
+    pub target_sr: u32,
+    /// Minimum BPM considered during autocorrelation search.
+    pub min_bpm: f32,
+    /// Maximum BPM considered during autocorrelation search.
+    pub max_bpm: f32,
+}
+
+impl Default for BpmOptions {
+    fn default() -> Self {
+        Self {
+            octave_correction: true,
+            target_sr: 22050,
+            min_bpm: 60.0,
+            max_bpm: 200.0,
+        }
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+pub mod bpm;
+
 /// Returns the app config directory used by both the Rust and Python layers.
 /// Matches `platformdirs.user_config_path("com.starlib.Starlib")`.
 fn app_config_dir() -> PathBuf {

--- a/desktop/src-tauri/tests/bpm.rs
+++ b/desktop/src-tauri/tests/bpm.rs
@@ -1,0 +1,82 @@
+//! Integration tests for the BPM analysis module.
+//!
+//! These exercise `starlib_lib::bpm::analyze_samples` on synthetic click
+//! tracks at known tempos and verify the estimated BPM is within ±1.0 BPM.
+
+use starlib_lib::bpm::{BpmOptions, analyze_samples};
+
+/// Build a mono click track at `bpm` for `duration_s` seconds at `sr` Hz.
+/// Each click is a short exponentially-decaying impulse — a decent stand-in
+/// for a percussive onset. Background silence everywhere else.
+fn click_track(bpm: f32, duration_s: f32, sr: u32) -> Vec<f32> {
+    let total = (duration_s * sr as f32) as usize;
+    let mut out = vec![0.0f32; total];
+    let period = 60.0 / bpm;
+    let click_len = (sr as f32 * 0.02) as usize; // 20 ms click
+    let mut t = 0.0f32;
+    while t < duration_s {
+        let start = (t * sr as f32) as usize;
+        for i in 0..click_len {
+            let idx = start + i;
+            if idx >= total {
+                break;
+            }
+            // Exponentially-decaying impulse.
+            let env = (-5.0 * i as f32 / click_len as f32).exp();
+            out[idx] += env;
+        }
+        t += period;
+    }
+    out
+}
+
+fn assert_bpm_close(bpm: f32, target: f32, tol: f32) {
+    assert!(
+        (bpm - target).abs() <= tol,
+        "detected bpm {bpm:.3} not within ±{tol} of {target}",
+    );
+}
+
+#[test]
+fn click_track_120_bpm() {
+    let sr = 22050u32;
+    let samples = click_track(120.0, 30.0, sr);
+    let opts = BpmOptions::default();
+    let result = analyze_samples(&samples, sr, &opts).unwrap();
+    assert_bpm_close(result.bpm, 120.0, 1.0);
+}
+
+#[test]
+fn click_track_128_bpm() {
+    let sr = 22050u32;
+    let samples = click_track(128.0, 30.0, sr);
+    let opts = BpmOptions::default();
+    let result = analyze_samples(&samples, sr, &opts).unwrap();
+    assert_bpm_close(result.bpm, 128.0, 1.0);
+}
+
+#[test]
+fn click_track_140_bpm() {
+    let sr = 22050u32;
+    let samples = click_track(140.0, 30.0, sr);
+    let opts = BpmOptions::default();
+    let result = analyze_samples(&samples, sr, &opts).unwrap();
+    assert_bpm_close(result.bpm, 140.0, 1.0);
+}
+
+#[test]
+fn octave_correction_doubles_60_bpm_click_track() {
+    // A 60 BPM click track — below the 90 BPM floor — should be doubled to
+    // 120 BPM when octave correction is on, with `corrected_from` set.
+    let sr = 22050u32;
+    let samples = click_track(60.0, 30.0, sr);
+    let opts = BpmOptions::default();
+    let result = analyze_samples(&samples, sr, &opts).unwrap();
+    assert_bpm_close(result.bpm, 120.0, 1.0);
+    assert!(
+        result.corrected_from.is_some(),
+        "expected corrected_from to be set when octave correction kicks in",
+    );
+    let from = result.corrected_from.unwrap();
+    assert_bpm_close(from, 60.0, 1.0);
+}


### PR DESCRIPTION
## Summary

- Ports the validated `bpm_bench_rs/` prototype into `desktop/src-tauri/src/bpm/` as a reusable library module — pure decode + analyze, no Tauri commands yet (those come in A2/A3).
- Decoder: `symphonia` (pure Rust) for AAC/fMP4/MP3/FLAC/WAV/Vorbis. Downmixes to mono, linearly resamples to 22050 Hz f32.
- Tempo: spectral-flux onset strength + autocorrelation, with **parabolic peak interpolation** fixing the prototype's integer-lag quantization (no more snap-to-132.51 artifacts). Octave correction folds <90/>180 into the 90–180 window.
- Return type: `BpmResult { bpm, confidence, corrected_from, algorithm_version }`. Confidence derived from autocorrelation peak sharpness — first cut; thresholds to be tuned in the accuracy sprint.
- Binary size impact on the Tauri bundle: single-digit MB (full standalone Rust bench was 6.6 MB).

## Context

Part of the plan at #PLAN (see chat). Option-2 Rust route chosen over Python librosa after benchmarking showed ~250 MB Python deps vs 6.6 MB Rust; wall-time parity; cold-start 1 ms vs 5 s librosa/numba JIT.

## Test plan

- [x] `cargo build` in `desktop/src-tauri/` — passes
- [x] `cargo test` — 10/10 pass (6 unit + 4 integration)
- [x] Synthetic click-track fixtures at 120/128/140 BPM detected within ±1.0 BPM
- [x] Octave correction: 60 BPM click track → returns 120 with `corrected_from = Some(~60.0)`
- [x] Parabolic interpolation unit test against a known 3-point parabola
- [x] `cargo clippy --tests --lib` — clean on new code (one pre-existing `needless_borrow` warning in `src/lib.rs:204` intentionally left untouched; surgical-changes rule)
- [ ] Tauri bundle build — not exercised here; verify in a follow-up

## Follow-ups (not this PR)

- A2 local-file BPM via `#[tauri::command]`
- A3 SoundCloud BPM pipeline (ports fetch + m3u8 logic from `bpm_bench_rs/`)
- Accuracy sprint to tune confidence thresholds against a real test set
- `bpm_bench_rs/` → convert to a `[[bin]]` target sharing this module (currently a standalone sibling crate)