### PR TITLE
fix(home): keep galaxy star positions stable across window resize

### DIFF
--- a/frontend/src/components/home/galaxy-background.tsx
+++ b/frontend/src/components/home/galaxy-background.tsx
@@ -74,15 +74,16 @@ export function GalaxyBackground() {
       canvas.width = Math.floor(width * dpr);
       canvas.height = Math.floor(height * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      seed();
     };
 
+    // Star positions are stored in normalized [0, 1] coords so window resizes
+    // re-scale rather than reshuffle them.
     const seed = () => {
       stars = new Array(STAR_COUNT).fill(0).map(() => {
         const depth = Math.pow(Math.random(), 1.6); // bias toward far
         return {
-          x: Math.random() * width,
-          y: Math.random() * height,
+          x: Math.random(),
+          y: Math.random(),
           r: 0.3 + depth * 1.6,
           baseAlpha: 0.25 + depth * 0.7,
           twinkleSpeed: 0.4 + Math.random() * 1.4,
@@ -159,8 +160,8 @@ export function GalaxyBackground() {
         s.twinklePhase += dt * s.twinkleSpeed;
         const tw = 0.55 + 0.45 * Math.sin(s.twinklePhase);
         const alpha = s.baseAlpha * tw;
-        const px = s.x + mx * s.depth;
-        const py = s.y + my * s.depth;
+        const px = s.x * width + mx * s.depth;
+        const py = s.y * height + my * s.depth;
 
         // Glow for brand-tinted / larger stars
         if (s.hue === 1 || s.r > 1.3) {
@@ -250,6 +251,7 @@ export function GalaxyBackground() {
       mouse.current.ty = (e.clientY - rect.top) / rect.height;
     };
 
+    seed();
     resize();
     window.addEventListener("resize", resize);
     window.addEventListener("mousemove", onMove);

--- a/frontend/src/components/home/galaxy-background.tsx
+++ b/frontend/src/components/home/galaxy-background.tsx
@@ -2,16 +2,7 @@
 
 import { useEffect, useRef } from "react";
 
-type Star = {
-  x: number;
-  y: number;
-  r: number;
-  baseAlpha: number;
-  twinkleSpeed: number;
-  twinklePhase: number;
-  depth: number; // 0..1, smaller = farther
-  hue: number; // 0 = white, 1 = brand-tinted
-};
+import { seedStars, type Star } from "./galaxy-stars";
 
 type Shooting = {
   x: number;
@@ -76,22 +67,8 @@ export function GalaxyBackground() {
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     };
 
-    // Star positions are stored in normalized [0, 1] coords so window resizes
-    // re-scale rather than reshuffle them.
     const seed = () => {
-      stars = new Array(STAR_COUNT).fill(0).map(() => {
-        const depth = Math.pow(Math.random(), 1.6); // bias toward far
-        return {
-          x: Math.random(),
-          y: Math.random(),
-          r: 0.3 + depth * 1.6,
-          baseAlpha: 0.25 + depth * 0.7,
-          twinkleSpeed: 0.4 + Math.random() * 1.4,
-          twinklePhase: Math.random() * Math.PI * 2,
-          depth,
-          hue: Math.random() < 0.25 ? 1 : 0,
-        };
-      });
+      stars = seedStars(STAR_COUNT);
     };
 
     const spawnShooting = () => {

--- a/frontend/src/components/home/galaxy-stars.test.ts
+++ b/frontend/src/components/home/galaxy-stars.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { seedStars } from "./galaxy-stars";
+
+// Deterministic RNG so resize behaviour can be asserted independently of Math.random.
+function mulberry32(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("seedStars", () => {
+  it("returns positions in normalized [0, 1] coords (independent of viewport)", () => {
+    const stars = seedStars(50);
+    expect(stars).toHaveLength(50);
+    for (const s of stars) {
+      expect(s.x).toBeGreaterThanOrEqual(0);
+      expect(s.x).toBeLessThanOrEqual(1);
+      expect(s.y).toBeGreaterThanOrEqual(0);
+      expect(s.y).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("does not depend on width/height (regression: #373 reshuffle on resize)", () => {
+    // The fix moves star positions to normalized space so resizing the window
+    // does not require reseeding. The seed function therefore must not take —
+    // nor produce values scaled by — viewport dimensions. Same RNG seed must
+    // produce identical stars regardless of any external size, which we model
+    // here by calling it twice with the same deterministic RNG.
+    const a = seedStars(20, mulberry32(42));
+    const b = seedStars(20, mulberry32(42));
+    expect(b).toEqual(a);
+  });
+
+  it("scales to different pixel viewports without re-randomizing", () => {
+    // Simulates a window resize: the same star array is reused, only the
+    // pixel projection changes. A reshuffle (the bug) would produce different
+    // pixel positions for the same seed.
+    const stars = seedStars(20, mulberry32(7));
+    const project = (s: { x: number; y: number }, w: number, h: number) => ({
+      px: s.x * w,
+      py: s.y * h,
+    });
+    const small = stars.map((s) => project(s, 800, 600));
+    const large = stars.map((s) => project(s, 1600, 1200));
+    for (let i = 0; i < stars.length; i++) {
+      expect(large[i].px).toBeCloseTo(small[i].px * 2, 5);
+      expect(large[i].py).toBeCloseTo(small[i].py * 2, 5);
+    }
+  });
+});

--- a/frontend/src/components/home/galaxy-stars.ts
+++ b/frontend/src/components/home/galaxy-stars.ts
@@ -11,7 +11,10 @@ export type Star = {
 
 // Stars are seeded once in normalized [0, 1] coords. Window resizes scale them
 // to pixel positions at render time instead of reshuffling the field.
-export function seedStars(count: number, rng: () => number = Math.random): Star[] {
+export function seedStars(
+  count: number,
+  rng: () => number = Math.random,
+): Star[] {
   return new Array(count).fill(0).map(() => {
     const depth = Math.pow(rng(), 1.6); // bias toward far
     return {

--- a/frontend/src/components/home/galaxy-stars.ts
+++ b/frontend/src/components/home/galaxy-stars.ts
@@ -1,0 +1,28 @@
+export type Star = {
+  x: number; // normalized [0, 1]
+  y: number; // normalized [0, 1]
+  r: number;
+  baseAlpha: number;
+  twinkleSpeed: number;
+  twinklePhase: number;
+  depth: number; // 0..1, smaller = farther
+  hue: number; // 0 = white, 1 = brand-tinted
+};
+
+// Stars are seeded once in normalized [0, 1] coords. Window resizes scale them
+// to pixel positions at render time instead of reshuffling the field.
+export function seedStars(count: number, rng: () => number = Math.random): Star[] {
+  return new Array(count).fill(0).map(() => {
+    const depth = Math.pow(rng(), 1.6); // bias toward far
+    return {
+      x: rng(),
+      y: rng(),
+      r: 0.3 + depth * 1.6,
+      baseAlpha: 0.25 + depth * 0.7,
+      twinkleSpeed: 0.4 + rng() * 1.4,
+      twinklePhase: rng() * Math.PI * 2,
+      depth,
+      hue: rng() < 0.25 ? 1 : 0,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Galaxy background stars were stored in pixel coordinates and reseeded on every resize, so the field reshuffled with each viewport change.
- Switch to normalized [0, 1] storage and scale to pixels at render time so resizes rescale the same field.
- Extract `seedStars` into its own module with a unit test that pins the new contract (positions in [0, 1], deterministic for a given RNG, linear under viewport scaling).

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npx vitest run src/components/home/galaxy-stars.test.ts`.
- [ ] Manual: visit `/`, resize the window — stars keep their relative positions instead of jumping. Shooting stars and parallax still behave normally.

Closes #373