### PR TITLE
fix(bpm): Rust core correctness & robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,6 +4319,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "thiserror 1.0.69",
  "tokio",
  "url",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -30,7 +30,8 @@ dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["json"] }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "sync"] }
+thiserror = "1"
 symphonia = { version = "0.5", features = ["aac", "aiff", "alac", "isomp4", "mp3", "flac", "wav", "vorbis"] }
 rustfft = "6"
 anyhow = "1"

--- a/desktop/src-tauri/src/bpm/decode.rs
+++ b/desktop/src-tauri/src/bpm/decode.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::Cursor;
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::DecoderOptions;
 use symphonia::core::errors::Error as SymphError;
@@ -18,7 +18,7 @@ use symphonia::core::io::{MediaSource, MediaSourceStream};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
-use super::types::BpmOptions;
+use super::types::{BpmError, BpmOptions};
 
 /// Decode in-memory audio bytes to mono f32 PCM at `options.target_sr`.
 ///
@@ -60,7 +60,12 @@ fn decode_from_source(
         .default_track()
         .ok_or_else(|| anyhow!("no default audio track"))?;
     let track_id = track.id;
-    let src_sr = track.codec_params.sample_rate.unwrap_or(44100);
+    // Refuse to guess: a missing sample rate would silently corrupt tempo
+    // detection (lag-to-BPM mapping is sample-rate dependent).
+    let src_sr = track
+        .codec_params
+        .sample_rate
+        .ok_or(BpmError::MissingSampleRate)?;
     let mut decoder = symphonia::default::get_codecs()
         .make(&track.codec_params, &DecoderOptions::default())
         .context("decoder init failed")?;

--- a/desktop/src-tauri/src/bpm/local.rs
+++ b/desktop/src-tauri/src/bpm/local.rs
@@ -7,12 +7,21 @@
 
 use std::path::Path;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 
 use super::tempo::consensus;
 use super::types::AnalysisMode;
 use super::{decode, tempo, types::BpmOptions, types::BpmResult};
 
+/// Offsets (as percent of track length) used in consensus mode.
+///
+/// Consensus mode is a *robustness* technique, not a precision one: by
+/// sampling three windows spaced across the track and taking the median,
+/// we avoid landing entirely inside a breakdown / intro / outro and
+/// reporting that section's tempo (or none at all). It does **not** produce
+/// a higher-resolution BPM value than single-shot — the per-window estimator
+/// is the same code path, and the final answer is one of the three window
+/// medians, not an average.
 const CONSENSUS_OFFSETS_PCT: &[f32] = &[25.0, 50.0, 75.0];
 
 /// Analyse a snippet of `path` and return a BPM estimate.
@@ -100,7 +109,7 @@ mod tests {
         f.write_all(&byte_rate.to_le_bytes()).unwrap();
         f.write_all(&2u16.to_le_bytes()).unwrap(); // block align
         f.write_all(&16u16.to_le_bytes()).unwrap(); // bits per sample
-        // data chunk
+                                                    // data chunk
         f.write_all(b"data").unwrap();
         f.write_all(&data_size.to_le_bytes()).unwrap();
         for s in samples {

--- a/desktop/src-tauri/src/bpm/soundcloud.rs
+++ b/desktop/src-tauri/src/bpm/soundcloud.rs
@@ -144,7 +144,7 @@ async fn sc_get(http: &Client, token: &str, url: &str) -> Result<reqwest::Respon
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    unreachable!()
+    Err(anyhow!("sc_get exhausted retries without returning"))
 }
 
 // ---------- m3u8 parsing ----------

--- a/desktop/src-tauri/src/bpm/tempo.rs
+++ b/desktop/src-tauri/src/bpm/tempo.rs
@@ -5,11 +5,11 @@
 //! to integer-lag BPMs, and returns a confidence bucket derived from peak
 //! sharpness.
 
-use anyhow::{Result, anyhow};
-use rustfft::FftPlanner;
+use anyhow::{anyhow, Result};
 use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
 
-use super::types::{ALGORITHM_VERSION, BpmOptions, BpmResult, Confidence};
+use super::types::{BpmError, BpmOptions, BpmResult, Confidence, ALGORITHM_VERSION};
 
 /// Combine multiple single-shot BPM results into one consensus estimate.
 ///
@@ -58,17 +58,21 @@ pub fn consensus(results: &[BpmResult]) -> Result<BpmResult> {
 
 /// Analyse PCM samples (mono, at `sr`) and return a BPM estimate.
 pub fn analyze(samples: &[f32], sr: u32, options: &BpmOptions) -> Result<BpmResult> {
+    // Need enough samples to run at least a couple of STFT frames
+    // (win=2048, hop=512) and leave room for autocorrelation lags.
     if samples.len() < 4096 {
-        return Ok(BpmResult {
-            bpm: 0.0,
-            confidence: Confidence::Low,
-            corrected_from: None,
-            algorithm_version: ALGORITHM_VERSION,
-        });
+        return Err(BpmError::InsufficientData(format!(
+            "need at least 4096 PCM samples for STFT, got {}",
+            samples.len()
+        ))
+        .into());
     }
 
-    let onset = spectral_flux_onset(samples);
-    let (raw_bpm, peak_ratio) = autocorrelate_bpm(&onset, sr, options);
+    let onset = spectral_flux_onset(samples)?;
+    if onset.iter().all(|&v| v == 0.0) {
+        return Err(BpmError::SilentInput.into());
+    }
+    let (raw_bpm, peak_ratio) = autocorrelate_bpm(&onset, sr, options)?;
 
     let confidence = if peak_ratio >= 3.0 {
         Confidence::High
@@ -94,9 +98,24 @@ pub fn analyze(samples: &[f32], sr: u32, options: &BpmOptions) -> Result<BpmResu
 
 /// Spectral-flux onset envelope: STFT magnitude differences (positive only),
 /// mean-subtracted and half-wave rectified.
-fn spectral_flux_onset(samples: &[f32]) -> Vec<f32> {
+///
+/// The 2048-sample window / 512-sample hop combo is the usual MIR default:
+/// at the pipeline's target sample rate of 22050 Hz this gives ~93 ms frames
+/// with ~23 ms steps (43 Hz frame rate) — fine-grained enough to catch
+/// percussive onsets while keeping FFT cost low. If `BpmOptions::target_sr`
+/// changes, revisit these constants.
+fn spectral_flux_onset(samples: &[f32]) -> Result<Vec<f32>> {
     let win = 2048usize;
     let hop = 512usize;
+
+    if samples.len() < win + hop {
+        return Err(BpmError::InsufficientData(format!(
+            "spectral-flux needs at least {} samples, got {}",
+            win + hop,
+            samples.len()
+        ))
+        .into());
+    }
 
     let hann: Vec<f32> = (0..win)
         .map(|i| 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / win as f32).cos())
@@ -133,21 +152,32 @@ fn spectral_flux_onset(samples: &[f32]) -> Vec<f32> {
     }
 
     let mean = flux.iter().sum::<f32>() / flux.len().max(1) as f32;
-    flux.iter().map(|v| (v - mean).max(0.0)).collect()
+    Ok(flux.iter().map(|v| (v - mean).max(0.0)).collect())
 }
 
 /// Autocorrelation over the onset envelope. Returns `(bpm, peak_ratio)` where
 /// `peak_ratio` is the peak autocorrelation score divided by the median over
 /// the searched lag range (used for confidence).
-fn autocorrelate_bpm(onset: &[f32], sr: u32, options: &BpmOptions) -> (f32, f32) {
+fn autocorrelate_bpm(onset: &[f32], sr: u32, options: &BpmOptions) -> Result<(f32, f32)> {
     let hop = 512usize;
     let frame_rate = sr as f32 / hop as f32;
     let min_lag = (frame_rate * 60.0 / options.max_bpm) as usize;
     let max_lag = (frame_rate * 60.0 / options.min_bpm) as usize;
 
     let n = onset.len();
-    if n <= max_lag + 2 || min_lag < 2 {
-        return (0.0, 0.0);
+    if min_lag < 2 {
+        return Err(BpmError::InsufficientData(format!(
+            "min_lag={min_lag} < 2; max_bpm={} too high for frame_rate={frame_rate}",
+            options.max_bpm
+        ))
+        .into());
+    }
+    if n <= max_lag + 2 {
+        return Err(BpmError::InsufficientData(format!(
+            "onset envelope ({n} frames) shorter than max_lag+2 ({})",
+            max_lag + 2
+        ))
+        .into());
     }
 
     // Classic autocorrelation. We need lags [min_lag - 1, max_lag + 1]
@@ -189,7 +219,7 @@ fn autocorrelate_bpm(onset: &[f32], sr: u32, options: &BpmOptions) -> (f32, f32)
     let median = search[search.len() / 2].max(1e-9);
     let peak_ratio = best_score / median;
 
-    (bpm, peak_ratio)
+    Ok((bpm, peak_ratio))
 }
 
 /// Parabolic peak interpolation for three adjacent samples `y0, y1, y2`

--- a/desktop/src-tauri/src/bpm/types.rs
+++ b/desktop/src-tauri/src/bpm/types.rs
@@ -1,8 +1,30 @@
 //! Public types for the BPM analysis module.
 
+use thiserror::Error;
+
 /// Current algorithm version. Bump when the analysis pipeline changes
 /// in a way that would produce different BPM values for the same input.
 pub const ALGORITHM_VERSION: u16 = 1;
+
+/// Typed errors produced by the BPM analysis pipeline.
+///
+/// These cover cases that were previously either swallowed (returning a
+/// zero-BPM `Low`-confidence result) or paved over with a silent default.
+/// Surface them to the caller so bad inputs don't masquerade as valid
+/// analysis results.
+#[derive(Debug, Error)]
+pub enum BpmError {
+    /// PCM buffer is too short to run the STFT / autocorrelation stages.
+    #[error("insufficient data for BPM analysis: {0}")]
+    InsufficientData(String),
+    /// The onset envelope is all zeros — the signal is silent or lacks any
+    /// detectable spectral change across frames.
+    #[error("silent or featureless input: onset envelope is all zeros")]
+    SilentInput,
+    /// The decoded track carries no sample-rate metadata. We refuse to guess.
+    #[error("decoded track is missing sample-rate metadata")]
+    MissingSampleRate,
+}
 
 /// Confidence bucket for a BPM estimate.
 ///

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -5,11 +5,28 @@
 //! underlying modules.
 
 use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
 
 use serde::Serialize;
+use tokio::sync::Semaphore;
 
 use crate::bpm::types::AnalysisMode;
 use crate::bpm::{self, BpmOptions, Confidence};
+
+/// Global bound on concurrent blocking BPM analysis tasks.
+///
+/// Tauri's `spawn_blocking` pool is shared with the rest of the app; without
+/// a bound a bulk-analyze run would flood it. Size the semaphore to logical
+/// CPU count so we saturate cores without starving other blocking work.
+fn analysis_semaphore() -> &'static Arc<Semaphore> {
+    static SEM: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    SEM.get_or_init(|| {
+        let n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+        Arc::new(Semaphore::new(n))
+    })
+}
 
 /// JSON representation of a `BpmResult` across the invoke boundary.
 #[derive(Serialize)]
@@ -44,12 +61,27 @@ fn to_response(r: bpm::BpmResult) -> BpmResponse {
 /// Runs synchronously on a blocking thread (the decode + analyze together
 /// take ~50 ms on a typical track); Tauri invoke handlers can be called from
 /// async contexts so no extra wrapper is needed for responsiveness.
+///
+/// # Parameters
+/// - `consensus`: when `true`, run the analyzer on three windows spaced
+///   across the track (25% / 50% / 75%) and take the median. This is a
+///   **robustness** toggle — it protects against intro/breakdown/outro
+///   sections that would mislead a single-window read — not a precision
+///   toggle. Per-window analysis uses the same algorithm either way.
+///   Costs roughly 3× CPU for the analyze step (decode only runs once).
+///   Param name is part of the wire contract; see the frontend `invoke` call.
 #[tauri::command]
 pub async fn analyze_local_bpm(
     path: String,
     consensus: Option<bool>,
 ) -> Result<BpmResponse, String> {
+    let sem = analysis_semaphore().clone();
+    let _permit = sem
+        .acquire_owned()
+        .await
+        .map_err(|e| format!("analysis semaphore closed: {e}"))?;
     tauri::async_runtime::spawn_blocking(move || {
+        let _permit = _permit; // hold across the blocking work
         let mut options = BpmOptions::default();
         if consensus.unwrap_or(false) {
             options.mode = AnalysisMode::Consensus;

--- a/desktop/src-tauri/tests/bpm.rs
+++ b/desktop/src-tauri/tests/bpm.rs
@@ -3,7 +3,9 @@
 //! These exercise `starlib_lib::bpm::analyze_samples` on synthetic click
 //! tracks at known tempos and verify the estimated BPM is within ±1.0 BPM.
 
-use starlib_lib::bpm::{BpmOptions, analyze_samples};
+use starlib_lib::bpm::local::analyze_local_file;
+use starlib_lib::bpm::types::AnalysisMode;
+use starlib_lib::bpm::{analyze_samples, BpmOptions};
 
 /// Build a mono click track at `bpm` for `duration_s` seconds at `sr` Hz.
 /// Each click is a short exponentially-decaying impulse — a decent stand-in
@@ -62,6 +64,82 @@ fn click_track_140_bpm() {
     let opts = BpmOptions::default();
     let result = analyze_samples(&samples, sr, &opts).unwrap();
     assert_bpm_close(result.bpm, 140.0, 1.0);
+}
+
+/// Write a mono 16-bit PCM WAV with `samples` at `sr` Hz.
+fn write_wav(path: &std::path::Path, samples: &[f32], sr: u32) {
+    use std::fs::File;
+    use std::io::Write;
+    let mut f = File::create(path).expect("create wav");
+    let n = samples.len();
+    let byte_rate = sr * 2; // 16-bit mono
+    let data_size = (n * 2) as u32;
+    let chunk_size = 36 + data_size;
+    f.write_all(b"RIFF").unwrap();
+    f.write_all(&chunk_size.to_le_bytes()).unwrap();
+    f.write_all(b"WAVE").unwrap();
+    f.write_all(b"fmt ").unwrap();
+    f.write_all(&16u32.to_le_bytes()).unwrap();
+    f.write_all(&1u16.to_le_bytes()).unwrap();
+    f.write_all(&1u16.to_le_bytes()).unwrap();
+    f.write_all(&sr.to_le_bytes()).unwrap();
+    f.write_all(&byte_rate.to_le_bytes()).unwrap();
+    f.write_all(&2u16.to_le_bytes()).unwrap();
+    f.write_all(&16u16.to_le_bytes()).unwrap();
+    f.write_all(b"data").unwrap();
+    f.write_all(&data_size.to_le_bytes()).unwrap();
+    for s in samples {
+        let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        f.write_all(&v.to_le_bytes()).unwrap();
+    }
+}
+
+#[test]
+fn consensus_mode_survives_middle_breakdown() {
+    // Build a 60-second 128 BPM track where the middle 20s is silent
+    // (breakdown). Single-window analysis landing at 50% would see silence;
+    // consensus samples 25/50/75, median rescues the real tempo.
+    let sr = 22050u32;
+    let bpm = 128.0_f32;
+    let total_s = 60.0_f32;
+    let mut samples = click_track(bpm, total_s, sr);
+    // Insert ghost notes (half-amplitude off-beat) across the full track
+    // to exercise the "tempo breakdown / ghost notes" scenario.
+    let period_samples = (60.0 / bpm * sr as f32) as usize;
+    let half_offset = period_samples / 2;
+    let click_len = (sr as f32 * 0.02) as usize;
+    let total = samples.len();
+    let mut t = 0usize;
+    while t + half_offset < total {
+        let start = t + half_offset;
+        for i in 0..click_len {
+            let idx = start + i;
+            if idx >= total {
+                break;
+            }
+            let env = 0.4 * (-5.0 * i as f32 / click_len as f32).exp();
+            samples[idx] += env;
+        }
+        t += period_samples;
+    }
+    // Zero out the middle 20 s (breakdown).
+    let mid_start = (20.0 * sr as f32) as usize;
+    let mid_end = (40.0 * sr as f32) as usize;
+    for v in &mut samples[mid_start..mid_end] {
+        *v = 0.0;
+    }
+
+    let dir = std::env::temp_dir().join("starlib-bpm-consensus-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("breakdown_128.wav");
+    write_wav(&path, &samples, sr);
+
+    let opts = BpmOptions {
+        mode: AnalysisMode::Consensus,
+        ..BpmOptions::default()
+    };
+    let result = analyze_local_file(&path, 30.0, 15.0, &opts).unwrap();
+    assert_bpm_close(result.bpm, 128.0, 1.5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Tightens the Rust BPM core so marginal / malformed inputs fail loudly instead of silently returning bad data, and bounds concurrent analysis.

### Changes

- **Typed errors** — `src/bpm/types.rs`: new `BpmError` enum (`InsufficientData`, `SilentInput`, `MissingSampleRate`) via `thiserror`. Surfaced from `tempo.rs` and `decode.rs`.
- **Boundary guards in tempo detection** — `src/bpm/tempo.rs:60-75, 107-118, 161-181`: explicit length checks on the spectral-flux frame loop and autocorrelation lag range. Returns `InsufficientData` with context instead of best-effort OOB math or `(0.0, 0.0)` sentinels.
- **Silent-input detection** — `src/bpm/tempo.rs:72-74`: all-zero onset envelope now returns `BpmError::SilentInput`, not `bpm=0, confidence=Low`.
- **No sample-rate fallback** — `src/bpm/decode.rs:65-68`: replaces `track.codec_params.sample_rate.unwrap_or(44100)` with `BpmError::MissingSampleRate`. Silent 44.1 kHz guess would corrupt lag→BPM mapping.
- **`unreachable!()` → `Err`** — `src/bpm/soundcloud.rs:147`: retry loop falls through to `anyhow!("sc_get exhausted retries without returning")`.
- **Bounded `spawn_blocking`** — `src/commands.rs`: global `OnceLock<Arc<Semaphore>>` sized by `std::thread::available_parallelism()`; permit acquired before `spawn_blocking` and held across the blocking call. Prevents a bulk-analyze run from flooding the Tauri blocking pool.
- **Consensus-mode docs** — `src/bpm/local.rs:16-25`, `src/commands.rs:64-72`: clarify consensus is a *robustness* (median-of-3-windows) technique, not a precision one. Wire param name `consensus` unchanged (PR 3 updates UI copy).
- **FFT window/hop note** — `src/bpm/tempo.rs:99-106`: documents the 2048/512 choice and `target_sr=22050` assumption.
- **Consensus test** — `tests/bpm.rs::consensus_mode_survives_middle_breakdown`: synthesizes a 60 s 128 BPM click track with off-beat ghost notes and a silent 20 s middle breakdown; asserts `AnalysisMode::Consensus` recovers 128 BPM within ±1.5.

### Out of scope / skipped

- `cargo fmt --check` and `cargo clippy -- -D warnings` fail on pre-existing drift in `src/lib.rs` (unrelated `needless_borrow` lint and multiline formatting). Not touching that file per PR lane discipline. All files I touched are clippy-clean and rustfmt-clean.

## Test plan

- [x] `cargo build` in `desktop/src-tauri/`
- [x] `cargo test` — 15 unit + 5 integration tests pass (including new consensus test)
- [x] `cargo clippy --tests` — zero warnings on BPM-touched files
- [ ] Smoke-test local `analyze_local_bpm` from the desktop UI
- [ ] Smoke-test SoundCloud `analyze_sc_bpm` end-to-end (retry path)