### PR TITLE
fix(db): drop algorithm_version via migration 0004

### DIFF
--- a/backend/alembic/versions/0003_soundcloud_track_bpm.py
+++ b/backend/alembic/versions/0003_soundcloud_track_bpm.py
@@ -23,10 +23,15 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Note: `algorithm_version` is dropped by 0004. Kept here so this matches
+    # what actually shipped to dev machines at 0003-head — rewriting history
+    # would leave those installs with a column the current chain doesn't
+    # know how to remove.
     op.create_table(
         "soundcloud_track_bpm",
         sa.Column("track_id", sa.Integer(), primary_key=True, nullable=False),
         sa.Column("bpm", sa.Integer(), nullable=False),
+        sa.Column("algorithm_version", sa.Integer(), nullable=False),
         sa.Column("analyzed_at", sa.Float(), nullable=False),
     )
 

--- a/backend/alembic/versions/0004_drop_algorithm_version.py
+++ b/backend/alembic/versions/0004_drop_algorithm_version.py
@@ -1,0 +1,40 @@
+"""Drop ``algorithm_version`` from ``soundcloud_track_bpm``.
+
+The column was dropped from the model/schema after 0003 landed on dev
+machines, but alembic only applies revisions once — installed DBs still
+carry the column with its NOT NULL constraint, which breaks inserts from
+the simplified ``upsert_sc_bpm`` helper. Rebuild the table without it.
+
+Cache invalidation on future algorithm changes will be done by an explicit
+``DELETE FROM soundcloud_track_bpm`` migration, not a per-row column.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-21
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: str = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # SQLite doesn't support DROP COLUMN before 3.35; alembic's batch_alter_table
+    # does the safe rebuild-and-swap dance under the hood.
+    with op.batch_alter_table("soundcloud_track_bpm") as batch_op:
+        batch_op.drop_column("algorithm_version")
+
+
+def downgrade() -> None:
+    # Re-add the column as nullable; data is not recoverable.
+    with op.batch_alter_table("soundcloud_track_bpm") as batch_op:
+        batch_op.add_column(sa.Column("algorithm_version", sa.Integer(), nullable=True))

--- a/tests/test_cache_db_migrations.py
+++ b/tests/test_cache_db_migrations.py
@@ -47,7 +47,7 @@ def _cols(db: Path, table: str) -> set[str]:
 def test_fresh_db_upgrades_to_head(tmp_path: Path) -> None:
     db = tmp_path / "cache.db"
     cache_db.init_db(db)
-    assert _rev(db) == "0003"
+    assert _rev(db) == "0004"
     assert {"tracks", "peaks", "alembic_version"} <= _tables(db)
 
 
@@ -108,7 +108,7 @@ def test_legacy_db_bootstrap_then_head(tmp_path: Path) -> None:
         "duration",
     ):
         assert col in tracks_cols, f"missing column after bootstrap: {col}"
-    assert _rev(db) == "0003"
+    assert _rev(db) == "0004"
 
 
 def test_backup_created_on_bootstrap(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes a migration-skew bug that breaks SoundCloud BPM persistence for anyone who applied migration \`0003\` before #334 merged.

## Root cause

A refactor commit on the #334 branch dropped \`algorithm_version\` from the model and silently modified the \`0003\` migration to no longer create the column. For **fresh** DBs this works: \`0003\` creates the table without the column. For **existing** dev DBs that had already applied the original \`0003\` (which DID include \`algorithm_version NOT NULL\`), the column stays — and the new \`upsert_sc_bpm\` no longer supplies it, so inserts fail with:

\`\`\`
sqlalchemy.exc.IntegrityError: NOT NULL constraint failed: soundcloud_track_bpm.algorithm_version
\`\`\`

Alembic only tracks revision IDs, not content, so rewriting \`0003\` after it had already shipped was the wrong move.

## Fix

- Restore \`0003\` to match what actually shipped (create the column, \`NOT NULL\`).
- Add \`0004\` that drops the column via \`batch_alter_table\` (SQLite's safe rebuild-and-swap pattern, since \`ALTER TABLE DROP COLUMN\` isn't supported before 3.35).
- Bump migration test assertions from \`0003\` → \`0004\`.

After this lands users will re-run migrations on next launch and the column disappears from their DB automatically. No data loss.

## Test plan

- [x] \`uv run python -m pytest tests/\` — 158 pass
- [x] Verified against a live dev DB: post-\`0004\` columns are \`track_id, bpm, analyzed_at\` and \`alembic_version\` is at \`0004\`.
- [ ] Merge + restart the app, click Detect on a SC track, confirm the previously-failing INSERT now succeeds.

## Process note for future PRs

Once a migration has shipped beyond the author's machine, treat its \`upgrade()\` body as immutable history. Schema changes go in a new revision, always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)