### PR TITLE
fix(bpm): enable symphonia aiff + alac codec features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,6 +4412,7 @@ dependencies = [
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
  "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
@@ -4462,6 +4463,16 @@ name = "symphonia-codec-adpcm"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
 dependencies = [
  "log",
  "symphonia-core",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1", features = ["time"] }
-symphonia = { version = "0.5", features = ["aac", "isomp4", "mp3", "flac", "wav", "vorbis"] }
+symphonia = { version = "0.5", features = ["aac", "aiff", "alac", "isomp4", "mp3", "flac", "wav", "vorbis"] }
 rustfft = "6"
 anyhow = "1"
 futures = "0.3"


### PR DESCRIPTION
## Summary

Clicking Detect on an \`.aiff\` file produced:

\`\`\`
symphonia::core::errors::Error: probe failed
\`\`\`

Root cause: the symphonia dep enabled \`aac\`, \`isomp4\`, \`mp3\`, \`flac\`, \`wav\`, \`vorbis\` — but not \`aiff\`. Symphonia's format probe only recognises enabled containers, so AIFF files get rejected before a decoder is even attempted.

## Fix

Add \`aiff\` and \`alac\` to the feature list. Both are common in DJ libraries:

- **AIFF** — uncompressed studio exports (the failing case)
- **ALAC** — Apple Lossless, dominant in iTunes/Music.app exports

Binary-size impact is negligible — each codec decoder adds a few KB.

## Test plan

- [x] \`cargo build\` / \`cargo test --lib --release\` — 11 tests pass
- [ ] Click Detect on an \`.aiff\` track, confirm a real BPM comes back (no more probe-failed).
- [ ] Same for an \`.m4a\`/ALAC track if you have one around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)