### PR TITLE
fix: replace starlib:// deep link with polling for OAuth

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -28,11 +28,27 @@ router = APIRouter(prefix="/auth/soundcloud", tags=["authentication"])
 _ALLOWED_RETURN_ORIGINS = frozenset(
     {
         "http://localhost:3000",
+        "http://127.0.0.1:8000",
         "https://tauri.localhost",
         "tauri://localhost",
         "starlib://localhost",
     }
 )
+
+_DONE_HTML = """
+<!DOCTYPE html>
+<html><head><title>Authenticated</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; text-align: center;
+         padding: 4rem 1rem; color: #111; background: #fafafa; }
+  h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+  p  { color: #555; margin: 0.25rem 0; }
+</style>
+</head><body>
+  <h1>SoundCloud connected</h1>
+  <p>You can close this tab and return to Starlib.</p>
+</body></html>
+"""
 
 # Server-side storage for pending OAuth flows: state -> (code_verifier, return_to)
 _pending_oauth_flows: dict[str, tuple[str, str]] = {}
@@ -199,6 +215,16 @@ def handle_redirect(
     redirect_url = f"{return_to}{separator}state={state}"
     html = _REDIRECT_HTML_TEMPLATE.replace("{redirect_url}", redirect_url)
     return HTMLResponse(content=html)
+
+
+@router.get("/done")
+def oauth_done() -> HTMLResponse:
+    """Static "you can close this tab" page for the Tauri OAuth flow.
+
+    The Tauri client polls `/result?state=...` independently to pick up the
+    exchanged tokens, so the browser itself just needs a dead-end page.
+    """
+    return HTMLResponse(content=_DONE_HTML)
 
 
 @router.get("/result", response_model=CallbackResponse)

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { open as openExternal } from "@tauri-apps/plugin-shell";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { fetchApi } from "@/lib/api";
+import { storeTokens } from "@/lib/auth";
 import { isTauri } from "@/lib/tauri";
 
 interface AuthorizeResponse {
@@ -12,33 +14,103 @@ interface AuthorizeResponse {
   state: string;
 }
 
+interface UserInfo {
+  id: number;
+  username: string;
+  permalink: string;
+  avatar_url: string | null;
+}
+
+interface CallbackResponse {
+  access_token: string;
+  refresh_token: string | null;
+  expires_in: number | null;
+  user: UserInfo;
+}
+
+const POLL_INTERVAL_MS = 1500;
+const POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Poll /auth/soundcloud/result until the browser-side redirect delivers it,
+ * or we time out. Returns the tokens on success; throws on timeout / abort. */
+async function pollForOAuthResult(
+  state: string,
+  abort: AbortController,
+): Promise<CallbackResponse> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (abort.signal.aborted) throw new Error("Login cancelled");
+    try {
+      const result = await fetchApi<CallbackResponse>(
+        `/auth/soundcloud/result?state=${encodeURIComponent(state)}`,
+        { signal: abort.signal },
+      );
+      return result;
+    } catch (err) {
+      // 404 = not yet available, keep polling. Anything else bubbles up.
+      const anyErr = err as { status?: number };
+      if (anyErr?.status !== 404) throw err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error("Login timed out. Please try again.");
+}
+
 export default function LoginPage() {
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   async function handleConnect() {
     setLoading(true);
     setError(null);
+    abortRef.current?.abort();
+    const abort = new AbortController();
+    abortRef.current = abort;
 
     try {
       const inTauri = isTauri();
+      // In Tauri we poll for the result from this window — browser just lands
+      // on a static "you can close this tab" page. In a plain browser, let
+      // the existing callback page handle it.
       const returnTo = inTauri
-        ? "starlib://localhost/auth/soundcloud/callback"
+        ? "http://127.0.0.1:8000/auth/soundcloud/done"
         : `${window.location.origin}/auth/soundcloud/callback`;
       const data = await fetchApi<AuthorizeResponse>(
         `/auth/soundcloud/authorize?return_to=${encodeURIComponent(returnTo)}`,
       );
       sessionStorage.setItem("oauth_state", data.state);
+
       if (inTauri) {
         await openExternal(data.authorization_url);
-        setLoading(false);
+        const result = await pollForOAuthResult(data.state, abort);
+        storeTokens(
+          result.access_token,
+          result.refresh_token,
+          result.expires_in,
+        );
+        localStorage.setItem("sc_user", JSON.stringify(result.user));
+        sessionStorage.removeItem("oauth_state");
+        window.dispatchEvent(new Event("auth-changed"));
+        router.push("/library?source=soundcloud");
       } else {
         window.location.href = data.authorization_url;
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to initiate login");
+      if ((err as Error)?.name !== "AbortError") {
+        setError(
+          err instanceof Error ? err.message : "Failed to initiate login",
+        );
+      }
+    } finally {
       setLoading(false);
     }
+  }
+
+  function handleCancel() {
+    abortRef.current?.abort();
+    setLoading(false);
   }
 
   return (
@@ -53,8 +125,17 @@ export default function LoginPage() {
           </p>
 
           <Button onClick={handleConnect} disabled={loading} className="w-full">
-            {loading ? "Opening…" : "Connect with SoundCloud"}
+            {loading ? "Waiting for SoundCloud…" : "Connect with SoundCloud"}
           </Button>
+
+          {loading && (
+            <button
+              onClick={handleCancel}
+              className="text-muted-foreground hover:text-foreground mt-3 text-xs"
+            >
+              Cancel
+            </button>
+          )}
 
           {error && <p className="text-destructive mt-4 text-sm">{error}</p>}
         </div>

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -93,6 +93,14 @@ export default function LoginPage() {
         localStorage.setItem("sc_user", JSON.stringify(result.user));
         sessionStorage.removeItem("oauth_state");
         window.dispatchEvent(new Event("auth-changed"));
+        // Bring the Starlib window back to the front — the user is currently
+        // looking at the "you can close this tab" page in their browser.
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          await getCurrentWindow().setFocus();
+        } catch (err) {
+          console.warn("focus on self failed:", err);
+        }
         router.push("/library?source=soundcloud");
       } else {
         window.location.href = data.authorization_url;

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -95,9 +95,20 @@ export default function LoginPage() {
         window.dispatchEvent(new Event("auth-changed"));
         // Bring the Starlib window back to the front — the user is currently
         // looking at the "you can close this tab" page in their browser.
+        // macOS throttles cross-app focus stealing hard; combine unminimize +
+        // show + setFocus for best-effort activation, then bounce the dock
+        // icon via requestUserAttention(Critical) which is explicitly
+        // permitted for user-attention cues even when activation is refused.
         try {
-          const { getCurrentWindow } = await import("@tauri-apps/api/window");
-          await getCurrentWindow().setFocus();
+          const { getCurrentWindow, UserAttentionType } =
+            await import("@tauri-apps/api/window");
+          const w = getCurrentWindow();
+          await w.unminimize().catch(() => {});
+          await w.show().catch(() => {});
+          await w.setFocus().catch(() => {});
+          await w
+            .requestUserAttention(UserAttentionType.Critical)
+            .catch(() => {});
         } catch (err) {
           console.warn("focus on self failed:", err);
         }


### PR DESCRIPTION
## Summary

OAuth login silently failed to authenticate the running Starlib window on macOS. Backend logs showed successful token exchange at \`/auth/soundcloud/redirect\`, but no subsequent \`/auth/soundcloud/result\` call ever followed — meaning the token was stored server-side but never reached the frontend.

## Root cause

On macOS \`starlib://\` URLs are resolved by LaunchServices to the registered packaged \`Starlib.app\` bundle. When \`make tauri-dev\` is running, the dev binary at \`target/debug/starlib\` holds the single-instance lock but isn't an LS-registered URL handler. The URL goes to the packaged app process, which arrives via \`NSApplication application:openURLs:\` there, not in argv. The \`tauri-plugin-single-instance\` argv-forwarding path doesn't see the URL on macOS, so the dev binary's deep-link plugin never fires and the frontend listener never runs. (Supersedes #332 — my earlier argv-based fix was based on an incorrect assumption about how deep links flow on macOS.)

## Fix

Stop relying on deep links for OAuth. In Tauri mode the login page:

1. Sends \`return_to=http://127.0.0.1:8000/auth/soundcloud/done\` (new static "close this tab" endpoint).
2. Opens the SoundCloud authorize URL in the system browser.
3. Polls \`GET /auth/soundcloud/result?state=…\` every 1.5s (5-minute timeout, cancellable).
4. On first 200 response, stores tokens + routes to the library.

Browser flow (non-Tauri) is unchanged — still uses the frontend callback page.

No dependency on URL scheme registration, works identically in \`make tauri-dev\` and packaged builds, no new plugins.

## Test plan

- [x] \`uv run python -m pytest tests/\` — 147 pass
- [x] \`uv run ruff check\` / \`format --check\` — clean
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` / \`test\` / \`build\` — all green
- [ ] End-to-end: \`make tauri-dev\`, click Connect, complete OAuth in browser, verify the dev window routes to \`/library?source=soundcloud\` within ~1.5s of the browser landing on the "close this tab" page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)