### PR TITLE
fix: forward deep-link URLs via single_instance on macOS

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -171,7 +171,20 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            // When a deep link (starlib://…) fires and macOS launches the
+            // registered packaged .app while the dev binary is already
+            // running, single_instance forwards the new instance's argv here
+            // and exits the second instance. The URL is in that argv. Re-emit
+            // it as a `deep-link` Tauri event so the frontend listener picks
+            // it up the same way it would from the deep_link plugin's native
+            // handler.
+            for arg in argv.iter().skip(1) {
+                if arg.starts_with("starlib://") {
+                    log::info!("[deep-link] forwarded via single_instance: {arg}");
+                    let _ = app.emit("deep-link", arg.as_str());
+                }
+            }
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_focus();
             }

--- a/frontend/src/components/deep-link-listener.tsx
+++ b/frontend/src/components/deep-link-listener.tsx
@@ -27,6 +27,8 @@ export function DeepLinkListener() {
       }
     };
 
+    let unlistenEvent: (() => void) | undefined;
+
     import("@tauri-apps/plugin-deep-link").then(async (mod) => {
       unlisten = await mod.onOpenUrl((urls) => {
         for (const u of urls) handleUrl(u);
@@ -38,8 +40,20 @@ export function DeepLinkListener() {
       }
     });
 
+    // Also listen for the `deep-link` Tauri event. The Rust side emits this
+    // both from the deep_link plugin's native handler AND from the
+    // single_instance callback when macOS launches the registered packaged
+    // app while this process holds the single-instance lock (argv forwarding).
+    // Without this the dev session misses OAuth callbacks.
+    import("@tauri-apps/api/event").then(async (mod) => {
+      unlistenEvent = await mod.listen<string>("deep-link", (event) => {
+        handleUrl(event.payload);
+      });
+    });
+
     return () => {
       unlisten?.();
+      unlistenEvent?.();
     };
   }, [router]);
 


### PR DESCRIPTION
## Summary

OAuth callbacks in dev mode silently dropped. Symptom: after SoundCloud auth the window gets focused but the frontend remains unauthenticated — backend logs show the redirect hits \`/auth/soundcloud/redirect\` + successful token exchange, but \`/auth/soundcloud/result\` is never called.

## Root cause

On macOS, \`starlib://\` URLs are resolved by LaunchServices to the registered packaged \`Starlib.app\`. When \`make tauri-dev\` is running, the dev binary at \`target/debug/starlib\` holds the single-instance lock but isn't a registered URL handler. So:

1. \`starlib://\` fires → macOS launches the packaged app as a new process
2. Packaged app's \`tauri-plugin-single-instance\` detects the dev binary's lock, forwards its argv (which contains the URL), and exits
3. The dev binary's \`single_instance\` callback was ignoring argv entirely — it only focused the window
4. The URL never reaches the deep-link plugin's native handler either, because that handler runs in the packaged process, not the dev one

The visible result: "it jumps back to the app" (window focus works), but auth never completes.

## Fix

- **Rust**: \`single_instance\` callback now parses argv for \`starlib://\` entries and re-emits each one as the same \`"deep-link"\` Tauri event the deep_link plugin's native handler already emits.
- **Frontend**: \`DeepLinkListener\` now subscribes to the \`"deep-link"\` Tauri event (via \`@tauri-apps/api/event\`) in addition to the plugin's \`onOpenUrl\`, so it picks up both the native-handler path (packaged builds) and the argv-forwarded path (dev-binary + packaged-registered).

## Test plan

- [x] \`cargo build\` in \`desktop/src-tauri\` — passes
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [ ] End-to-end: run \`make tauri-dev\`, click "Connect with SoundCloud", complete OAuth in browser, confirm the dev window shows authenticated state and routes to \`/library?source=soundcloud\`. Worth verifying interactively before merging.

## Note

This is a pre-existing bug in how \`single_instance\` and \`deep_link\` interact, not introduced by any recent PR. It only surfaces now because the packaged \`/Applications/Starlib.app\` was recently rebuilt to v0.4.0 and re-registered as the handler, making the dev-mode forwarding path the default route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)