### PR TITLE
fix(ui): hide reorder drag handles until row hover

### DIFF
--- a/frontend/e2e/drag-handle-hover.spec.ts
+++ b/frontend/e2e/drag-handle-hover.spec.ts
@@ -28,13 +28,13 @@ test.describe("drag handle hover affordance", () => {
     ).toBeLessThan(0.05);
 
     // Hover the row that owns this handle: opacity transitions to 1.
-    const row = handle.locator("xpath=ancestor::*[contains(@class,'group')][1]");
+    const row = handle.locator(
+      "xpath=ancestor::*[contains(@class,'group')][1]",
+    );
     await row.hover();
     await expect
       .poll(async () =>
-        handle.evaluate(
-          (el) => parseFloat(getComputedStyle(el).opacity) || 0,
-        ),
+        handle.evaluate((el) => parseFloat(getComputedStyle(el).opacity) || 0),
       )
       .toBeGreaterThan(0.9);
   });

--- a/frontend/e2e/drag-handle-hover.spec.ts
+++ b/frontend/e2e/drag-handle-hover.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "./fixtures";
+
+// Regression for #372: reorder drag handles must be hidden until row hover,
+// so they don't clutter every row in the resting state.
+test.describe("drag handle hover affordance", () => {
+  test("folder-config handle is hidden until row is hovered", async ({
+    page,
+  }) => {
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    await page.locator('button[aria-label="Settings"]').click();
+    await page
+      .locator('[data-slot="dialog-content"]')
+      .waitFor({ state: "visible" });
+    await page.getByText("Folders", { exact: true }).click();
+
+    const handle = page
+      .locator('[data-testid="folder-config-drag-handle"]')
+      .first();
+    await handle.waitFor({ state: "attached" });
+
+    // Resting: opacity 0 (handle is in DOM and accessible, just invisible).
+    expect(
+      await handle.evaluate(
+        (el) => parseFloat(getComputedStyle(el).opacity) || 0,
+      ),
+    ).toBeLessThan(0.05);
+
+    // Hover the row that owns this handle: opacity transitions to 1.
+    const row = handle.locator("xpath=ancestor::*[contains(@class,'group')][1]");
+    await row.hover();
+    await expect
+      .poll(async () =>
+        handle.evaluate(
+          (el) => parseFloat(getComputedStyle(el).opacity) || 0,
+        ),
+      )
+      .toBeGreaterThan(0.9);
+  });
+});

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -416,7 +416,7 @@ function TrackRowInner({
       <div
         role="row"
         tabIndex={0}
-        className={`border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isSelected ? "bg-[var(--brand-soft)]" : isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
+        className={`group border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isSelected ? "bg-[var(--brand-soft)]" : isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
         onClick={onExpand}
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}
@@ -435,8 +435,9 @@ function TrackRowInner({
             {...dragHandle.listeners}
             tabIndex={-1}
             aria-label="Drag to reorder"
+            data-testid="likes-row-drag-handle"
             onClick={(e) => e.stopPropagation()}
-            className="text-muted-foreground/50 hover:text-foreground flex size-4 shrink-0 cursor-grab items-center justify-center active:cursor-grabbing"
+            className="text-muted-foreground/50 hover:text-foreground flex size-4 shrink-0 cursor-grab items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 active:cursor-grabbing"
           >
             <GripVertical className="size-3" />
           </button>

--- a/frontend/src/components/rulesets/folder-config-manager.tsx
+++ b/frontend/src/components/rulesets/folder-config-manager.tsx
@@ -62,7 +62,7 @@ function FolderRow({
         ref={setNodeRef}
         style={style}
         className={cn(
-          "border-border bg-card flex items-center gap-2 rounded-md border px-2.5 py-2",
+          "group border-border bg-card flex items-center gap-2 rounded-md border px-2.5 py-2",
           isDragging && "opacity-50 shadow-lg",
         )}
       >
@@ -72,7 +72,9 @@ function FolderRow({
               {...attributes}
               {...listeners}
               tabIndex={-1}
-              className="text-muted-foreground hover:text-muted-foreground shrink-0 cursor-grab transition-colors active:cursor-grabbing"
+              aria-label="Drag to reorder"
+              data-testid="folder-config-drag-handle"
+              className="text-muted-foreground hover:text-muted-foreground shrink-0 cursor-grab opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 active:cursor-grabbing"
             >
               <GripVertical className="size-3.5" />
             </button>

--- a/frontend/src/components/rulesets/rule-card.tsx
+++ b/frontend/src/components/rulesets/rule-card.tsx
@@ -471,10 +471,12 @@ export function RuleCard({
         <button
           {...(draggable ? { ...attributes, ...listeners } : {})}
           tabIndex={-1}
+          aria-label="Drag to reorder"
+          data-testid="rule-card-drag-handle"
           className={cn(
-            "text-muted-foreground group-hover:text-muted-foreground shrink-0 transition-colors",
+            "text-muted-foreground shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100",
             isBuiltin || !draggable
-              ? "pointer-events-none cursor-default opacity-30"
+              ? "pointer-events-none cursor-default group-hover:opacity-30"
               : "cursor-grab active:cursor-grabbing",
           )}
         >


### PR DESCRIPTION
## Summary
- Reorder grip handles on rule cards, likes-table rows, and folder-config items were always visible — cluttering every row.
- Adopt the existing filesystem-tree pattern: `opacity-0` by default, fade in on `group-hover` and `focus-visible` so keyboard focus still reveals them.
- Add a Playwright regression (`drag-handle-hover.spec.ts`) that asserts resting opacity is 0 and goes to 1 on row hover.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npx playwright test drag-handle-hover` (passes; verified it fails when the opacity classes are removed).
- [x] Manual: open Settings → Rulesets / Folders, hover rows — handles fade in. /library?source=soundcloud likes rows behave the same once SC data is loaded.

Closes #372