### PR TITLE
fix(track-editor): clearer Link SoundCloud track button

### DIFF
--- a/frontend/e2e/sc-link-button.spec.ts
+++ b/frontend/e2e/sc-link-button.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "./fixtures";
+
+// #376: the "Link selected SC track" button must have a clear icon and tooltip
+// instead of relying on a bare title attribute and the source brand icon.
+test.describe("SoundCloud link-track button", () => {
+  test("has descriptive aria-label and tooltip on the link icon", async ({
+    page,
+  }) => {
+    const filePath = "/music/test - track.mp3";
+
+    const browseItem = {
+      file_path: filePath,
+      file_name: "test - track.mp3",
+      file_size: 1000,
+      file_format: "mp3",
+      has_artwork: false,
+      title: "track",
+      artist: "test",
+      bpm: null,
+      key: null,
+      genre: null,
+      comment: null,
+      release_date: null,
+      remixers: null,
+      soundcloud_id: null,
+      duration: 200,
+      mtime: Date.now() / 1000,
+    };
+    const browseBody = {
+      items: [browseItem],
+      total: 1,
+      page: 1,
+      size: 50,
+      pages: 1,
+    };
+    await page.route("**/api/metadata/folders/*/browse*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(browseBody),
+      }),
+    );
+    await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(browseBody),
+      }),
+    );
+
+    await page.route(/\/api\/metadata\/files\/.+\/info/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          file_path: filePath,
+          file_name: "test - track.mp3",
+          title: "track",
+          artist: "test",
+          bpm: null,
+          key: null,
+          genre: null,
+          comment: null,
+          release_date: null,
+          remixers: null,
+          has_artwork: false,
+          is_ready: true,
+          missing_fields: [],
+          issues: [],
+        }),
+      }),
+    );
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // Click the row to open the editor (same flow as screenshots.spec).
+    const dataRow = page.locator('[data-index="0"]');
+    await dataRow.waitFor({ state: "visible" });
+    await dataRow.locator("[data-file-path]").first().click();
+    await page
+      .locator('input[data-slot="input"][placeholder="Title"]')
+      .waitFor({ state: "visible" });
+
+    const btn = page.locator('[data-testid="link-sc-track-button"]');
+    await btn.waitFor({ state: "attached" });
+    await expect(btn).toHaveAttribute(
+      "aria-label",
+      /Link selected SoundCloud track/i,
+    );
+
+    // The icon is Link2, not the source brand icon. Lucide marks every icon
+    // with a `lucide-<name>` class on the root <svg>.
+    const svgClass = await btn.locator("svg").first().getAttribute("class");
+    expect(svgClass ?? "").toMatch(/lucide-link-?2/);
+  });
+});

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -1876,7 +1876,9 @@ export function TrackEditor({
                             <Button
                               variant="ghost"
                               size="icon-xs"
-                              onClick={() => setCommentData(originalCommentData)}
+                              onClick={() =>
+                                setCommentData(originalCommentData)
+                              }
                               aria-label="Reset SoundCloud link"
                             >
                               <RotateCcw />

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   ChevronDown,
   Image as ImageIcon,
+  Link2,
   Loader2,
   MoveRight,
   RotateCcw,
@@ -1812,56 +1813,82 @@ export function TrackEditor({
                       </span>
                     )}
                   </div>
-                  <div className="flex shrink-0 scale-75 gap-0.5 opacity-0 transition-all duration-150 ease-out group-hover:scale-100 group-hover:opacity-100">
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() => {
-                        if (!selectedScTrack) return;
-                        const meta =
-                          activeSource.extractMetadata(selectedScTrack);
-                        setCommentData({
-                          soundcloud_id: meta.source_id,
-                          soundcloud_permalink: meta.source_permalink,
-                        });
-                        setScLinkEnabled(true);
-                      }}
-                      disabled={!selectedScTrack}
-                      title="Link selected SC track"
-                    >
-                      <activeSource.Icon className="size-3" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() =>
-                        setCommentData({
-                          soundcloud_id: "",
-                          soundcloud_permalink: "",
-                        })
-                      }
-                      disabled={
-                        !commentData.soundcloud_id &&
-                        !commentData.soundcloud_permalink
-                      }
-                      title="Clear link"
-                    >
-                      <Trash2 />
-                    </Button>
-                    {(commentData.soundcloud_id !==
-                      originalCommentData.soundcloud_id ||
-                      commentData.soundcloud_permalink !==
-                        originalCommentData.soundcloud_permalink) && (
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() => setCommentData(originalCommentData)}
-                        title="Reset"
-                      >
-                        <RotateCcw />
-                      </Button>
-                    )}
-                  </div>
+                  <TooltipProvider delayDuration={300}>
+                    <div className="flex shrink-0 scale-75 gap-0.5 opacity-0 transition-all duration-150 ease-out group-hover:scale-100 group-hover:opacity-100">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => {
+                              if (!selectedScTrack) return;
+                              const meta =
+                                activeSource.extractMetadata(selectedScTrack);
+                              setCommentData({
+                                soundcloud_id: meta.source_id,
+                                soundcloud_permalink: meta.source_permalink,
+                              });
+                              setScLinkEnabled(true);
+                            }}
+                            disabled={!selectedScTrack}
+                            data-testid="link-sc-track-button"
+                            aria-label="Link selected SoundCloud track to this file"
+                          >
+                            <Link2 className="size-3" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={4}>
+                          {selectedScTrack
+                            ? "Link selected SoundCloud track"
+                            : "Pick a SoundCloud track in the search panel first"}
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() =>
+                              setCommentData({
+                                soundcloud_id: "",
+                                soundcloud_permalink: "",
+                              })
+                            }
+                            disabled={
+                              !commentData.soundcloud_id &&
+                              !commentData.soundcloud_permalink
+                            }
+                            aria-label="Clear SoundCloud link"
+                          >
+                            <Trash2 />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={4}>
+                          Clear link
+                        </TooltipContent>
+                      </Tooltip>
+                      {(commentData.soundcloud_id !==
+                        originalCommentData.soundcloud_id ||
+                        commentData.soundcloud_permalink !==
+                          originalCommentData.soundcloud_permalink) && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              onClick={() => setCommentData(originalCommentData)}
+                              aria-label="Reset SoundCloud link"
+                            >
+                              <RotateCcw />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" sideOffset={4}>
+                            Reset
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </TooltipProvider>
                 </div>
 
                 {/* Compact track preview (search closed, track selected) */}


### PR DESCRIPTION
## Summary
- The "link the selected SoundCloud track" button used the SC brand icon and a bare `title` attribute, reading like "open SoundCloud" rather than "link this track."
- Swap to a `Link2` icon, give every button in the SC link row an explicit `aria-label`, and replace the bare `title`s with shadcn `Tooltip`s that explain what each button does (and why the link button is disabled when no SC track is selected in the search panel).
- Placement and hover-reveal animation are unchanged so it stays aligned with the other SC actions.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npx playwright test sc-link-button` — passes; fails on main (no testid / Link2).
- [ ] Manual: open a track, hover the SC link row → tooltips read clearly; pick an SC result in the search panel → link button enables and tooltip text switches.

Closes #376