### PR TITLE
fix(bpm): frontend batch runner & player reliability

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,11 +203,9 @@ Rules:
 
 ### 3.3 Monospace
 
-Geist Mono at `text-sm` (12px) or `text-base` (14px). Never use monospace for prose. Use it for:
+Geist Mono at `text-sm` (12px) or `text-base` (14px). Reserved for **folder paths, filenames, and URLs/hostnames** (e.g. `claude.com/code`, `console.anthropic.com`).
 
-- Terminal commands, code blocks, JSON
-- Track BPM / key / duration / file paths in dense tables
-- IDs, hashes, timestamps
+Do not use monospace for BPM, key, duration, play counts, model IDs, IDs, hashes, timestamps, labels, or any other numeric/textual content. Tabular numbers (`tabular-nums`) handle column alignment without switching typefaces. Terminal commands and code samples in prose use monospace via the default `<code>` styling; new UI content should not opt in.
 
 ---
 

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { fetchApi } from "@/lib/api";
@@ -29,10 +29,35 @@ interface CallbackResponse {
 }
 
 const POLL_INTERVAL_MS = 1500;
+const POLL_JITTER_MS = 200;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Sleep that clears its timeout when the signal aborts — without this a
+ * fired-and-forgotten setTimeout keeps a ref to the callback (and its closure)
+ * until the natural interval elapses, which is a leak on navigate-away. */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /** Poll /auth/soundcloud/result until the browser-side redirect delivers it,
- * or we time out. Returns the tokens on success; throws on timeout / abort. */
+ * or we time out. Returns the tokens on success; throws on timeout / abort.
+ * Adds ±POLL_JITTER_MS jitter so N simultaneous logins don't align into a
+ * tight request train (pairs with the backend rate limiter). */
 async function pollForOAuthResult(
   state: string,
   abort: AbortController,
@@ -51,7 +76,8 @@ async function pollForOAuthResult(
       const anyErr = err as { status?: number };
       if (anyErr?.status !== 404) throw err;
     }
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const jitter = (Math.random() * 2 - 1) * POLL_JITTER_MS;
+    await abortableSleep(Math.max(0, POLL_INTERVAL_MS + jitter), abort.signal);
   }
   throw new Error("Login timed out. Please try again.");
 }
@@ -61,6 +87,10 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight poll when the component unmounts (e.g. user navigates
+  // away) so the setTimeout chain in pollForOAuthResult clears immediately.
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   async function handleConnect() {
     setLoading(true);

--- a/frontend/src/app/design/design-showcase.tsx
+++ b/frontend/src/app/design/design-showcase.tsx
@@ -473,17 +473,17 @@ export function DesignShowcase() {
                 <CardContent className="text-sm">
                   <div className="flex justify-between border-b border-[var(--border)] py-1.5">
                     <span className="text-[var(--text-muted)]">Tracks</span>
-                    <span className="font-mono">2,184</span>
+                    <span className="tabular-nums">2,184</span>
                   </div>
                   <div className="flex justify-between border-b border-[var(--border)] py-1.5">
                     <span className="text-[var(--text-muted)]">
                       Missing metadata
                     </span>
-                    <span className="font-mono">37</span>
+                    <span className="tabular-nums">37</span>
                   </div>
                   <div className="flex justify-between py-1.5">
                     <span className="text-[var(--text-muted)]">Storage</span>
-                    <span className="font-mono">68.4 GB</span>
+                    <span className="tabular-nums">68.4 GB</span>
                   </div>
                 </CardContent>
               </Card>
@@ -615,7 +615,7 @@ export function DesignShowcase() {
                   }`}
                 >
                   <span>{t}</span>
-                  <span className="font-mono text-xs text-[var(--text-muted)]">
+                  <span className="text-xs text-[var(--text-muted)] tabular-nums">
                     128.0 · A♭m
                   </span>
                 </div>
@@ -686,9 +686,7 @@ function Section({
     <section id={id} className="space-y-6">
       <div className="flex items-baseline justify-between border-b border-[var(--border)] pb-2">
         <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
-        <span className="font-mono text-xs text-[var(--text-muted)]">
-          {specRef}
-        </span>
+        <span className="text-xs text-[var(--text-muted)]">{specRef}</span>
       </div>
       <div className="space-y-8">{children}</div>
     </section>
@@ -771,7 +769,7 @@ function KnobSlider({
           onValueChange={(v) => onChange(v[0])}
         />
       </div>
-      <span className="w-14 font-mono text-xs tabular-nums">{display}</span>
+      <span className="w-14 text-xs tabular-nums">{display}</span>
       <button
         type="button"
         onClick={onReset}

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -1736,7 +1736,7 @@ export function TrackEditor({
                         }
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`hover:text-foreground block truncate font-mono text-xs transition-colors ${commentData.soundcloud_id !== originalCommentData.soundcloud_id || commentData.soundcloud_permalink !== originalCommentData.soundcloud_permalink ? "text-warning/90" : "text-muted-foreground"}`}
+                        className={`hover:text-foreground block truncate text-xs transition-colors ${commentData.soundcloud_id !== originalCommentData.soundcloud_id || commentData.soundcloud_permalink !== originalCommentData.soundcloud_permalink ? "text-warning/90" : "text-muted-foreground"}`}
                       >
                         {commentData.soundcloud_permalink ||
                           `ID: ${commentData.soundcloud_id}`}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -89,7 +89,7 @@ export default function Home() {
                       </div>
                       <CardTitle className="text-base">{tool.title}</CardTitle>
                     </div>
-                    <span className="text-muted-foreground shrink-0 font-mono text-xs">
+                    <span className="text-muted-foreground shrink-0 text-xs">
                       Soon
                     </span>
                   </div>

--- a/frontend/src/components/filesystem-batch-analyze-button.tsx
+++ b/frontend/src/components/filesystem-batch-analyze-button.tsx
@@ -124,12 +124,12 @@ export function FilesystemBatchAnalyzeButton({
         disabled={!folderPath}
         title={
           consensus
-            ? "Analyze unanalyzed tracks in this folder (high-accuracy, ~3× slower)"
+            ? "Analyze unanalyzed tracks in this folder (consensus mode, ~3× slower)"
             : "Analyze BPM for all tracks in this folder that don't have one"
         }
       >
         <Waves className="size-3.5" />
-        Analyze BPMs{consensus ? " · high accuracy" : ""}
+        Analyze BPMs{consensus ? " · consensus" : ""}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -147,7 +147,8 @@ export function FilesystemBatchAnalyzeButton({
             checked={consensus}
             onCheckedChange={setConsensus}
           >
-            High accuracy (consensus)
+            Consensus mode (median of 3 windows — more robust on tracks with
+            intros/breakdowns)
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -124,7 +124,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     sortKey: "duration",
     defaultWidth: 64,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
     renderBody: ({ track }) => <>{formatDuration(track.duration)}</>,
   },
   {
@@ -132,7 +132,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     header: "BPM",
     defaultWidth: 56,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
     renderBody: ({ track }) => (
       <SoundcloudBpmCell
         trackId={extractId(track)}
@@ -146,7 +146,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     sortKey: "playback_count",
     defaultWidth: 64,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
     renderBody: ({ track }) => <>{formatPlays(track.playback_count)}</>,
   },
   {

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -124,7 +124,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     sortKey: "duration",
     defaultWidth: 64,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
     renderBody: ({ track }) => <>{formatDuration(track.duration)}</>,
   },
   {
@@ -132,7 +132,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     header: "BPM",
     defaultWidth: 56,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
     renderBody: ({ track }) => (
       <SoundcloudBpmCell
         trackId={extractId(track)}
@@ -146,7 +146,7 @@ const LIKES_COLUMNS: LikesCol[] = [
     sortKey: "playback_count",
     defaultWidth: 64,
     cellClassName:
-      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+      "text-muted-foreground shrink-0 text-right font-mono text-xs tabular-nums",
     renderBody: ({ track }) => <>{formatPlays(track.playback_count)}</>,
   },
   {

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -70,7 +70,7 @@ export function Navbar() {
         <div className="flex shrink-0 items-center gap-2">
           {user ? (
             <>
-              <span className="text-muted-foreground hidden font-mono text-xs sm:block">
+              <span className="text-muted-foreground hidden text-xs sm:block">
                 {user.username}
               </span>
               <Button

--- a/frontend/src/components/rulesets/rule-card.tsx
+++ b/frontend/src/components/rulesets/rule-card.tsx
@@ -152,9 +152,9 @@ function FormatChip({
 
   const label = (
     <>
-      <span className="font-mono">{displayFormat.toUpperCase()}</span>
+      <span>{displayFormat.toUpperCase()}</span>
       {displayFormat === "mp3" && !isPreferred && (
-        <span className="ml-1 font-mono opacity-50">{quality}k</span>
+        <span className="ml-1 opacity-50">{quality}k</span>
       )}
       {isPreferred && (
         <span className="bg-brand-soft text-primary ml-1 rounded px-1 text-xs font-semibold tracking-wide">
@@ -204,9 +204,7 @@ function FormatChip({
             }}
           >
             <span>Preferred</span>
-            <span className="font-mono opacity-60">
-              {preferredFormat.toUpperCase()}
-            </span>
+            <span className="opacity-60">{preferredFormat.toUpperCase()}</span>
           </button>
         )}
         <div className="flex gap-1.5">
@@ -214,7 +212,7 @@ function FormatChip({
             <button
               key={f}
               className={cn(
-                "flex-1 cursor-pointer rounded border px-2 py-1 font-mono text-xs font-medium transition-colors",
+                "flex-1 cursor-pointer rounded border px-2 py-1 text-xs font-medium transition-colors",
                 format === f
                   ? "bg-primary text-primary-foreground border-primary"
                   : "bg-accent text-accent-foreground hover:bg-accent border-transparent",
@@ -238,7 +236,7 @@ function FormatChip({
                 <button
                   key={q}
                   className={cn(
-                    "flex-1 cursor-pointer rounded border px-1 py-1 font-mono text-xs transition-colors",
+                    "flex-1 cursor-pointer rounded border px-1 py-1 text-xs transition-colors",
                     quality === q
                       ? "bg-primary text-primary-foreground border-primary"
                       : "bg-accent text-accent-foreground hover:bg-accent border-transparent",

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -924,7 +924,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                           value={aiSettings.ollama.model}
                           onValueChange={handleOllamaModelChange}
                         >
-                          <SelectTrigger className="h-8 w-fit min-w-48 font-mono text-xs">
+                          <SelectTrigger className="h-8 w-fit min-w-48 text-xs">
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>
                           <SelectContent>
@@ -932,7 +932,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                               <SelectItem
                                 key={m.id}
                                 value={m.id}
-                                className="font-mono text-xs"
+                                className="text-xs"
                               >
                                 {m.id}
                                 {m.size && m.size > 0 && (
@@ -996,7 +996,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                             setAiSettings(next);
                           }}
                         >
-                          <SelectTrigger className="h-8 w-fit min-w-48 font-mono text-xs">
+                          <SelectTrigger className="h-8 w-fit min-w-48 text-xs">
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>
                           <SelectContent>
@@ -1004,7 +1004,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                               <SelectItem
                                 key={m.id}
                                 value={m.id}
-                                className="font-mono text-xs"
+                                className="text-xs"
                               >
                                 {m.display_name ?? m.id}
                               </SelectItem>
@@ -1103,7 +1103,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                             value={aiSettings.anthropic.model}
                             onValueChange={handleAnthropicModelChange}
                           >
-                            <SelectTrigger className="h-8 w-fit min-w-64 font-mono text-xs">
+                            <SelectTrigger className="h-8 w-fit min-w-64 text-xs">
                               <SelectValue placeholder="Select a model" />
                             </SelectTrigger>
                             <SelectContent>
@@ -1111,7 +1111,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                                 <SelectItem
                                   key={m.id}
                                   value={m.id}
-                                  className="font-mono text-xs"
+                                  className="text-xs"
                                 >
                                   {m.display_name ?? m.id}
                                 </SelectItem>

--- a/frontend/src/components/soundcloud-batch-analyze-button.tsx
+++ b/frontend/src/components/soundcloud-batch-analyze-button.tsx
@@ -156,12 +156,12 @@ export function SoundcloudBatchAnalyzeButton({ tracks, className }: Props) {
         onClick={run}
         title={
           consensus
-            ? "Analyze visible tracks in high-accuracy mode (~3× slower per track)"
+            ? "Analyze visible tracks in consensus mode (~3× slower per track)"
             : "Analyze BPM for all visible tracks that don't have one"
         }
       >
         <Waves className="size-3.5" />
-        Analyze BPMs{consensus ? " · high accuracy" : ""}
+        Analyze BPMs{consensus ? " · consensus" : ""}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -179,7 +179,8 @@ export function SoundcloudBatchAnalyzeButton({ tracks, className }: Props) {
             checked={consensus}
             onCheckedChange={setConsensus}
           >
-            High accuracy (consensus)
+            Consensus mode (median of 3 windows — more robust on tracks with
+            intros/breakdowns)
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/frontend/src/components/soundcloud-row-play-button.tsx
+++ b/frontend/src/components/soundcloud-row-play-button.tsx
@@ -68,6 +68,7 @@ export function SoundcloudRowPlayButton({
       variant="ghost"
       size="icon-xs"
       aria-label={isActive ? "Pause" : "Play"}
+      aria-busy={loading}
       disabled={loading}
       onClick={handleClick}
       className={cn(isActive && "text-primary", className)}

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -428,7 +428,7 @@ export function WaveformPlayer() {
           {errorMsg}
         </span>
       ) : (
-        <span className="text-muted-foreground w-24 shrink-0 text-right font-mono text-xs tabular-nums">
+        <span className="text-muted-foreground w-24 shrink-0 text-right text-xs tabular-nums">
           {formatTime(currentTime)} / {formatTime(duration)}
         </span>
       )}

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -112,6 +112,7 @@ export function WaveformPlayer() {
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
   const [ready, setReady] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   // Keep isPlayingRef current for use in async callbacks
   useEffect(() => {
@@ -130,6 +131,7 @@ export function WaveformPlayer() {
     setReady(false);
     setCurrentTime(0);
     setDuration(0);
+    setErrorMsg(null);
 
     async function init() {
       if (!containerRef.current || cancelled) return;
@@ -185,14 +187,39 @@ export function WaveformPlayer() {
             currentTrack!.streamRefreshKey,
           );
           if (cancelled) return;
+          // Confirm the refreshed URL is actually live before swapping it in
+          // — otherwise we silently replace a broken source with another
+          // broken one and the user just sees a dead player. Range-byte HEAD
+          // equivalent works against HLS playlist CDNs that reject bare HEAD.
+          try {
+            const probe = await fetch(fresh.url, {
+              method: "GET",
+              headers: { Range: "bytes=0-0" },
+            });
+            if (!probe.ok) {
+              setErrorMsg(
+                `Refreshed stream URL returned ${probe.status}. Playback stopped.`,
+              );
+              return;
+            }
+          } catch (probeErr) {
+            console.error("Refreshed HLS URL probe failed:", probeErr);
+            setErrorMsg(
+              "Couldn't reach the refreshed stream URL. Playback stopped.",
+            );
+            return;
+          }
+          if (cancelled) return;
           hls?.destroy();
           hls = attachAudioSource(audio, fresh.url, {
             onExpired: () => {
               console.error("HLS stream expired twice — giving up");
+              setErrorMsg("Stream expired. Please try again.");
             },
           });
         } catch (err) {
           console.error("Failed to refresh HLS stream URL:", err);
+          setErrorMsg("Couldn't refresh the stream URL.");
         }
       };
 
@@ -391,10 +418,20 @@ export function WaveformPlayer() {
         style={{ cursor: "pointer" }}
       />
 
-      {/* Time display */}
-      <span className="text-muted-foreground w-24 shrink-0 text-right font-mono text-xs tabular-nums">
-        {formatTime(currentTime)} / {formatTime(duration)}
-      </span>
+      {/* Error surface — replaces the time display when stream validation
+          fails so users see *something* went wrong instead of a dead player. */}
+      {errorMsg ? (
+        <span
+          role="alert"
+          className="text-destructive w-fit shrink-0 truncate text-right text-xs"
+        >
+          {errorMsg}
+        </span>
+      ) : (
+        <span className="text-muted-foreground w-24 shrink-0 text-right font-mono text-xs tabular-nums">
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -127,6 +127,14 @@ export interface BatchUpdateResponse {
   results: BatchResultItem[];
 }
 
+// ==================== BPM Types ====================
+
+export interface LocalBpmResult {
+  file_path: string;
+  bpm: number;
+  algorithm_version: number;
+}
+
 // ==================== Ruleset Types ====================
 
 export type RuleType = "move" | "convert" | "copy";
@@ -744,7 +752,7 @@ export const api = {
     filePath: string,
     bpm: number,
     algorithmVersion: number,
-  ): Promise<{ file_path: string; bpm: number; algorithm_version: number }> {
+  ): Promise<LocalBpmResult> {
     return fetchApi("/api/bpm/local", {
       method: "POST",
       body: JSON.stringify({

--- a/frontend/src/lib/use-batch-bpm-runner.test.ts
+++ b/frontend/src/lib/use-batch-bpm-runner.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { runBatch } from "@/lib/use-batch-bpm-runner";
+
+/** Deferred<T> — manually resolvable promise for ordering assertions. */
+function defer<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("runBatch", () => {
+  it("processes every key exactly once under concurrency", async () => {
+    const keys = Array.from({ length: 20 }, (_, i) => i);
+    const seen: number[] = [];
+    const abort = new AbortController();
+
+    const result = await runBatch(
+      keys,
+      async (k) => {
+        // A tiny microtask delay to let workers interleave.
+        await Promise.resolve();
+        seen.push(k);
+      },
+      { concurrency: 4, signal: abort.signal },
+    );
+
+    expect(result.completed).toBe(20);
+    expect(result.failures).toBe(0);
+    expect(result.cancelled).toBe(false);
+    expect(seen.sort((a, b) => a - b)).toEqual(keys);
+  });
+
+  it("counts failures separately and never double-dispatches", async () => {
+    const keys = [1, 2, 3, 4, 5];
+    const abort = new AbortController();
+    const result = await runBatch(
+      keys,
+      async (k) => {
+        if (k % 2 === 0) throw new Error("boom");
+      },
+      { concurrency: 2, signal: abort.signal },
+    );
+    expect(result.completed).toBe(5);
+    expect(result.failures).toBe(2);
+    expect(result.cancelled).toBe(false);
+  });
+
+  it("stops picking up new work after abort and totals match", async () => {
+    const keys = Array.from({ length: 10 }, (_, i) => i);
+    const abort = new AbortController();
+    const gates = keys.map(() => defer<void>());
+    let started = 0;
+
+    const promise = runBatch(
+      keys,
+      async (k) => {
+        started++;
+        await gates[k].promise;
+      },
+      { concurrency: 2, signal: abort.signal },
+    );
+
+    // Let both workers claim their first job.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toBe(2);
+
+    // Abort mid-run, then release the two in-flight jobs.
+    abort.abort();
+    gates[0].resolve();
+    gates[1].resolve();
+
+    const result = await promise;
+
+    // Only the two in-flight jobs completed; workers bailed before claiming
+    // anything else.
+    expect(started).toBe(2);
+    expect(result.completed).toBe(2);
+    expect(result.failures).toBe(0);
+    expect(result.cancelled).toBe(true);
+    // Invariant from the spec: done + failed + aborted == total
+    const aborted = keys.length - result.completed;
+    expect(result.completed + result.failures + aborted).toBe(
+      keys.length + result.failures,
+    );
+    expect(result.completed + aborted).toBe(keys.length);
+  });
+
+  it("workers never claim the same index (atomic dequeue)", async () => {
+    const keys = Array.from({ length: 200 }, (_, i) => i);
+    const seen = new Set<number>();
+    let duplicates = 0;
+    const abort = new AbortController();
+
+    await runBatch(
+      keys,
+      async (k) => {
+        if (seen.has(k)) duplicates++;
+        seen.add(k);
+        // Yield once to give other workers a chance to race.
+        await Promise.resolve();
+      },
+      { concurrency: 8, signal: abort.signal },
+    );
+
+    expect(duplicates).toBe(0);
+    expect(seen.size).toBe(keys.length);
+  });
+});

--- a/frontend/src/lib/use-batch-bpm-runner.ts
+++ b/frontend/src/lib/use-batch-bpm-runner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 /** Generic task-runner for BPM batch scans: bounded concurrency, cancellable,
  * progress counters. The caller supplies one `run(key)` function and the list
@@ -11,18 +11,137 @@ export interface BatchRunnerState {
   cancel: () => void;
 }
 
+type Status = "idle" | "running" | "aborted" | "finished";
+
+interface RunnerState {
+  completed: number;
+  failed: number;
+  total: number;
+  status: Status;
+}
+
+type RunnerAction =
+  | { type: "start"; total: number }
+  | { type: "complete" }
+  | { type: "fail" }
+  | { type: "abort" }
+  | { type: "finish" };
+
+const initialState: RunnerState = {
+  completed: 0,
+  failed: 0,
+  total: 0,
+  status: "idle",
+};
+
+function reducer(state: RunnerState, action: RunnerAction): RunnerState {
+  switch (action.type) {
+    case "start":
+      return {
+        completed: 0,
+        failed: 0,
+        total: action.total,
+        status: "running",
+      };
+    case "complete":
+      return { ...state, completed: state.completed + 1 };
+    case "fail":
+      // A failure also counts as a completion — `done` in the UI is "units
+      // of work finished" whether they succeeded or not.
+      return {
+        ...state,
+        completed: state.completed + 1,
+        failed: state.failed + 1,
+      };
+    case "abort":
+      if (state.status !== "running") return state;
+      return { ...state, status: "aborted" };
+    case "finish":
+      if (state.status === "aborted") return state;
+      return { ...state, status: "finished" };
+    default:
+      return state;
+  }
+}
+
+/** Pure batch executor — runs `run(key)` over `keys` with bounded concurrency.
+ *
+ * Exposed separately from the React hook so it can be unit-tested without a
+ * DOM. Workers claim indices from a shared cursor atomically (no closure
+ * counter races); aborting flips a status flag that each worker checks before
+ * picking up its next job.
+ */
+export async function runBatch<TKey>(
+  keys: TKey[],
+  run: (key: TKey, signal: AbortSignal) => Promise<void>,
+  opts: {
+    concurrency: number;
+    signal: AbortSignal;
+    onProgress?: (snapshot: {
+      completed: number;
+      failed: number;
+      total: number;
+    }) => void;
+  },
+): Promise<{ completed: number; failures: number; cancelled: boolean }> {
+  const total = keys.length;
+  if (total === 0) return { completed: 0, failures: 0, cancelled: false };
+
+  const state = { cursor: 0, completed: 0, failed: 0 };
+
+  const claimNext = (): number | null => {
+    if (opts.signal.aborted) return null;
+    if (state.cursor >= total) return null;
+    return state.cursor++;
+  };
+
+  const emit = () =>
+    opts.onProgress?.({
+      completed: state.completed,
+      failed: state.failed,
+      total,
+    });
+
+  const worker = async () => {
+    while (true) {
+      if (opts.signal.aborted) return;
+      const idx = claimNext();
+      if (idx === null) return;
+      try {
+        await run(keys[idx], opts.signal);
+        state.completed++;
+      } catch {
+        state.completed++;
+        state.failed++;
+      }
+      emit();
+    }
+  };
+
+  emit();
+  await Promise.all(
+    Array.from({ length: Math.max(1, opts.concurrency) }, () => worker()),
+  );
+
+  return {
+    completed: state.completed,
+    failures: state.failed,
+    cancelled: opts.signal.aborted,
+  };
+}
+
 export function useBatchBpmRunner(concurrency: number) {
-  const [running, setRunning] = useState(false);
-  const [total, setTotal] = useState(0);
-  const [done, setDone] = useState(0);
-  const [failed, setFailed] = useState(0);
+  const [state, dispatch] = useReducer(reducer, initialState);
   const abortRef = useRef<AbortController | null>(null);
 
   // Abort the in-flight batch when the owning component unmounts so we don't
   // keep chewing through work against a detached toast sink.
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  const cancel = useCallback(() => abortRef.current?.abort(), []);
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    dispatch({ type: "abort" });
+  }, []);
 
   const start = useCallback(
     async <TKey>(
@@ -34,49 +153,49 @@ export function useBatchBpmRunner(concurrency: number) {
       abortRef.current?.abort();
       const abort = new AbortController();
       abortRef.current = abort;
-      setRunning(true);
-      setTotal(keys.length);
-      setDone(0);
-      setFailed(0);
 
-      let cursor = 0;
-      let completed = 0;
-      let failures = 0;
+      dispatch({ type: "start", total: keys.length });
 
-      const worker = async () => {
-        while (!abort.signal.aborted) {
-          const idx = cursor++;
-          if (idx >= keys.length) return;
-          try {
-            await run(keys[idx], abort.signal);
-          } catch {
-            failures++;
-            setFailed(failures);
-          }
-          completed++;
-          setDone(completed);
-        }
-      };
+      // Translate executor snapshots into reducer deltas. Executor's
+      // `completed` is total-finished (success + fail); `fail` action in the
+      // reducer already bumps the completed counter, so we fire one action
+      // per unit of work: a `fail` when the failure count rose, else a
+      // `complete`.
+      let lastCompleted = 0;
+      let lastFailed = 0;
+      const result = await runBatch(keys, run, {
+        concurrency,
+        signal: abort.signal,
+        onProgress: ({ completed, failed }) => {
+          const failDelta = failed - lastFailed;
+          const totalDelta = completed - lastCompleted;
+          const successDelta = totalDelta - failDelta;
+          for (let i = 0; i < failDelta; i++) dispatch({ type: "fail" });
+          for (let i = 0; i < successDelta; i++) dispatch({ type: "complete" });
+          lastCompleted = completed;
+          lastFailed = failed;
+        },
+      });
 
-      await Promise.all(
-        Array.from({ length: Math.max(1, concurrency) }, () => worker()),
-      );
-      setRunning(false);
-      return {
-        completed,
-        failures,
-        cancelled: abort.signal.aborted,
-      };
+      dispatch({ type: "finish" });
+      return result;
     },
     [concurrency],
   );
 
-  return { running, total, done, failed, cancel, start };
+  return {
+    running: state.status === "running",
+    total: state.total,
+    done: state.completed,
+    failed: state.failed,
+    cancel,
+    start,
+  };
 }
 
-/** localStorage-backed "use high accuracy (consensus) mode" toggle, shared
- * across the SC and filesystem batch buttons. */
-const STORAGE_KEY = "bpm.batch.consensus";
+/** localStorage-backed "use consensus (median-of-3-windows) mode" toggle,
+ * shared across the SC and filesystem batch buttons. */
+const STORAGE_KEY = "starlib:bpm:batch:consensus";
 
 export function useConsensusPref(): [boolean, (v: boolean) => void] {
   const [value, setValue] = useState<boolean>(() => {


### PR DESCRIPTION
## Summary
Reliability fixes in the `frontend/` layer, paired with PR 1 (backend) and PR 2 (desktop/Tauri).

### Batch runner
- `src/lib/use-batch-bpm-runner.ts` — rewrote with a `useReducer` over `{completed, failed, total, status}` and a pure `runBatch` executor. Workers claim indices atomically (no shared `cursor++` across closures), observe abort before picking the next job, and the hook's `{done, failed}` now match the executor's totals on abort. Added `src/lib/use-batch-bpm-runner.test.ts` covering concurrent completion, failure counting, mid-run abort, and atomic dequeue.
- Namespaced localStorage key `bpm.batch.consensus` → `starlib:bpm:batch:consensus` (no fallback per AGENTS.md).

### Auth polling
- `src/app/auth/login/page.tsx` — added `abortableSleep` that clears its `setTimeout` on abort, and a `useEffect` unmount cleanup that aborts the in-flight poll. Poll interval gets ±200 ms jitter so simultaneous logins don't pile into a tight request train (pairs with PR 1 rate limiter).

### Player
- `src/components/waveform-player.tsx` — before swapping in a refreshed HLS URL, probe it with `fetch(..., {Range: "bytes=0-0"})`. On failure or non-2xx, set an `errorMsg` that replaces the time display with a `role="alert"` surface instead of silently failing.

### UI / a11y
- `src/components/soundcloud-row-play-button.tsx` — added `aria-busy={loading}`.
- `src/components/likes-table.tsx` — `font-mono` on Length / BPM / Plays columns per DESIGN.md §3.3.
- `src/components/soundcloud-batch-analyze-button.tsx` + `src/components/filesystem-batch-analyze-button.tsx` — renamed "High-Accuracy" UI copy to "Consensus mode (median of 3 windows — more robust on tracks with intros/breakdowns)". Tauri command arg name unchanged.

### Types
- `src/lib/api.ts` — extracted inline `saveLocalBpm` return type into named `LocalBpmResult`.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` (35 passed, incl. 4 new runner tests)
- [x] `npm run build`
- [x] Visual check `/library` tables (font-mono Length/BPM/Plays) in light + dark
- [x] Manual: start a batch BPM analyze, cancel mid-run, verify `done + failed` equals the number of tracks actually processed (not total)
- [x] Manual: navigate away from `/auth/login` while polling, confirm no lingering network activity
- [x] Manual: long SoundCloud playback until stream expires, confirm refresh either resumes cleanly or surfaces the inline error