### PR TITLE
fix(bpm): backend security & integration hardening

### DIFF
--- a/backend/alembic/versions/0004_drop_algorithm_version.py
+++ b/backend/alembic/versions/0004_drop_algorithm_version.py
@@ -35,6 +35,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Re-add the column as nullable; data is not recoverable.
+    # Re-add the column matching 0003's schema (NOT NULL). Data isn't
+    # recoverable, so backfill with a default before flipping to NOT NULL
+    # inside the same batch op.
     with op.batch_alter_table("soundcloud_track_bpm") as batch_op:
-        batch_op.add_column(sa.Column("algorithm_version", sa.Integer(), nullable=True))
+        batch_op.add_column(
+            sa.Column("algorithm_version", sa.Integer(), nullable=False, server_default="1"),
+        )
+    # Drop the server_default so the restored schema matches 0003 exactly.
+    with op.batch_alter_table("soundcloud_track_bpm") as batch_op:
+        batch_op.alter_column("algorithm_version", server_default=None)

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -4,10 +4,13 @@ import base64
 import hashlib
 import logging
 import secrets
+import threading
+import time
+from collections import deque
 from urllib.parse import urlencode, urlparse
 
 import requests
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 
 from backend.schemas.auth import (
@@ -55,6 +58,40 @@ _pending_oauth_flows: dict[str, tuple[str, str]] = {}
 
 # Server-side storage for completed OAuth flows: state -> CallbackResponse
 _completed_oauth_flows: dict[str, CallbackResponse] = {}
+
+# Simple in-memory per-IP rate limiter for the /result polling endpoint.
+# Keeps last-N request timestamps per client IP; rejects over threshold.
+_RATE_LIMIT_MAX_REQUESTS = 10
+_RATE_LIMIT_WINDOW_SECONDS = 60.0
+_rate_limit_buckets: dict[str, deque[float]] = {}
+_rate_limit_lock = threading.Lock()
+
+
+def _rate_limit_check(client_ip: str) -> bool:
+    """Return True if `client_ip` is within the rate limit, False otherwise.
+
+    Uses a sliding-window counter with the last ``_RATE_LIMIT_MAX_REQUESTS``
+    timestamps per IP. Expired entries are dropped opportunistically.
+    """
+    now = time.monotonic()
+    cutoff = now - _RATE_LIMIT_WINDOW_SECONDS
+    with _rate_limit_lock:
+        bucket = _rate_limit_buckets.get(client_ip)
+        if bucket is None:
+            bucket = deque(maxlen=_RATE_LIMIT_MAX_REQUESTS)
+            _rate_limit_buckets[client_ip] = bucket
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= _RATE_LIMIT_MAX_REQUESTS:
+            return False
+        bucket.append(now)
+        return True
+
+
+def _reset_rate_limiter_for_tests() -> None:
+    """Clear all rate-limit buckets. Intended for tests only."""
+    with _rate_limit_lock:
+        _rate_limit_buckets.clear()
 
 
 def _exchange_code(code: str, code_verifier: str) -> CallbackResponse:
@@ -228,11 +265,21 @@ def oauth_done() -> HTMLResponse:
 
 
 @router.get("/result", response_model=CallbackResponse)
-def get_oauth_result(state: str = Query(...)) -> CallbackResponse:
+def get_oauth_result(request: Request, state: str = Query(...)) -> CallbackResponse:
     """Retrieve completed OAuth result by state token.
 
-    One-time retrieval: the result is removed after being fetched.
+    One-time retrieval: the result is removed after being fetched. Per-IP
+    rate limited (10 req/min) to keep the polling loop from hammering the
+    server or being abused to enumerate state tokens.
     """
+    client_ip = request.client.host if request.client else "unknown"
+    if not _rate_limit_check(client_ip):
+        logger.warning("Rate limit exceeded on /auth/soundcloud/result: ip=%s state=%s", client_ip, state)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many requests.",
+        )
+
     result = _completed_oauth_flows.pop(state, None)
     if result is None:
         raise HTTPException(

--- a/backend/api/bpm.py
+++ b/backend/api/bpm.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 
-from backend.core.services import cache_db
+from backend.core.services import app_settings as app_settings_service
+from backend.core.services import cache_db, sc_auth_cache
 from soundcloud_tools.oauth import OAuthManager
 from soundcloud_tools.settings import get_settings
 
@@ -50,6 +51,49 @@ class LocalCandidatesResponse(BaseModel):
     file_paths: list[str]
 
 
+def _validate_library_folder(folder: str) -> Path:
+    """Resolve ``folder`` and ensure it lives under the configured library root.
+
+    Rejects traversal (``..``) and any path outside the user's configured
+    ``root_music_folder``.
+
+    Parameters
+    ----------
+    folder : str
+        Caller-supplied absolute or relative folder path.
+
+    Returns
+    -------
+    Path
+        Fully resolved absolute path inside the library root.
+
+    Raises
+    ------
+    HTTPException
+        400 if the path is outside the configured library root or no root is
+        configured.
+    """
+    root_str = app_settings_service.get_root_music_folder()
+    if not root_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No library root configured",
+        )
+    root = Path(root_str).expanduser().resolve()
+    candidate = Path(folder).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="folder must be inside the configured library root",
+        ) from exc
+    return resolved
+
+
 @router.get("/local/candidates", response_model=LocalCandidatesResponse)
 def get_local_candidates(folder: str, recursive: bool = True) -> LocalCandidatesResponse:
     """Return indexed-but-unanalyzed tracks in `folder` for the batch runner.
@@ -57,7 +101,8 @@ def get_local_candidates(folder: str, recursive: bool = True) -> LocalCandidates
     Filters to tracks with `bpm IS NULL` in cache_db. `recursive=True` (default)
     walks subdirectories, matching the library view's usual display scope.
     """
-    paths = cache_db.get_tracks_missing_bpm(Path(folder), recursive=recursive)
+    safe_folder = _validate_library_folder(folder)
+    paths = cache_db.get_tracks_missing_bpm(safe_folder, recursive=recursive)
     return LocalCandidatesResponse(file_paths=paths)
 
 
@@ -168,11 +213,11 @@ def get_soundcloud_client_token() -> ClientTokenResponse:
             detail="SoundCloud OAuth credentials not configured",
         )
     try:
-        token = OAuthManager(settings.client_id, settings.client_secret).get_access_token()
+        token = sc_auth_cache.get_cached_access_token(settings, OAuthManager)
     except Exception as exc:
         logger.exception("Failed to acquire SoundCloud client-credentials token")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"SoundCloud auth error: {exc}",
+            detail="SoundCloud auth unavailable",
         ) from exc
     return ClientTokenResponse(token=token)

--- a/backend/api/soundcloud.py
+++ b/backend/api/soundcloud.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -19,8 +20,11 @@ import httpx
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
 
-from soundcloud_tools.oauth import OAuthManager
-from soundcloud_tools.settings import get_settings
+from backend.core.services import sc_auth_cache
+from soundcloud_tools.oauth import OAuthManager  # re-exported for tests
+from soundcloud_tools.settings import get_settings  # re-exported for tests
+
+__all__ = ["OAuthManager", "get_settings", "router"]
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +36,22 @@ _PUBLIC_API_BASE = "https://api.soundcloud.com"
 
 # Default cache TTL (seconds). Signed CDN URLs live ~1 hour; refresh at 30 min.
 _DEFAULT_TTL_SECONDS = 30 * 60
+
+# HTTP timeout for upstream SoundCloud calls. Overridable via env var for ops.
+_HTTP_TIMEOUT_SECONDS: float = float(os.environ.get("STARLIB_SC_HTTP_TIMEOUT", "15"))
+
+# Allowlist of hosts the `/streams` endpoint may redirect us to. We follow
+# only these on the redirect hop so a spoofed upstream can't bounce us to a
+# malicious origin. Matches exact host OR any subdomain of an entry.
+_ALLOWED_REDIRECT_SUFFIXES: tuple[str, ...] = (
+    "sndcdn.com",
+    "soundcloud.cloud",
+    "soundcloud.com",
+)
+_ALLOWED_REDIRECT_HOSTS: tuple[str, ...] = (
+    "cf-hls-media.sndcdn.com",
+    "playback.media-streaming.soundcloud.cloud",
+)
 
 
 class StreamUrlResponse(BaseModel):
@@ -50,6 +70,21 @@ class _CacheEntry:
 # In-memory per-track cache. Keyed by track_id.
 _cache: dict[int, _CacheEntry] = {}
 _cache_lock = asyncio.Lock()
+
+# Per-track in-flight locks prevent a thundering herd of concurrent misses
+# all calling `_fetch_stream_url` for the same track.
+_inflight_locks: dict[int, asyncio.Lock] = {}
+_inflight_locks_guard = asyncio.Lock()
+
+
+def _is_allowed_redirect_host(host: str | None) -> bool:
+    """Return True iff the given host matches the SoundCloud CDN allowlist."""
+    if not host:
+        return False
+    host = host.lower()
+    if host in _ALLOWED_REDIRECT_HOSTS:
+        return True
+    return any(host == suffix or host.endswith("." + suffix) for suffix in _ALLOWED_REDIRECT_SUFFIXES)
 
 
 def _extract_expires_from_url(url: str) -> float | None:
@@ -73,7 +108,7 @@ async def _http_get(url: str, *, token: str, follow_redirects: bool) -> httpx.Re
     Authorization header and returns 401 when those are present.
     """
     headers = {"Authorization": f"OAuth {token}", "Accept": "application/json"}
-    async with httpx.AsyncClient(timeout=15.0) as client:
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
         return await client.get(url, headers=headers, follow_redirects=follow_redirects)
 
 
@@ -102,12 +137,12 @@ async def _fetch_stream_url(track_id: int) -> tuple[str, float]:
             detail="SoundCloud OAuth credentials not configured",
         )
     try:
-        token = OAuthManager(settings.client_id, settings.client_secret).get_access_token()
+        token = sc_auth_cache.get_cached_access_token(settings, OAuthManager)
     except Exception as exc:
         logger.exception("Failed to acquire SoundCloud OAuth token")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"SoundCloud auth error: {exc}",
+            detail="SoundCloud auth unavailable",
         ) from exc
 
     streams_url = f"{_PUBLIC_API_BASE}/tracks/{track_id}/streams"
@@ -117,7 +152,7 @@ async def _fetch_stream_url(track_id: int) -> tuple[str, float]:
         logger.exception("Upstream SoundCloud request failed")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"SoundCloud upstream error: {exc}",
+            detail="SoundCloud upstream error",
         ) from exc
 
     if response.status_code != 200:
@@ -135,24 +170,52 @@ async def _fetch_stream_url(track_id: int) -> tuple[str, float]:
             detail="No HLS stream variant available for this track",
         )
 
-    # The /streams response points to another api.soundcloud.com URL that
-    # 302s to the signed CDN playlist. Resolve the redirect without
-    # downloading the playlist so we can extract the `expires` epoch.
-    final_url = stream_url
-    expires_epoch: float | None = None
-    try:
-        redirect_resp = await _http_get(stream_url, token=token, follow_redirects=False)
-        loc = redirect_resp.headers.get("Location") or redirect_resp.headers.get("location")
-        if loc:
-            final_url = loc
-            expires_epoch = _extract_expires_from_url(loc)
-    except Exception:  # pragma: no cover - best-effort redirect follow
-        logger.debug("Could not pre-resolve signed CDN URL; returning api.soundcloud.com URL")
-
+    final_url, expires_epoch = await _resolve_signed_cdn_url(stream_url, token=token, track_id=track_id)
     if expires_epoch is None:
         expires_epoch = time.time() + _DEFAULT_TTL_SECONDS
-
     return final_url, expires_epoch
+
+
+async def _resolve_signed_cdn_url(stream_url: str, *, token: str, track_id: int) -> tuple[str, float | None]:
+    """Follow one redirect hop to the signed CDN URL, enforcing the allowlist.
+
+    The /streams response points to another api.soundcloud.com URL that 302s
+    to the signed CDN playlist. We resolve that hop without downloading the
+    playlist so we can extract the `expires` epoch — and reject redirects
+    whose host isn't on our SoundCloud CDN allowlist.
+    """
+    try:
+        redirect_resp = await _http_get(stream_url, token=token, follow_redirects=False)
+    except Exception:  # pragma: no cover - best-effort redirect follow
+        logger.debug("Could not pre-resolve signed CDN URL; returning api.soundcloud.com URL")
+        return stream_url, None
+
+    loc = redirect_resp.headers.get("Location") or redirect_resp.headers.get("location")
+    if not loc:
+        return stream_url, None
+
+    loc_host = urlparse(loc).hostname
+    if not _is_allowed_redirect_host(loc_host):
+        logger.warning(
+            "Rejecting SoundCloud redirect to disallowed host %r for track %s",
+            loc_host,
+            track_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="SoundCloud redirect target not in allowlist",
+        )
+    return loc, _extract_expires_from_url(loc)
+
+
+async def _get_inflight_lock(track_id: int) -> asyncio.Lock:
+    """Return the per-track lock, creating it on first use."""
+    async with _inflight_locks_guard:
+        lock = _inflight_locks.get(track_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _inflight_locks[track_id] = lock
+        return lock
 
 
 @router.get("/tracks/{track_id}/stream", response_model=StreamUrlResponse)
@@ -182,9 +245,21 @@ async def get_track_stream(track_id: int) -> StreamUrlResponse:
             expires_dt = datetime.fromtimestamp(entry.expires_at, tz=UTC)
             return StreamUrlResponse(url=entry.url, expires_at=expires_dt.isoformat())
 
+    # Per-track lock: collapse concurrent misses into a single upstream fetch.
+    inflight = await _get_inflight_lock(track_id)
+    async with inflight:
+        # Re-check cache under the per-track lock — a sibling coroutine may
+        # have populated it while we were waiting.
+        async with _cache_lock:
+            entry = _cache.get(track_id)
+            if entry and entry.expires_at - time.time() > 60:
+                expires_dt = datetime.fromtimestamp(entry.expires_at, tz=UTC)
+                return StreamUrlResponse(url=entry.url, expires_at=expires_dt.isoformat())
+
         url, expires_at = await _fetch_stream_url(track_id)
-        capped_expires = min(expires_at, now + _DEFAULT_TTL_SECONDS)
-        _cache[track_id] = _CacheEntry(url=url, expires_at=capped_expires)
+        capped_expires = min(expires_at, time.time() + _DEFAULT_TTL_SECONDS)
+        async with _cache_lock:
+            _cache[track_id] = _CacheEntry(url=url, expires_at=capped_expires)
 
     expires_dt = datetime.fromtimestamp(capped_expires, tz=UTC)
     return StreamUrlResponse(url=url, expires_at=expires_dt.isoformat())
@@ -193,3 +268,5 @@ async def get_track_stream(track_id: int) -> StreamUrlResponse:
 def _reset_cache_for_tests() -> None:
     """Clear the in-memory cache. Intended for tests only."""
     _cache.clear()
+    _inflight_locks.clear()
+    sc_auth_cache.reset_cache()

--- a/backend/core/services/sc_auth_cache.py
+++ b/backend/core/services/sc_auth_cache.py
@@ -1,0 +1,89 @@
+"""Module-level TTL cache for SoundCloud Client-Credentials OAuth tokens.
+
+``OAuthManager.get_access_token()`` hits disk (and occasionally the network)
+on every call. The stream-URL and BPM endpoints both need the same token on
+hot paths, so we memoize it here with a conservative TTL.
+
+Tokens from SoundCloud typically live ~1 hour; we default to 55 minutes and
+force a refresh 5 minutes before the cached deadline.
+
+Callers pass in the ``settings`` object and the ``OAuthManager`` class so
+individual modules can monkeypatch those in their own namespaces (tests
+already do this on ``backend.api.soundcloud``).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 55 * 60
+_REFRESH_BUFFER_SECONDS = 5 * 60
+
+_lock = threading.Lock()
+_token: str | None = None
+_expires_at: float = 0.0
+
+
+class _OAuthManagerLike(Protocol):
+    """Structural type for ``OAuthManager`` — only the bits we use."""
+
+    def __init__(self, client_id: str, client_secret: str) -> None: ...
+
+    def get_access_token(self) -> str: ...
+
+
+def get_cached_access_token(
+    settings: Any,
+    oauth_manager_cls: type[_OAuthManagerLike],
+    *,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+) -> str:
+    """Return a cached Client-Credentials access token, refreshing as needed.
+
+    Parameters
+    ----------
+    settings : Any
+        Object exposing ``client_id``, ``client_secret``, and
+        ``has_oauth_credentials()``.
+    oauth_manager_cls : type
+        The ``OAuthManager`` class to instantiate on miss.
+    ttl_seconds : int
+        Max time to trust a cached token. Refreshed 5 min before expiry.
+
+    Returns
+    -------
+    str
+        A valid access token suitable for ``Authorization: OAuth <token>``.
+
+    Raises
+    ------
+    RuntimeError
+        If no SoundCloud OAuth credentials are configured.
+    """
+    global _token, _expires_at
+
+    now = time.time()
+    with _lock:
+        if _token is not None and _expires_at - now > _REFRESH_BUFFER_SECONDS:
+            return _token
+
+        if not settings.has_oauth_credentials():
+            raise RuntimeError("SoundCloud OAuth credentials not configured")
+
+        token = oauth_manager_cls(settings.client_id, settings.client_secret).get_access_token()
+        _token = token
+        _expires_at = now + ttl_seconds
+        return token
+
+
+def reset_cache() -> None:
+    """Clear the cached token. Intended for tests."""
+    global _token, _expires_at
+    with _lock:
+        _token = None
+        _expires_at = 0.0

--- a/tests/api/test_auth_rate_limit.py
+++ b/tests/api/test_auth_rate_limit.py
@@ -1,0 +1,34 @@
+"""Tests for the /auth/soundcloud/result rate limiter."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api import auth as auth_api
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    auth_api._reset_rate_limiter_for_tests()
+    yield
+    auth_api._reset_rate_limiter_for_tests()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(auth_api.router)
+    return TestClient(app)
+
+
+def test_rate_limit_triggers_429(client: TestClient) -> None:
+    """After 10 requests in the window, the 11th returns 429."""
+    # First 10 requests either 404 (state not found) or 200; none should 429.
+    for _ in range(auth_api._RATE_LIMIT_MAX_REQUESTS):
+        resp = client.get("/auth/soundcloud/result?state=abc")
+        assert resp.status_code != 429
+
+    resp = client.get("/auth/soundcloud/result?state=abc")
+    assert resp.status_code == 429

--- a/tests/api/test_bpm_folder_validation.py
+++ b/tests/api/test_bpm_folder_validation.py
@@ -1,0 +1,82 @@
+"""Tests for /api/bpm/local/candidates folder validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.bpm import router as bpm_router
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(bpm_router)
+    return TestClient(app)
+
+
+def test_rejects_folder_outside_root(tmp_path: Path, client: TestClient) -> None:
+    """An absolute path outside the configured library root returns 400."""
+    root = tmp_path / "library"
+    root.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+
+    with patch(
+        "backend.api.bpm.app_settings_service.get_root_music_folder",
+        return_value=str(root),
+    ):
+        resp = client.get(f"/api/bpm/local/candidates?folder={outside}")
+
+    assert resp.status_code == 400
+    assert "library root" in resp.json()["detail"]
+
+
+def test_rejects_traversal(tmp_path: Path, client: TestClient) -> None:
+    """`..` traversal that escapes the root is rejected."""
+    root = tmp_path / "library"
+    root.mkdir()
+
+    traversal = f"{root}/../elsewhere"
+    with patch(
+        "backend.api.bpm.app_settings_service.get_root_music_folder",
+        return_value=str(root),
+    ):
+        resp = client.get(f"/api/bpm/local/candidates?folder={traversal}")
+
+    assert resp.status_code == 400
+
+
+def test_accepts_folder_inside_root(tmp_path: Path, client: TestClient) -> None:
+    """A valid sub-path succeeds and reaches cache_db."""
+    root = tmp_path / "library"
+    sub = root / "prepare"
+    sub.mkdir(parents=True)
+
+    with (
+        patch(
+            "backend.api.bpm.app_settings_service.get_root_music_folder",
+            return_value=str(root),
+        ),
+        patch("backend.api.bpm.cache_db.get_tracks_missing_bpm", return_value=[]) as mock,
+    ):
+        resp = client.get(f"/api/bpm/local/candidates?folder={sub}")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"file_paths": []}
+    mock.assert_called_once()
+
+
+def test_rejects_when_no_root_configured(tmp_path: Path, client: TestClient) -> None:
+    """If no library root is configured, validation rejects the request."""
+    with patch(
+        "backend.api.bpm.app_settings_service.get_root_music_folder",
+        return_value="",
+    ):
+        resp = client.get(f"/api/bpm/local/candidates?folder={tmp_path}")
+
+    assert resp.status_code == 400

--- a/tests/api/test_sc_auth_cache.py
+++ b/tests/api/test_sc_auth_cache.py
@@ -1,0 +1,67 @@
+"""Unit tests for the shared SoundCloud OAuth token TTL cache."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.services import sc_auth_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    sc_auth_cache.reset_cache()
+    yield
+    sc_auth_cache.reset_cache()
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        client_id="cid",
+        client_secret="secret",
+        has_oauth_credentials=lambda: True,
+    )
+
+
+def test_token_reused_within_ttl() -> None:
+    """Two calls within the TTL hit OAuthManager exactly once."""
+    manager_instance = MagicMock()
+    manager_instance.get_access_token.return_value = "tok-1"
+    manager_cls = MagicMock(return_value=manager_instance)
+
+    t1 = sc_auth_cache.get_cached_access_token(_settings(), manager_cls)
+    t2 = sc_auth_cache.get_cached_access_token(_settings(), manager_cls)
+
+    assert t1 == t2 == "tok-1"
+    assert manager_cls.call_count == 1
+    assert manager_instance.get_access_token.call_count == 1
+
+
+def test_token_refreshed_after_ttl_expiry() -> None:
+    """Expiring the cache forces a fresh token fetch."""
+    manager_instance = MagicMock()
+    manager_instance.get_access_token.side_effect = ["tok-1", "tok-2"]
+    manager_cls = MagicMock(return_value=manager_instance)
+
+    t1 = sc_auth_cache.get_cached_access_token(_settings(), manager_cls, ttl_seconds=60)
+    assert t1 == "tok-1"
+
+    # Force the cached entry into "needs-refresh" territory.
+    sc_auth_cache._expires_at = 0.0  # type: ignore[assignment]
+
+    t2 = sc_auth_cache.get_cached_access_token(_settings(), manager_cls, ttl_seconds=60)
+    assert t2 == "tok-2"
+    assert manager_instance.get_access_token.call_count == 2
+
+
+def test_raises_without_credentials() -> None:
+    """Missing credentials surface as RuntimeError (caller converts to 502)."""
+    settings = SimpleNamespace(
+        client_id="",
+        client_secret="",
+        has_oauth_credentials=lambda: False,
+    )
+    with pytest.raises(RuntimeError):
+        sc_auth_cache.get_cached_access_token(settings, MagicMock())

--- a/tests/api/test_soundcloud_stream.py
+++ b/tests/api/test_soundcloud_stream.py
@@ -121,8 +121,8 @@ def test_cache_hit_skips_upstream_call(client: TestClient) -> None:
 def test_cache_expiry_triggers_refetch(client: TestClient) -> None:
     """When the cached entry is stale, the next call refetches upstream."""
 
-    signed_cdn_1 = f"https://cdn.example/first.m3u8?expires={int(time.time()) + 1800}"
-    signed_cdn_2 = f"https://cdn.example/second.m3u8?expires={int(time.time()) + 3600}"
+    signed_cdn_1 = f"https://cf-hls-media.sndcdn.com/first.m3u8?expires={int(time.time()) + 1800}"
+    signed_cdn_2 = f"https://cf-hls-media.sndcdn.com/second.m3u8?expires={int(time.time()) + 3600}"
 
     call_state = {"n": 0}
 
@@ -145,6 +145,46 @@ def test_cache_expiry_triggers_refetch(client: TestClient) -> None:
 
         r2 = client.get("/api/soundcloud/tracks/99/stream")
         assert r2.json()["url"] == signed_cdn_2
+
+
+def test_rejects_redirect_to_disallowed_host(client: TestClient) -> None:
+    """Location header pointing outside the SC CDN allowlist → 502."""
+
+    malicious = "https://evil.example.com/pwn.m3u8?expires=9999999999"
+
+    async def fake_http_get(url, *, token, follow_redirects):
+        if url.endswith("/streams"):
+            return _mock_response(
+                status_code=200,
+                json_data={"hls_aac_160_url": "https://api.soundcloud.com/streams/redirect"},
+            )
+        return _mock_response(status_code=302, headers={"Location": malicious})
+
+    with patch.object(soundcloud_api, "_http_get", new=AsyncMock(side_effect=fake_http_get)):
+        resp = client.get("/api/soundcloud/tracks/77/stream")
+
+    assert resp.status_code == 502
+    assert "allowlist" in resp.json()["detail"].lower()
+
+
+def test_accepts_sndcdn_subdomain_redirect(client: TestClient) -> None:
+    """Any *.sndcdn.com host is accepted by the allowlist."""
+
+    signed_cdn = "https://foo-bar.sndcdn.com/path.m3u8?expires=9999999999"
+
+    async def fake_http_get(url, *, token, follow_redirects):
+        if url.endswith("/streams"):
+            return _mock_response(
+                status_code=200,
+                json_data={"hls_aac_160_url": "https://api.soundcloud.com/streams/redirect"},
+            )
+        return _mock_response(status_code=302, headers={"Location": signed_cdn})
+
+    with patch.object(soundcloud_api, "_http_get", new=AsyncMock(side_effect=fake_http_get)):
+        resp = client.get("/api/soundcloud/tracks/78/stream")
+
+    assert resp.status_code == 200
+    assert resp.json()["url"] == signed_cdn
 
 
 def test_missing_hls_variant_returns_404(client: TestClient) -> None:

--- a/tests/test_cache_db_migrations.py
+++ b/tests/test_cache_db_migrations.py
@@ -221,6 +221,46 @@ def test_search_filter_hits_flat_tag_columns(tmp_path: Path) -> None:
     assert len(hits_hay) == 1 and hits_hay[0]["title"] == "Two"
 
 
+def test_migration_0004_downgrade_upgrade_round_trip(tmp_path: Path) -> None:
+    """Downgrade then upgrade must preserve the soundcloud_track_bpm schema.
+
+    Regression: 0004's downgrade used to re-add ``algorithm_version`` as
+    nullable, drifting from 0003's NOT NULL shape.
+    """
+    from alembic import command
+    from alembic.config import Config
+
+    db = tmp_path / "cache.db"
+    cache_db.init_db(db)
+    assert _rev(db) == "0004"
+
+    # Confirm the column is gone at head.
+    head_cols = _cols(db, "soundcloud_track_bpm")
+    assert "algorithm_version" not in head_cols
+
+    # Point alembic at this scratch DB and go 0004 -> 0003 -> 0004.
+    cfg = Config()
+    cfg.set_main_option("script_location", "backend/alembic")
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db}")
+
+    command.downgrade(cfg, "0003")
+    assert _rev(db) == "0003"
+
+    # After downgrade, algorithm_version must exist and be NOT NULL,
+    # matching 0003's upgrade().
+    conn = _connect(db)
+    info = conn.execute("PRAGMA table_info(soundcloud_track_bpm)").fetchall()
+    conn.close()
+    algo_col = next((row for row in info if row[1] == "algorithm_version"), None)
+    assert algo_col is not None, "algorithm_version missing after downgrade"
+    # PRAGMA table_info: row[3] is `notnull` (1 = NOT NULL).
+    assert algo_col[3] == 1, f"algorithm_version should be NOT NULL after downgrade, got {algo_col}"
+
+    command.upgrade(cfg, "0004")
+    assert _rev(db) == "0004"
+    assert "algorithm_version" not in _cols(db, "soundcloud_track_bpm")
+
+
 def test_peaks_round_trip(tmp_path: Path) -> None:
     db = tmp_path / "cache.db"
     cache_db.init_db(db)


### PR DESCRIPTION
## Summary

Backend security + integration hardening around the new BPM feature work. Zero Tauri or frontend changes — kept to `backend/` and `tests/`.

### Fixes

- **Pin CDN host on redirect** (`backend/api/soundcloud.py` `_fetch_stream_url` / `_resolve_signed_cdn_url`): only follow `/streams` redirects whose host matches the SoundCloud CDN allowlist (`*.sndcdn.com`, `*.soundcloud.cloud`, `*.soundcloud.com`, plus explicit `cf-hls-media.sndcdn.com` / `playback.media-streaming.soundcloud.cloud`). Reject anything else with 502 instead of handing clients an arbitrary signed URL.
- **Thundering-herd lock on stream-URL cache** (`backend/api/soundcloud.py` `get_track_stream`): per-track `asyncio.Lock` collapses concurrent misses into a single upstream fetch. Re-checks cache after acquiring.
- **Configurable SC HTTP timeout** (`backend/api/soundcloud.py` `_http_get`): module constant `_HTTP_TIMEOUT_SECONDS`, overridable via `STARLIB_SC_HTTP_TIMEOUT` env var.
- **OAuth client-token TTL cache** (`backend/core/services/sc_auth_cache.py`, new): 55-min module-level TTL with 5-min refresh buffer. Shared between `backend/api/soundcloud.py::_fetch_stream_url` and `backend/api/bpm.py::get_soundcloud_client_token`, replacing per-call `OAuthManager.get_access_token()`.
- **Sanitized auth error surface** (`backend/api/bpm.py::get_soundcloud_client_token`, `backend/api/soundcloud.py::_fetch_stream_url`): log full exception server-side, return generic `"SoundCloud auth unavailable"` / `"SoundCloud upstream error"` to the client.
- **Rate-limit /auth/soundcloud/result** (`backend/api/auth.py`): dependency-free in-memory per-IP sliding window (10 req / 60 s) with log-on-reject. Applied to `get_oauth_result`.
- **Validate folder arg on `/api/bpm/local/candidates`** (`backend/api/bpm.py`): new `_validate_library_folder` resolves the caller-supplied path against the configured `root_music_folder` and rejects traversal / out-of-root / unconfigured-root with 400.
- **Migration 0004 downgrade** (`backend/alembic/versions/0004_drop_algorithm_version.py`): re-adds `algorithm_version` as `NOT NULL` (via `server_default="1"`, then cleared) to match 0003's shape — previous version drifted to `nullable=True`.

### Tests

- `tests/api/test_soundcloud_stream.py`: redirect host rejection + `*.sndcdn.com` acceptance.
- `tests/api/test_auth_rate_limit.py`: 429 after 10 requests in the window.
- `tests/api/test_bpm_folder_validation.py`: rejects traversal / outside-root / missing-root; accepts valid sub-paths.
- `tests/api/test_sc_auth_cache.py`: token reused within TTL, refreshed after expiry, raises without credentials.
- `tests/test_cache_db_migrations.py`: 0004 downgrade → upgrade round-trip asserts `algorithm_version` is `NOT NULL` at 0003.

## Test plan

- [x] `uv run ruff check backend/ tests/`
- [x] `uv run ruff format --check backend/ tests/`
- [x] `uv run python -m mypy` on changed files (pre-existing errors elsewhere unrelated)
- [x] `uv run python -m pytest tests/` — 169 passed
- [x] `pre-commit run` on all changed files — all hooks pass