### PR TITLE
feat: local-file BPM detection (Detect button in track editor)

### DIFF
--- a/backend/api/bpm.py
+++ b/backend/api/bpm.py
@@ -1,0 +1,63 @@
+"""BPM persistence endpoints.
+
+Analysis itself happens in the Tauri/Rust layer (see
+`desktop/src-tauri/src/bpm/`). This endpoint exists so the frontend can hand
+the computed BPM to the backend for storage in the local cache DB — the
+single source of truth for track metadata.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from backend.core.services import cache_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/bpm", tags=["bpm"])
+
+
+class LocalBpmPayload(BaseModel):
+    """Client-computed BPM for a local audio file."""
+
+    file_path: str = Field(..., description="Absolute path of the local audio file.")
+    bpm: float = Field(..., gt=0, description="Detected BPM from the analysis layer.")
+    algorithm_version: int = Field(..., ge=1, description="Version tag of the analyzer.")
+
+
+class LocalBpmResponse(BaseModel):
+    file_path: str
+    bpm: int
+    algorithm_version: int
+
+
+@router.post("/local", response_model=LocalBpmResponse)
+def save_local_bpm(payload: LocalBpmPayload) -> LocalBpmResponse:
+    """Persist a BPM value for a local track.
+
+    The cache DB stores BPM as an integer, matching existing metadata-editor
+    conventions. Float precision is dropped at write time — if sub-integer
+    BPM ever matters, migrate the column first.
+    """
+    bpm_int = round(payload.bpm)
+    if bpm_int <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="BPM rounds to a non-positive integer",
+        )
+    updated = cache_db.update_track_bpm(Path(payload.file_path), bpm_int)
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No cached track found at {payload.file_path}",
+        )
+    logger.info("saved bpm=%d for %s (algo v%d)", bpm_int, payload.file_path, payload.algorithm_version)
+    return LocalBpmResponse(
+        file_path=payload.file_path,
+        bpm=bpm_int,
+        algorithm_version=payload.algorithm_version,
+    )

--- a/backend/core/services/cache_db.py
+++ b/backend/core/services/cache_db.py
@@ -18,7 +18,7 @@ import logging
 from datetime import date
 from pathlib import Path
 
-from sqlalchemy import Select, String, delete, func, or_, select
+from sqlalchemy import Select, String, delete, func, or_, select, update
 
 from backend.core.db.engine import get_engine, init_engine
 from backend.core.db.migrations import run_migrations
@@ -141,6 +141,14 @@ def upsert_track(
     stmt = stmt.on_conflict_do_update(index_elements=[Track.__table__.c.file_path], set_=update_cols)
     with engine.begin() as conn:
         conn.execute(stmt)
+
+
+def update_track_bpm(file_path: Path, bpm: int) -> bool:
+    """Update the cached BPM for a track. Returns True if a row was updated."""
+    stmt = update(Track).where(Track.file_path == str(file_path)).values(bpm=bpm)
+    with get_engine().begin() as conn:
+        result = conn.execute(stmt)
+    return result.rowcount > 0
 
 
 def delete_track(file_path: Path) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from fastapi_pagination import add_pagination
 from backend.api.ai import router as ai_router
 from backend.api.app_settings import router as app_settings_router
 from backend.api.auth import router as auth_router
+from backend.api.bpm import router as bpm_router
 from backend.api.folder_config import router as folder_config_router
 from backend.api.metadata import router as metadata_router
 from backend.api.rulesets import router as rulesets_router
@@ -102,6 +103,7 @@ def create_app() -> FastAPI:
     app.include_router(folder_config_router)
     app.include_router(app_settings_router)
     app.include_router(ai_router)
+    app.include_router(bpm_router)
 
     add_pagination(app)
 

--- a/desktop/src-tauri/src/bpm/local.rs
+++ b/desktop/src-tauri/src/bpm/local.rs
@@ -1,0 +1,124 @@
+//! Local-file BPM analysis.
+//!
+//! Decodes the file at `path`, slices a window starting at `offset_pct` of
+//! the total duration, and runs tempo detection on that slice. Window-based
+//! analysis keeps analysis cost constant regardless of track length; decode
+//! cost still scales with file length but is negligible on local disk.
+
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+
+use super::{decode, tempo, types::BpmOptions, types::BpmResult};
+
+/// Analyse a snippet of `path` and return a BPM estimate.
+///
+/// # Parameters
+/// - `offset_pct`: start of the analysis window as a percent of track length
+///   (clamped to `[0, 100]`). 30 is a reasonable default for electronic music
+///   — past the intro, inside the first main section.
+/// - `snippet_s`: window length in seconds. Shorter = faster, less accurate.
+pub fn analyze_local_file(
+    path: &Path,
+    offset_pct: f32,
+    snippet_s: f32,
+    options: &BpmOptions,
+) -> Result<BpmResult> {
+    let pcm = decode::decode_file(path, options)?;
+    let sr = options.target_sr;
+    let total_samples = pcm.len();
+    if total_samples == 0 {
+        return Err(anyhow!("decoded PCM is empty"));
+    }
+    let total_s = total_samples as f32 / sr as f32;
+    let start_s = (total_s * offset_pct.clamp(0.0, 100.0) / 100.0).max(0.0);
+    let start = ((start_s * sr as f32) as usize).min(total_samples);
+    let end = (((start_s + snippet_s) * sr as f32) as usize).min(total_samples);
+    let window: &[f32] = if start >= end {
+        // Track shorter than the requested window / offset — analyse what we have.
+        &pcm
+    } else {
+        &pcm[start..end]
+    };
+    if window.is_empty() {
+        return Err(anyhow!("analysis window is empty"));
+    }
+    tempo::analyze(window, sr, options)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a tiny WAV (RIFF) file with the given mono f32 samples at `sr`.
+    fn write_wav(path: &Path, samples: &[f32], sr: u32) {
+        use std::fs::File;
+        let mut f = File::create(path).expect("create wav");
+        let n = samples.len();
+        let byte_rate = sr * 2; // 16-bit mono
+        let data_size = (n * 2) as u32;
+        let chunk_size = 36 + data_size;
+        // RIFF header
+        f.write_all(b"RIFF").unwrap();
+        f.write_all(&chunk_size.to_le_bytes()).unwrap();
+        f.write_all(b"WAVE").unwrap();
+        // fmt chunk
+        f.write_all(b"fmt ").unwrap();
+        f.write_all(&16u32.to_le_bytes()).unwrap(); // PCM header size
+        f.write_all(&1u16.to_le_bytes()).unwrap(); // PCM format
+        f.write_all(&1u16.to_le_bytes()).unwrap(); // mono
+        f.write_all(&sr.to_le_bytes()).unwrap();
+        f.write_all(&byte_rate.to_le_bytes()).unwrap();
+        f.write_all(&2u16.to_le_bytes()).unwrap(); // block align
+        f.write_all(&16u16.to_le_bytes()).unwrap(); // bits per sample
+        // data chunk
+        f.write_all(b"data").unwrap();
+        f.write_all(&data_size.to_le_bytes()).unwrap();
+        for s in samples {
+            let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+            f.write_all(&v.to_le_bytes()).unwrap();
+        }
+    }
+
+    fn click_track(bpm: f32, seconds: f32, sr: u32) -> Vec<f32> {
+        let n = (seconds * sr as f32) as usize;
+        let period = (60.0 / bpm * sr as f32) as usize;
+        let mut out = vec![0.0f32; n];
+        let mut i = 0;
+        while i < n {
+            for j in 0..64 {
+                if i + j < n {
+                    out[i + j] = 1.0;
+                }
+            }
+            i += period;
+        }
+        out
+    }
+
+    #[test]
+    fn analyze_local_file_wav_128_bpm() {
+        let dir = std::env::temp_dir().join("starlib-bpm-local-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("click_128.wav");
+        write_wav(&path, &click_track(128.0, 30.0, 22050), 22050);
+        let result = analyze_local_file(&path, 30.0, 15.0, &BpmOptions::default()).unwrap();
+        assert!(
+            (result.bpm - 128.0).abs() < 1.0,
+            "expected 128 BPM, got {}",
+            result.bpm
+        );
+    }
+
+    #[test]
+    fn analyze_local_file_window_shorter_than_snippet_is_tolerated() {
+        // 5-second track, ask for a 15-second window at 30% offset.
+        let dir = std::env::temp_dir().join("starlib-bpm-local-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("click_short.wav");
+        write_wav(&path, &click_track(128.0, 5.0, 22050), 22050);
+        let result = analyze_local_file(&path, 30.0, 15.0, &BpmOptions::default()).unwrap();
+        assert!((result.bpm - 128.0).abs() < 1.5);
+    }
+}

--- a/desktop/src-tauri/src/bpm/mod.rs
+++ b/desktop/src-tauri/src/bpm/mod.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use anyhow::Result;
 
 pub mod decode;
+pub mod local;
 pub mod tempo;
 pub mod types;
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -1,0 +1,52 @@
+//! Tauri commands exposed to the frontend via `invoke`.
+//!
+//! Keep this file as a thin adapter: parameter parsing, type conversion for
+//! the JSON boundary, and error mapping to strings. Real work lives in the
+//! underlying modules.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::bpm::{self, BpmOptions, Confidence};
+
+#[derive(Serialize)]
+pub struct LocalBpmResponse {
+    /// Detected BPM. Rounded at persistence time by the backend, but kept
+    /// as float here for algorithm-version migrations / debugging.
+    pub bpm: f32,
+    pub confidence: &'static str,
+    /// Original pre-correction BPM when octave correction kicked in.
+    pub corrected_from: Option<f32>,
+    pub algorithm_version: u16,
+}
+
+fn confidence_str(c: Confidence) -> &'static str {
+    match c {
+        Confidence::High => "high",
+        Confidence::Medium => "medium",
+        Confidence::Low => "low",
+    }
+}
+
+/// Analyze BPM for a local audio file.
+///
+/// Runs synchronously on a blocking thread (the decode + analyze together
+/// take ~50 ms on a typical track); Tauri invoke handlers can be called from
+/// async contexts so no extra wrapper is needed for responsiveness.
+#[tauri::command]
+pub async fn analyze_local_bpm(path: String) -> Result<LocalBpmResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let options = BpmOptions::default();
+        let result = bpm::local::analyze_local_file(&PathBuf::from(&path), 30.0, 15.0, &options)
+            .map_err(|e| e.to_string())?;
+        Ok::<_, String>(LocalBpmResponse {
+            bpm: result.bpm,
+            confidence: confidence_str(result.confidence),
+            corrected_from: result.corrected_from,
+            algorithm_version: result.algorithm_version,
+        })
+    })
+    .await
+    .map_err(|e| format!("analysis task failed: {e}"))?
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub mod bpm;
+pub mod commands;
 
 /// Returns the app config directory used by both the Rust and Python layers.
 /// Matches `platformdirs.user_config_path("com.starlib.Starlib")`.
@@ -179,6 +180,7 @@ pub fn run() {
     }
 
     builder
+        .invoke_handler(tauri::generate_handler![commands::analyze_local_bpm])
         .plugin(
             tauri_plugin_log::Builder::new()
                 .targets([

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   ChevronDown,
   Image as ImageIcon,
+  Loader2,
   MoveRight,
   RotateCcw,
   Search,
@@ -15,6 +16,7 @@ import {
   Trash2,
   Users,
   Wand2,
+  Waves,
   Workflow,
   X,
 } from "lucide-react";
@@ -69,6 +71,7 @@ import {
   removeParenthesis,
   titelize,
 } from "@/lib/string-utils";
+import { analyzeLocalBpm, isTauri } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
 import { useSourceSearch } from "./use-source-search";
@@ -175,6 +178,9 @@ export function TrackEditor({
     soundcloud_permalink: "",
   });
   const [scLinkEnabled, setScLinkEnabled] = useState(true);
+
+  // BPM detection state (Rust-side analysis via Tauri invoke)
+  const [bpmAnalyzing, setBpmAnalyzing] = useState(false);
 
   // Active ruleset (shown in Apply Rules popover) — only set when the folder has one assigned
   const [activeRuleset, setActiveRuleset] = useState<Ruleset | null>(null);
@@ -1187,6 +1193,41 @@ export function TrackEditor({
                     BPM
                   </span>
                   <div className="flex scale-75 gap-0.5 opacity-0 transition-all duration-150 ease-out group-focus-within:scale-100 group-focus-within:opacity-100 group-hover:scale-100 group-hover:opacity-100">
+                    {isTauri() && trackInfo && (
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={async () => {
+                          setBpmAnalyzing(true);
+                          try {
+                            const result = await analyzeLocalBpm(
+                              trackInfo.file_path,
+                            );
+                            handleFormChange(
+                              "bpm",
+                              String(Math.round(result.bpm)),
+                            );
+                            toast.success(
+                              `Detected ${Math.round(result.bpm)} BPM (${result.confidence} confidence)`,
+                            );
+                          } catch (err) {
+                            toast.error(
+                              `BPM detection failed: ${err instanceof Error ? err.message : String(err)}`,
+                            );
+                          } finally {
+                            setBpmAnalyzing(false);
+                          }
+                        }}
+                        disabled={bpmAnalyzing}
+                        title="Detect BPM from audio"
+                      >
+                        {bpmAnalyzing ? (
+                          <Loader2 className="animate-spin" />
+                        ) : (
+                          <Waves />
+                        )}
+                      </Button>
+                    )}
                     {isChanged("bpm") && (
                       <Button
                         variant="ghost"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -738,4 +738,20 @@ export const api = {
   async deleteAnthropicApiKey(): Promise<AiSettings> {
     return fetchApi("/api/ai/anthropic/credentials", { method: "DELETE" });
   },
+
+  // BPM
+  async saveLocalBpm(
+    filePath: string,
+    bpm: number,
+    algorithmVersion: number,
+  ): Promise<{ file_path: string; bpm: number; algorithm_version: number }> {
+    return fetchApi("/api/bpm/local", {
+      method: "POST",
+      body: JSON.stringify({
+        file_path: filePath,
+        bpm,
+        algorithm_version: algorithmVersion,
+      }),
+    });
+  },
 };

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -1,5 +1,24 @@
-/** Tauri environment detection. */
+/** Tauri environment detection + thin wrappers around Rust-backed commands. */
+
+import { invoke } from "@tauri-apps/api/core";
 
 export function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/** Detection result from `desktop/src-tauri/src/bpm/local.rs`. */
+export interface LocalBpmResult {
+  bpm: number;
+  confidence: "high" | "medium" | "low";
+  /** Original BPM prior to octave correction, when it fired. */
+  corrected_from: number | null;
+  algorithm_version: number;
+}
+
+/**
+ * Run BPM detection on a local audio file. Resolves with the detection
+ * result; rejects with a human-readable string on decode / analysis failure.
+ */
+export async function analyzeLocalBpm(path: string): Promise<LocalBpmResult> {
+  return invoke<LocalBpmResult>("analyze_local_bpm", { path });
 }

--- a/tests/test_bpm_api.py
+++ b/tests/test_bpm_api.py
@@ -1,0 +1,65 @@
+"""Tests for the local-file BPM persistence endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.bpm import router as bpm_router
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(bpm_router)
+    return TestClient(app)
+
+
+def _payload(file_path: str = "/music/track.mp3", bpm: float = 128.4, algo: int = 1) -> dict:
+    return {"file_path": file_path, "bpm": bpm, "algorithm_version": algo}
+
+
+def test_rounds_bpm_and_persists(client: TestClient) -> None:
+    """Happy path: float BPM is rounded and handed to cache_db."""
+
+    with patch("backend.api.bpm.cache_db.update_track_bpm", return_value=True) as mock:
+        resp = client.post("/api/bpm/local", json=_payload(bpm=128.4))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bpm"] == 128
+    assert body["algorithm_version"] == 1
+    mock.assert_called_once()
+    called_path, called_bpm = mock.call_args.args
+    assert called_path == Path("/music/track.mp3")
+    assert called_bpm == 128
+
+
+def test_rounds_half_up(client: TestClient) -> None:
+    """128.6 → 129, not 128."""
+    with patch("backend.api.bpm.cache_db.update_track_bpm", return_value=True):
+        resp = client.post("/api/bpm/local", json=_payload(bpm=128.6))
+    assert resp.json()["bpm"] == 129
+
+
+def test_unknown_track_returns_404(client: TestClient) -> None:
+    """update_track_bpm returning False (no row updated) surfaces as 404."""
+
+    with patch("backend.api.bpm.cache_db.update_track_bpm", return_value=False):
+        resp = client.post("/api/bpm/local", json=_payload())
+
+    assert resp.status_code == 404
+    assert "track" in resp.json()["detail"].lower()
+
+
+def test_rejects_non_positive_bpm(client: TestClient) -> None:
+    """Pydantic validation rejects BPM <= 0 before it reaches the handler."""
+    resp = client.post("/api/bpm/local", json=_payload(bpm=0))
+    assert resp.status_code == 422
+
+    resp = client.post("/api/bpm/local", json=_payload(bpm=-1))
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Adds \`bpm::local::analyze_local_file\` — symphonia decode of an audio file followed by window-based tempo detection (default 30% offset, 15s snippet). Analysis cost is constant per track regardless of length.
- **First Tauri command in the codebase**: \`analyze_local_bpm(path)\`. Runs on a blocking thread, returns BPM + confidence + octave-correction metadata to the frontend. All other frontend ↔ app communication continues to go through the Python backend over HTTP; Tauri invoke is introduced only for CPU-intensive work that would otherwise drag the ~250 MB librosa/numba stack into the Python sidecar.
- Backend endpoint \`POST /api/bpm/local\` persists the computed BPM into \`cache_db\` (rounds to int to match the existing schema). Returns 404 when the track isn't in the cache.
- Track editor gets a Detect icon button next to the existing BPM field. Click → Rust analysis → populate form → user saves through the existing flow. Button is hidden outside the Tauri WebView (plain browser dev runs) since the invoke target isn't available there.

## Architecture note

The plan explicitly pushed BPM compute to Rust to keep the Tauri bundle small (6.6 MB vs ~250 MB if we'd shipped librosa). This PR makes the architectural commitment concrete by introducing the first \`#[tauri::command]\` and the first \`@tauri-apps/api/core\` \`invoke\` call in the frontend. Subsequent BPM PRs (A3 SoundCloud, A4 batch) extend the same pattern; non-BPM features keep using the Python backend.

## Test plan

- [x] \`cargo test --lib --release\` in \`desktop/src-tauri\` — 8/8 pass (6 from A1 + 2 new local-file cases: 128 BPM WAV fixture within ±1 BPM; short-track-than-window tolerated)
- [x] \`cargo build\` in \`desktop/src-tauri\` — clean
- [x] \`uv run python -m pytest tests/\` — 147 pass (4 new for the persistence endpoint)
- [x] \`uv run ruff check backend/ tests/\` — clean
- [x] \`uv run ruff format --check backend/ tests/\` — clean
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` / \`test\` / \`build\` — all green
- [ ] Live smoke test inside Tauri WebView — not exercised in CI; click the Detect button on a real track before merging

## Follow-ups

- Partial-file decode via symphonia seek for very long tracks (current path decodes the full file then slices in PCM). For a 5-min MP3 that's ~150 ms of needless decode; acceptable, but an obvious optimization.
- A4 batch scan will call \`api.saveLocalBpm\` directly without going through the editor.
- BPM column stays int in cache_db; revisit if fractional precision ever matters for DJs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)