### PR TITLE
feat: bulk BPM prefill + consensus analysis mode

### DIFF
--- a/desktop/src-tauri/src/bpm/soundcloud.rs
+++ b/desktop/src-tauri/src/bpm/soundcloud.rs
@@ -17,13 +17,17 @@ use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
+use super::tempo::consensus;
+use super::types::AnalysisMode;
 use super::{analyze_bytes, types::BpmOptions, types::BpmResult};
 
 const API_BASE: &str = "https://api.soundcloud.com";
-/// Window offset into the track (percent of duration). 30% lands past the
-/// intro on typical electronic tracks — matches A2's default.
-const OFFSET_PCT: f32 = 30.0;
-/// Analysis window length in seconds.
+/// Single-shot offset. 30% lands past the intro on typical electronic tracks.
+const DEFAULT_OFFSET_PCT: f32 = 30.0;
+/// Consensus-mode offsets. Catch intro-heavy, breakdown-in-middle, and
+/// outro-fade tracks by sampling spread across the body.
+const CONSENSUS_OFFSETS_PCT: &[f32] = &[25.0, 50.0, 75.0];
+/// Analysis window length in seconds (per window).
 const SNIPPET_SECONDS: f32 = 15.0;
 
 #[derive(Deserialize)]
@@ -33,15 +37,42 @@ struct StreamsResponse {
 }
 
 /// Analyze a SoundCloud track via its HLS stream and return a BPM estimate.
+///
+/// When `options.mode == Consensus`, runs the pipeline three times at
+/// different offsets through the track (25% / 50% / 75%) and returns the
+/// median — ~3× network cost, more robust against breakdowns and intro
+/// sections. Single mode (default) hits a single ~15 s window at 30%.
 pub async fn analyze_sc_track(track_id: u64, token: &str, options: &BpmOptions) -> Result<BpmResult> {
     let http = Client::builder()
         .timeout(Duration::from_secs(30))
         .build()
         .context("reqwest client build")?;
 
-    // 1. /streams → get the HLS playlist URL
+    // Resolve the playlist once; reuse across offsets in consensus mode.
+    let playlist = resolve_playlist(&http, token, track_id).await?;
+    let offsets: &[f32] = match options.mode {
+        AnalysisMode::Single => &[DEFAULT_OFFSET_PCT],
+        AnalysisMode::Consensus => CONSENSUS_OFFSETS_PCT,
+    };
+
+    let mut results = Vec::with_capacity(offsets.len());
+    for &off in offsets {
+        let raw = fetch_window_bytes(&http, &playlist, off).await?;
+        let fmt = if playlist.init_url.is_some() { "mp4" } else { "aac" };
+        results.push(analyze_bytes(&raw, Some(fmt), options)?);
+    }
+
+    if results.len() == 1 {
+        Ok(results.into_iter().next().unwrap())
+    } else {
+        consensus(&results)
+    }
+}
+
+/// Hit /streams, follow the redirect to the signed CDN m3u8, parse it.
+async fn resolve_playlist(http: &Client, token: &str, track_id: u64) -> Result<Playlist> {
     let streams_url = format!("{API_BASE}/tracks/{track_id}/streams");
-    let streams: StreamsResponse = sc_get(&http, token, &streams_url)
+    let streams: StreamsResponse = sc_get(http, token, &streams_url)
         .await?
         .json()
         .await
@@ -51,16 +82,19 @@ pub async fn analyze_sc_track(track_id: u64, token: &str, options: &BpmOptions) 
         .or(streams.hls_mp3_128_url)
         .ok_or_else(|| anyhow!("no HLS variant available for track {track_id}"))?;
 
-    // 2. Fetch the m3u8 (redirect to the signed CDN needs the OAuth header)
-    let m3u8_resp = sc_get(&http, token, &hls_url).await?;
+    let m3u8_resp = sc_get(http, token, &hls_url).await?;
     let final_url = m3u8_resp.url().clone();
     let m3u8_text = m3u8_resp.text().await.context("read m3u8 body")?;
-    let playlist = parse_m3u8(&m3u8_text, &final_url);
+    Ok(parse_m3u8(&m3u8_text, &final_url))
+}
 
-    // 3. Pick a window of segments; init.mp4 (fMP4 CMAF) is fetched alongside
-    let seg_urls = select_segments(&playlist.entries, OFFSET_PCT, SNIPPET_SECONDS);
+/// Download `init.mp4` + the segments covering a window starting at
+/// `offset_pct` of the track, concatenated into one byte buffer ready for
+/// the symphonia fMP4 decoder.
+async fn fetch_window_bytes(http: &Client, playlist: &Playlist, offset_pct: f32) -> Result<Vec<u8>> {
+    let seg_urls = select_segments(&playlist.entries, offset_pct, SNIPPET_SECONDS);
     if seg_urls.is_empty() {
-        return Err(anyhow!("no segments selected from m3u8"));
+        return Err(anyhow!("no segments selected from m3u8 at offset {offset_pct}%"));
     }
     let mut fetch_urls: Vec<String> = Vec::with_capacity(seg_urls.len() + 1);
     if let Some(init) = &playlist.init_url {
@@ -68,7 +102,6 @@ pub async fn analyze_sc_track(track_id: u64, token: &str, options: &BpmOptions) 
     }
     fetch_urls.extend(seg_urls);
 
-    // 4. Concurrent download of init + segments; concatenate the bytes
     let bodies = join_all(fetch_urls.iter().map(|u| {
         let http = http.clone();
         async move {
@@ -87,11 +120,7 @@ pub async fn analyze_sc_track(track_id: u64, token: &str, options: &BpmOptions) 
     for b in bodies {
         raw.extend(b?);
     }
-
-    // 5. Hand the bytes to the BPM pipeline. fMP4 when init.mp4 was prepended;
-    //    ADTS AAC otherwise (rare on modern SoundCloud but we fall back).
-    let fmt = if playlist.init_url.is_some() { "mp4" } else { "aac" };
-    analyze_bytes(&raw, Some(fmt), options)
+    Ok(raw)
 }
 
 // ---------- SC API helpers ----------

--- a/desktop/src-tauri/src/bpm/tempo.rs
+++ b/desktop/src-tauri/src/bpm/tempo.rs
@@ -5,11 +5,56 @@
 //! to integer-lag BPMs, and returns a confidence bucket derived from peak
 //! sharpness.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use rustfft::FftPlanner;
 use rustfft::num_complex::Complex;
 
 use super::types::{ALGORITHM_VERSION, BpmOptions, BpmResult, Confidence};
+
+/// Combine multiple single-shot BPM results into one consensus estimate.
+///
+/// Returns the median BPM. Confidence is derived from window agreement
+/// spread: High if all within ±2 BPM of the median, Medium if within ±5,
+/// else Low. `corrected_from` on the consensus result is the pre-correction
+/// median in case any octave correction was applied.
+pub fn consensus(results: &[BpmResult]) -> Result<BpmResult> {
+    if results.is_empty() {
+        return Err(anyhow!("consensus requires at least one result"));
+    }
+    let mut bpms: Vec<f32> = results.iter().map(|r| r.bpm).collect();
+    bpms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median = bpms[bpms.len() / 2];
+
+    let max_dev = bpms
+        .iter()
+        .map(|b| (b - median).abs())
+        .fold(0.0_f32, f32::max);
+    let confidence = if max_dev <= 2.0 {
+        Confidence::High
+    } else if max_dev <= 5.0 {
+        Confidence::Medium
+    } else {
+        Confidence::Low
+    };
+
+    // Consensus doesn't "correct" itself — correction already happened per
+    // window. Expose any pre-correction median for debugging if every run
+    // carries a corrected_from value.
+    let corrected_from = if results.iter().all(|r| r.corrected_from.is_some()) {
+        let mut pre: Vec<f32> = results.iter().map(|r| r.corrected_from.unwrap()).collect();
+        pre.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        Some(pre[pre.len() / 2])
+    } else {
+        None
+    };
+
+    Ok(BpmResult {
+        bpm: median,
+        confidence,
+        corrected_from,
+        algorithm_version: ALGORITHM_VERSION,
+    })
+}
 
 /// Analyse PCM samples (mono, at `sr`) and return a BPM estimate.
 pub fn analyze(samples: &[f32], sr: u32, options: &BpmOptions) -> Result<BpmResult> {
@@ -224,5 +269,44 @@ mod tests {
         let (corrected, from) = apply_octave_correction(128.0);
         assert_eq!(corrected, 128.0);
         assert_eq!(from, None);
+    }
+
+    fn result(bpm: f32) -> BpmResult {
+        BpmResult {
+            bpm,
+            confidence: Confidence::Medium,
+            corrected_from: None,
+            algorithm_version: ALGORITHM_VERSION,
+        }
+    }
+
+    #[test]
+    fn consensus_tight_cluster_is_high_confidence() {
+        let c = consensus(&[result(127.0), result(128.0), result(128.5)]).unwrap();
+        assert_eq!(c.bpm, 128.0);
+        assert_eq!(c.confidence, Confidence::High);
+    }
+
+    #[test]
+    fn consensus_moderate_spread_is_medium() {
+        let c = consensus(&[result(125.0), result(128.0), max_dev_helper()]).unwrap();
+        assert_eq!(c.bpm, 128.0);
+        assert_eq!(c.confidence, Confidence::Medium);
+    }
+
+    fn max_dev_helper() -> BpmResult {
+        result(132.0) // 4 BPM from median 128 → Medium (≤5)
+    }
+
+    #[test]
+    fn consensus_wide_spread_is_low() {
+        let c = consensus(&[result(120.0), result(128.0), result(140.0)]).unwrap();
+        assert_eq!(c.bpm, 128.0);
+        assert_eq!(c.confidence, Confidence::Low); // 12 BPM from median
+    }
+
+    #[test]
+    fn consensus_empty_errors() {
+        assert!(consensus(&[]).is_err());
     }
 }

--- a/desktop/src-tauri/src/bpm/types.rs
+++ b/desktop/src-tauri/src/bpm/types.rs
@@ -28,6 +28,20 @@ pub struct BpmResult {
     pub algorithm_version: u16,
 }
 
+/// Analysis strategy — single-shot or multi-window consensus.
+///
+/// `Consensus` runs the single-shot analyzer on three windows at 25%, 50%
+/// and 75% of the track (or the source-provided range) and returns the
+/// median, with confidence derived from agreement spread. Cost is ~3× but
+/// catches breakdowns / intro-heavy tracks where a single 15s window can
+/// land in a tempo-ambiguous section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AnalysisMode {
+    #[default]
+    Single,
+    Consensus,
+}
+
 /// Tunables for the BPM analysis pipeline.
 #[derive(Debug, Clone)]
 pub struct BpmOptions {
@@ -40,6 +54,8 @@ pub struct BpmOptions {
     pub min_bpm: f32,
     /// Maximum BPM considered during autocorrelation search.
     pub max_bpm: f32,
+    /// Single-shot vs multi-window consensus.
+    pub mode: AnalysisMode,
 }
 
 impl Default for BpmOptions {
@@ -49,6 +65,7 @@ impl Default for BpmOptions {
             target_sr: 22050,
             min_bpm: 60.0,
             max_bpm: 200.0,
+            mode: AnalysisMode::Single,
         }
     }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
+use crate::bpm::types::AnalysisMode;
 use crate::bpm::{self, BpmOptions, Confidence};
 
 /// JSON representation of a `BpmResult` across the invoke boundary.
@@ -61,8 +62,15 @@ pub async fn analyze_local_bpm(path: String) -> Result<BpmResponse, String> {
 /// command doesn't touch credentials. See
 /// ``backend/api/bpm.py::get_soundcloud_client_token``.
 #[tauri::command]
-pub async fn analyze_sc_bpm(track_id: u64, token: String) -> Result<BpmResponse, String> {
-    let options = BpmOptions::default();
+pub async fn analyze_sc_bpm(
+    track_id: u64,
+    token: String,
+    consensus: Option<bool>,
+) -> Result<BpmResponse, String> {
+    let mut options = BpmOptions::default();
+    if consensus.unwrap_or(false) {
+        options.mode = AnalysisMode::Consensus;
+    }
     let result = bpm::soundcloud::analyze_sc_track(track_id, &token, &options)
         .await
         .map_err(|e| e.to_string())?;

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -29,13 +29,16 @@ import {
   ShoppingCart,
 } from "lucide-react";
 import * as React from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   SortableColumnHeader,
   SortableHeaderCell,
 } from "@/components/columns/sortable-columns";
-import { SoundcloudBpmCell } from "@/components/soundcloud-bpm-cell";
+import {
+  SoundcloudBpmCacheContext,
+  SoundcloudBpmCell,
+} from "@/components/soundcloud-bpm-cell";
 import { SoundcloudRowPlayButton } from "@/components/soundcloud-row-play-button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -546,6 +549,38 @@ export function LikesTable({
   onVisibleOrderChange,
 }: LikesTableProps) {
   const reorderEnabled = !!onReorderTracks;
+
+  // Pre-fill cached BPMs for all tracks in this table in a single bulk
+  // request, rather than making one GET per visible row. The map survives
+  // re-renders; cells read it via SoundcloudBpmCacheContext.
+  const [bpmCache, setBpmCache] = useState<Map<number, number>>(new Map());
+  useEffect(() => {
+    const ids: number[] = [];
+    for (const t of tracks) {
+      if (t.urn) {
+        const parts = t.urn.split(":");
+        const id = parseInt(parts[parts.length - 1], 10);
+        if (id > 0) ids.push(id);
+      }
+    }
+    if (ids.length === 0) return;
+    let cancelled = false;
+    api
+      .getSoundcloudBpmsBulk(ids)
+      .then((resp) => {
+        if (cancelled) return;
+        const next = new Map<number, number>();
+        for (const [k, v] of Object.entries(resp.bpms)) next.set(Number(k), v);
+        setBpmCache(next);
+      })
+      .catch(() => {
+        /* Prefill is best-effort; cells fall back to metadata + Detect button. */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tracks]);
+
   const colVisible = React.useCallback(
     (id: string) => (isColumnVisible ? isColumnVisible(id) : true),
     [isColumnVisible],
@@ -704,201 +739,206 @@ export function LikesTable({
     });
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      {/* Header */}
-      <div
-        role="row"
-        className="border-border text-muted-foreground flex h-9 shrink-0 items-center gap-2 border-b bg-[var(--surface-2)] px-3 text-xs font-medium"
-      >
-        {reorderable && <div className="size-4 shrink-0" aria-hidden />}
+    <SoundcloudBpmCacheContext.Provider value={bpmCache}>
+      <div className="flex h-full min-h-0 flex-col">
+        {/* Header */}
         <div
-          className="flex w-6 shrink-0 items-center justify-center"
-          onClick={(e) => e.stopPropagation()}
+          role="row"
+          className="border-border text-muted-foreground flex h-9 shrink-0 items-center gap-2 border-b bg-[var(--surface-2)] px-3 text-xs font-medium"
         >
-          <Checkbox
-            checked={
-              allSelected ? true : someSelected ? "indeterminate" : false
-            }
-            onCheckedChange={(checked) =>
-              checked ? onSelectAll() : onDeselectAll()
-            }
-            aria-label="Select all"
-            className={cn(
-              "size-3.5 cursor-pointer",
-              "data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:text-primary-foreground",
-              allSelected &&
-                "data-[state=checked]:bg-primary data-[state=checked]:border-primary",
-            )}
-          />
-        </div>
-        <div className="size-8 shrink-0" />
-        <SortableColumnHeader
-          ids={visibleColumns.map((c) => c.id)}
-          onOrderChange={(nextIds) => {
-            if (!onColumnOrderChange) return;
-            const hidden = LIKES_COLUMNS.map((c) => c.id).filter(
-              (id) => !visibleColumns.some((v) => v.id === id),
-            );
-            onColumnOrderChange([...nextIds, ...hidden]);
-          }}
-        >
-          {visibleColumns.map((col) => (
-            <SortableHeaderCell
-              key={col.id}
-              id={col.id}
-              className={col.cellClassName}
-              style={{ width: col.width }}
-              onResize={(w, phase) => {
-                if (phase === "drag") {
-                  setLiveWidths((p) => ({ ...p, [col.id]: w }));
-                } else {
-                  onColumnWidthChange?.(col.id, w);
-                  setLiveWidths((p) => {
-                    const { [col.id]: _omit, ...rest } = p;
-                    return rest;
-                  });
-                }
-              }}
-              onResetWidth={() => onColumnWidthReset?.(col.id)}
-            >
-              {col.renderHeader ? (
-                col.renderHeader()
-              ) : col.sortKey ? (
-                <button
-                  className="hover:text-foreground flex w-full cursor-pointer items-center gap-0.5 transition-colors"
-                  onClick={() => col.sortKey && handleSort(col.sortKey)}
-                >
-                  {col.header}
-                  <SortIcon
-                    col={col.sortKey}
-                    sortBy={sortBy}
-                    sortOrder={sortOrder}
-                  />
-                </button>
-              ) : (
-                <span>{col.header}</span>
+          {reorderable && <div className="size-4 shrink-0" aria-hidden />}
+          <div
+            className="flex w-6 shrink-0 items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Checkbox
+              checked={
+                allSelected ? true : someSelected ? "indeterminate" : false
+              }
+              onCheckedChange={(checked) =>
+                checked ? onSelectAll() : onDeselectAll()
+              }
+              aria-label="Select all"
+              className={cn(
+                "size-3.5 cursor-pointer",
+                "data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:text-primary-foreground",
+                allSelected &&
+                  "data-[state=checked]:bg-primary data-[state=checked]:border-primary",
               )}
-            </SortableHeaderCell>
-          ))}
-        </SortableColumnHeader>
-      </div>
-
-      {/* Virtual scroll */}
-      <div
-        ref={scrollParentRef}
-        className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
-      >
-        {(() => {
-          const body = (
-            <div
-              style={{
-                height: `${virtualizer.getTotalSize()}px`,
-                position: "relative",
-              }}
-            >
-              {virtualItems.map((virtualRow) => {
-                const track = sortedTracks[virtualRow.index];
-                if (!track) return null;
-                const id = extractId(track);
-                const sortableId = reorderable
-                  ? (track.urn ?? `__idx_${virtualRow.index}`)
-                  : undefined;
-
-                return (
-                  <div
-                    key={virtualRow.key}
-                    data-index={virtualRow.index}
-                    ref={virtualizer.measureElement}
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      transform: `translateY(${virtualRow.start}px)`,
-                    }}
-                  >
-                    <TrackRow
-                      sortableId={sortableId}
-                      track={track}
-                      isSelected={selectedIds.has(id)}
-                      isExpanded={expandedId === id}
-                      inCollection={collectionIds?.has(id) ?? false}
-                      isNew={
-                        newTrackUrns
-                          ? track.urn
-                            ? newTrackUrns.has(track.urn)
-                            : false
-                          : undefined
-                      }
-                      onToggleSelect={(shiftKey) => {
-                        const currentIndex = virtualRow.index;
-                        if (shiftKey && lastSelectedIndexRef.current !== null) {
-                          const start = Math.min(
-                            lastSelectedIndexRef.current,
-                            currentIndex,
-                          );
-                          const end = Math.max(
-                            lastSelectedIndexRef.current,
-                            currentIndex,
-                          );
-                          const rangeIds = sortedTracks
-                            .slice(start, end + 1)
-                            .map(extractId)
-                            .filter(Boolean);
-                          onRangeSelect(rangeIds);
-                        } else {
-                          onToggleSelect(id);
-                          lastSelectedIndexRef.current = currentIndex;
-                        }
-                      }}
-                      onExpand={() => handleExpand(track)}
-                      visibleColumns={visibleColumns}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          );
-          if (!reorderable) return body;
-          return (
-            <DndContext
-              sensors={dndSensors}
-              collisionDetection={closestCenter}
-              onDragStart={handleReorderDragStart}
-              onDragEnd={handleReorderDragEnd}
-              onDragCancel={() => setActiveDragId(null)}
-            >
-              <SortableContext
-                items={sortableIds}
-                strategy={verticalListSortingStrategy}
+            />
+          </div>
+          <div className="size-8 shrink-0" />
+          <SortableColumnHeader
+            ids={visibleColumns.map((c) => c.id)}
+            onOrderChange={(nextIds) => {
+              if (!onColumnOrderChange) return;
+              const hidden = LIKES_COLUMNS.map((c) => c.id).filter(
+                (id) => !visibleColumns.some((v) => v.id === id),
+              );
+              onColumnOrderChange([...nextIds, ...hidden]);
+            }}
+          >
+            {visibleColumns.map((col) => (
+              <SortableHeaderCell
+                key={col.id}
+                id={col.id}
+                className={col.cellClassName}
+                style={{ width: col.width }}
+                onResize={(w, phase) => {
+                  if (phase === "drag") {
+                    setLiveWidths((p) => ({ ...p, [col.id]: w }));
+                  } else {
+                    onColumnWidthChange?.(col.id, w);
+                    setLiveWidths((p) => {
+                      const { [col.id]: _omit, ...rest } = p;
+                      return rest;
+                    });
+                  }
+                }}
+                onResetWidth={() => onColumnWidthReset?.(col.id)}
               >
-                {body}
-              </SortableContext>
-              <DragOverlay>
-                {activeDragTrack ? (
-                  <div className="bg-[var(--surface-2)] opacity-95 shadow-lg">
-                    <TrackRowInner
-                      track={activeDragTrack}
-                      isSelected={false}
-                      isExpanded={false}
-                      inCollection={false}
-                      isNew={false}
-                      onToggleSelect={() => undefined}
-                      onExpand={() => undefined}
-                      visibleColumns={visibleColumns}
-                      dragHandle={{
-                        attributes: {},
-                        listeners: undefined,
-                        isDragging: false,
-                      }}
+                {col.renderHeader ? (
+                  col.renderHeader()
+                ) : col.sortKey ? (
+                  <button
+                    className="hover:text-foreground flex w-full cursor-pointer items-center gap-0.5 transition-colors"
+                    onClick={() => col.sortKey && handleSort(col.sortKey)}
+                  >
+                    {col.header}
+                    <SortIcon
+                      col={col.sortKey}
+                      sortBy={sortBy}
+                      sortOrder={sortOrder}
                     />
-                  </div>
-                ) : null}
-              </DragOverlay>
-            </DndContext>
-          );
-        })()}
+                  </button>
+                ) : (
+                  <span>{col.header}</span>
+                )}
+              </SortableHeaderCell>
+            ))}
+          </SortableColumnHeader>
+        </div>
+
+        {/* Virtual scroll */}
+        <div
+          ref={scrollParentRef}
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
+        >
+          {(() => {
+            const body = (
+              <div
+                style={{
+                  height: `${virtualizer.getTotalSize()}px`,
+                  position: "relative",
+                }}
+              >
+                {virtualItems.map((virtualRow) => {
+                  const track = sortedTracks[virtualRow.index];
+                  if (!track) return null;
+                  const id = extractId(track);
+                  const sortableId = reorderable
+                    ? (track.urn ?? `__idx_${virtualRow.index}`)
+                    : undefined;
+
+                  return (
+                    <div
+                      key={virtualRow.key}
+                      data-index={virtualRow.index}
+                      ref={virtualizer.measureElement}
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        transform: `translateY(${virtualRow.start}px)`,
+                      }}
+                    >
+                      <TrackRow
+                        sortableId={sortableId}
+                        track={track}
+                        isSelected={selectedIds.has(id)}
+                        isExpanded={expandedId === id}
+                        inCollection={collectionIds?.has(id) ?? false}
+                        isNew={
+                          newTrackUrns
+                            ? track.urn
+                              ? newTrackUrns.has(track.urn)
+                              : false
+                            : undefined
+                        }
+                        onToggleSelect={(shiftKey) => {
+                          const currentIndex = virtualRow.index;
+                          if (
+                            shiftKey &&
+                            lastSelectedIndexRef.current !== null
+                          ) {
+                            const start = Math.min(
+                              lastSelectedIndexRef.current,
+                              currentIndex,
+                            );
+                            const end = Math.max(
+                              lastSelectedIndexRef.current,
+                              currentIndex,
+                            );
+                            const rangeIds = sortedTracks
+                              .slice(start, end + 1)
+                              .map(extractId)
+                              .filter(Boolean);
+                            onRangeSelect(rangeIds);
+                          } else {
+                            onToggleSelect(id);
+                            lastSelectedIndexRef.current = currentIndex;
+                          }
+                        }}
+                        onExpand={() => handleExpand(track)}
+                        visibleColumns={visibleColumns}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            );
+            if (!reorderable) return body;
+            return (
+              <DndContext
+                sensors={dndSensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleReorderDragStart}
+                onDragEnd={handleReorderDragEnd}
+                onDragCancel={() => setActiveDragId(null)}
+              >
+                <SortableContext
+                  items={sortableIds}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {body}
+                </SortableContext>
+                <DragOverlay>
+                  {activeDragTrack ? (
+                    <div className="bg-[var(--surface-2)] opacity-95 shadow-lg">
+                      <TrackRowInner
+                        track={activeDragTrack}
+                        isSelected={false}
+                        isExpanded={false}
+                        inCollection={false}
+                        isNew={false}
+                        onToggleSelect={() => undefined}
+                        onExpand={() => undefined}
+                        visibleColumns={visibleColumns}
+                        dragHandle={{
+                          attributes: {},
+                          listeners: undefined,
+                          isDragging: false,
+                        }}
+                      />
+                    </div>
+                  ) : null}
+                </DragOverlay>
+              </DndContext>
+            );
+          })()}
+        </div>
       </div>
-    </div>
+    </SoundcloudBpmCacheContext.Provider>
   );
 }

--- a/frontend/src/components/soundcloud-bpm-cell.tsx
+++ b/frontend/src/components/soundcloud-bpm-cell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Loader2, Waves } from "lucide-react";
-import { useState } from "react";
+import React, { useContext, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,14 @@ interface Props {
   /** SoundCloud-metadata BPM from the track object; often null for user uploads. */
   metadataBpm: number | null | undefined;
 }
+
+/** Lookup table of track_id → cached BPM, provided by the table that pre-fills
+ * the page's visible rows in one bulk call (see likes-table.tsx). A null value
+ * means "pre-fill attempted but no row in the cache"; an entry missing
+ * entirely means pre-fill hasn't resolved yet. */
+export const SoundcloudBpmCacheContext = React.createContext<
+  Map<number, number>
+>(new Map());
 
 /** BPM cell for SoundCloud library rows.
  *
@@ -26,8 +34,10 @@ interface Props {
 export function SoundcloudBpmCell({ trackId, metadataBpm }: Props) {
   const [analyzedBpm, setAnalyzedBpm] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
+  const bpmCache = useContext(SoundcloudBpmCacheContext);
 
-  const displayBpm = analyzedBpm ?? metadataBpm ?? null;
+  const cachedBpm = bpmCache.get(trackId);
+  const displayBpm = analyzedBpm ?? cachedBpm ?? metadataBpm ?? null;
 
   async function handleAnalyze() {
     if (!isTauri() || !trackId || loading) return;


### PR DESCRIPTION
## Summary

Two orthogonal follow-ups to #334 (SoundCloud BPM). Targets \`feat/soundcloud-bpm\` so they land together; merge into main after #334.

### 1. Bulk prefill in the Likes table

Cells in the new BPM column currently show \`—\` + Detect button until the user clicks, even when the backend already has a cached result from a previous session. This PR wires \`POST /api/bpm/soundcloud/bulk\` (added in #334 but not hooked up) into \`LikesTable\`: one call on mount builds a \`Map<track_id, bpm>\`, delivered to cells via a new \`SoundcloudBpmCacheContext\`. Precedence tier remains session-analyzed > cache > metadata > Detect, so analyzing a track still instantly updates its own row.

Failures are swallowed — prefill is best-effort; cells gracefully degrade to metadata + Detect.

### 2. Consensus analysis mode

\`AnalysisMode::Consensus\` runs the single-shot analyzer at 25% / 50% / 75% offsets and returns the median BPM. Confidence is derived from spread:

- max deviation ≤ 2 BPM → High
- ≤ 5 BPM → Medium
- \> 5 BPM → Low

The SC pipeline reuses the playlist resolve for all three windows so only the segment downloads triple — ~1s single-shot → ~2.5s consensus. Exposed via an optional \`consensus: bool\` flag on \`analyze_sc_bpm\`. Single mode remains default. The accuracy sprint will wire the flag into the UI.

4 new Rust unit tests cover the consensus combinator (tight / medium / wide spread, empty error).

### Separately on #334

Pushed a small refactor commit to the base branch that drops \`algorithm_version\` from the \`soundcloud_track_bpm\` schema. Invalidating the cache on algorithm changes is simpler as a future alembic migration (\`DELETE FROM soundcloud_track_bpm\`) than runtime version comparison.

## Test plan

- [x] \`cargo test --lib --release\` — 13/13 pass (9 A1/A3 + 4 new consensus)
- [x] \`uv run python -m pytest tests/\` — 154 pass
- [x] \`uv run ruff\` / \`npm run lint\` / \`typecheck\` / \`format:check\` / \`test\` / \`build\` — all green
- [ ] Live: open \`/library?source=soundcloud\` — BPMs already in the cache should populate the column immediately on render, without per-row clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)