### PR TITLE
fix: dev sidecar uses project venv python directly

### DIFF
--- a/desktop/scripts/setup-dev-sidecar.sh
+++ b/desktop/scripts/setup-dev-sidecar.sh
@@ -38,13 +38,29 @@ if [[ ! -f "$FFMPEG_BIN" ]]; then
   fi
 fi
 
-cat > "$OUT" << 'STUB'
+REPO_ROOT="$(cd "${DESKTOP_DIR}/.." && pwd)"
+
+# Ensure the project venv exists + is in sync. We call the venv's python
+# directly from the stub (not `uv run`) because Tauri's sidecar child env
+# may pick up a different Python via uv's auto-download/UV_PYTHON defaults.
+# Pinning to the venv interpreter avoids any PATH / uv-config ambiguity.
+echo "Syncing project venv via uv..."
+(cd "$REPO_ROOT" && uv sync >/dev/null)
+
+VENV_PY="${REPO_ROOT}/.venv/bin/python"
+if [[ ! -x "$VENV_PY" ]]; then
+  echo "Error: expected venv python at $VENV_PY" >&2
+  exit 1
+fi
+
+cat > "$OUT" << STUB
 #!/usr/bin/env bash
 # Dev sidecar stub — replaced by the PyInstaller binary in production builds.
-REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
-cd "$REPO_ROOT"
-export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
-exec uv run python -m backend.main "$@"
+# Repo root and interpreter baked in at stub-generation time so the Tauri
+# child process doesn't depend on PATH, CWD, or uv auto-discovery.
+cd "${REPO_ROOT}"
+export PYTHONPATH="${REPO_ROOT}:\${PYTHONPATH:-}"
+exec "${VENV_PY}" -m backend.main "\$@"
 STUB
 
 chmod +x "$OUT"


### PR DESCRIPTION
## Summary

Fix for \`ModuleNotFoundError: No module named 'backend'\` when running the Tauri dev window (the sidecar error that surfaces while trying to test #329).

## Root cause

\`desktop/scripts/setup-dev-sidecar.sh\` generated a stub that resolved the repo root via \`\$0\`-relative \`dirname\` lookups at runtime and used \`uv run python -m backend.main\` to start the backend. That works fine when invoked from an interactive shell, but fails when Tauri's \`tauri_plugin_shell::ShellExt::sidecar()\` spawns it: the child process inherits a minimal env, and \`uv run\` resolves \`python\` to \`/opt/homebrew/opt/python@3.14/bin/python3.14\` (homebrew's system Python 3.14, where \`backend\` isn't installed) instead of the project's \`.venv/bin/python\` (3.13).

## Fix

- Run \`uv sync\` in the setup script to guarantee the venv exists and is current.
- Bake the absolute repo root + \`.venv/bin/python\` path into the stub at generation time. The runtime stub now \`cd\`'s to the repo root, exports \`PYTHONPATH\`, and \`exec\`s the venv interpreter directly. No runtime dependency on \`\$0\` resolution, PATH, CWD, or uv's Python auto-discovery.

## Test plan

- [x] \`bash desktop/scripts/setup-dev-sidecar.sh\` regenerates the stub with absolute paths.
- [x] Running the stub directly starts the backend on port 8000.
- [x] \`make tauri-dev\` (#330 or \`cd desktop && npm run desktop:dev\`) opens the Tauri window and the sidecar starts without the ModuleNotFoundError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)