### PR TITLE
fix(rulesets): refresh cached ruleset lists when one is created or edited

### DIFF
--- a/frontend/e2e/ruleset-list-refresh.spec.ts
+++ b/frontend/e2e/ruleset-list-refresh.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "./fixtures";
+
+// #374: a ruleset created in Settings → Rulesets must appear in the
+// folder-tree right-click "Ruleset" submenu without reloading the page.
+// Before the fix, that menu used a snapshot of `getRulesets()` from mount.
+test("new ruleset shows up in folder-tree context menu without reload", async ({
+  page,
+}) => {
+  const store: { id: string; name: string; rules: unknown[] }[] = [];
+  await page.route("**/api/rulesets", (route) => {
+    if (route.request().method() === "POST") {
+      const body = JSON.parse(route.request().postData() || "{}");
+      const created = {
+        id: "rs-" + (store.length + 1),
+        name: body.name,
+        is_builtin: false,
+        rules: body.rules ?? [],
+        required_attributes: [],
+      };
+      store.push(created);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(created),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rulesets: store,
+        active_ruleset_id: store[0]?.id ?? null,
+      }),
+    });
+  });
+
+  await page.goto("/library");
+  await page.waitForLoadState("networkidle");
+
+  // Open Settings → Rulesets and create a new ruleset.
+  await page.locator('button[aria-label="Settings"]').click();
+  await page
+    .locator('[data-slot="dialog-content"]')
+    .waitFor({ state: "visible" });
+  await page.getByText("Rulesets", { exact: true }).click();
+  await page.getByText("New ruleset").click();
+  // dispatchRulesetsChanged fires synchronously inside handleCreate after the
+  // POST resolves — give listeners a tick to run before closing the dialog.
+  await page.waitForTimeout(200);
+
+  // Close the dialog so the context menu has nothing on top of it.
+  await page.keyboard.press("Escape");
+  await page
+    .locator('[data-slot="dialog-content"]')
+    .waitFor({ state: "hidden" });
+
+  // Right-click the root folder ("music") and hover the Ruleset submenu.
+  // The default name from handleCreate is "New Ruleset"; before the fix the
+  // tree's allRulesets snapshot was stale and this menuitem wouldn't appear.
+  const treeRoot = page.getByRole("button", { name: /music/i }).first();
+  await treeRoot.waitFor({ state: "visible" });
+  await treeRoot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: /^Ruleset$/ }).hover();
+  await expect(
+    page.getByRole("menuitem", { name: "New Ruleset" }),
+  ).toBeVisible();
+});

--- a/frontend/src/app/library/filesystem-view.tsx
+++ b/frontend/src/app/library/filesystem-view.tsx
@@ -41,6 +41,7 @@ import { useColumnPrefs } from "@/lib/columns/use-column-prefs";
 import { useFilterSchema } from "@/lib/filters/use-filter-schema";
 import { useFilterState } from "@/lib/filters/use-filter-state";
 import { usePlayer } from "@/lib/player-context";
+import { onRulesetsChanged } from "@/lib/rulesets-events";
 import { searchParams } from "@/lib/search-params";
 import { useResizable } from "@/lib/use-resizable";
 import { cn } from "@/lib/utils";
@@ -115,16 +116,21 @@ export function FilesystemView() {
       })
       .catch(() => {});
 
-    api
-      .getRulesets()
-      .then((data) => {
-        if (!cancelled) setAllRulesets(data.rulesets);
-      })
-      .catch(() => {});
+    function loadRulesets() {
+      api
+        .getRulesets()
+        .then((data) => {
+          if (!cancelled) setAllRulesets(data.rulesets);
+        })
+        .catch(() => {});
+    }
+    loadRulesets();
+    const unsubscribeRulesets = onRulesetsChanged(loadRulesets);
 
     return () => {
       cancelled = true;
       window.removeEventListener("folders-config-changed", loadFolders);
+      unsubscribeRulesets();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -61,6 +61,7 @@ import {
   type TrackInfo,
   type TrackInfoUpdateRequest,
 } from "@/lib/api";
+import { onRulesetsChanged } from "@/lib/rulesets-events";
 import { soundCloudSource } from "@/lib/sources/soundcloud";
 import type { SourceTrack } from "@/lib/sources/types";
 import {
@@ -189,18 +190,30 @@ export function TrackEditor({
   // Active ruleset (shown in Apply Rules popover) — only set when the folder has one assigned
   const [activeRuleset, setActiveRuleset] = useState<Ruleset | null>(null);
   useEffect(() => {
-    if (folderRulesetId) {
+    if (!folderRulesetId) {
+      setActiveRuleset(null);
+      return;
+    }
+    let cancelled = false;
+    function load() {
       api
         .getRulesets()
-        .then((data) =>
+        .then((data) => {
+          if (cancelled) return;
           setActiveRuleset(
             data.rulesets.find((r) => r.id === folderRulesetId) ?? null,
-          ),
-        )
-        .catch(() => setActiveRuleset(null));
-    } else {
-      setActiveRuleset(null);
+          );
+        })
+        .catch(() => {
+          if (!cancelled) setActiveRuleset(null);
+        });
     }
+    load();
+    const unsubscribe = onRulesetsChanged(load);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [folderRulesetId]);
 
   // Compute which of the ruleset's required attributes are missing on the current track

--- a/frontend/src/components/rulesets/ruleset-manager.tsx
+++ b/frontend/src/components/rulesets/ruleset-manager.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { api, type Ruleset } from "@/lib/api";
+import { dispatchRulesetsChanged } from "@/lib/rulesets-events";
 import { cn } from "@/lib/utils";
 
 import { RulesetEditor } from "./ruleset-editor";
@@ -45,6 +46,7 @@ export function RulesetManager() {
       const updated = rulesets.filter((r) => r.id !== id);
       setRulesets(updated);
       if (selectedId === id) setSelectedId(updated[0]?.id ?? "");
+      dispatchRulesetsChanged();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to delete";
       toast.error(msg);
@@ -62,6 +64,7 @@ export function RulesetManager() {
       setRulesets((prev) => [...prev, created]);
       setSelectedId(created.id);
       setPendingEdit(created);
+      dispatchRulesetsChanged();
     } catch {
       toast.error("Failed to create ruleset");
     }
@@ -86,6 +89,7 @@ export function RulesetManager() {
       setRulesets((prev) => prev.map((r) => (r.id === saved.id ? saved : r)));
       setPendingEdit(null);
       toast.success("Saved");
+      dispatchRulesetsChanged();
     } catch {
       toast.error("Failed to save");
     } finally {

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -50,6 +50,7 @@ import {
   type FolderRulesetBinding,
   type Ruleset,
 } from "@/lib/api";
+import { onRulesetsChanged } from "@/lib/rulesets-events";
 import { getSetting, setSetting } from "@/lib/settings";
 import { isTauri } from "@/lib/tauri";
 import { checkForUpdate, type UpdateResult } from "@/lib/updater";
@@ -200,6 +201,16 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
         setLoaded(true);
       },
     );
+  }, [open]);
+
+  // Re-fetch the ruleset list when it changes elsewhere in the dialog
+  // (RulesetManager create/save/delete) so per-folder dropdowns and the
+  // Folders section see the new rulesets without having to reopen the dialog.
+  useEffect(() => {
+    if (!open) return;
+    return onRulesetsChanged(() => {
+      api.getRulesets().then((data) => setAllRulesets(data.rulesets));
+    });
   }, [open]);
 
   async function handleAutoUpdateChange(checked: boolean) {

--- a/frontend/src/lib/rulesets-events.ts
+++ b/frontend/src/lib/rulesets-events.ts
@@ -1,0 +1,21 @@
+/**
+ * Tiny event bus used to invalidate cached ruleset lists across the app
+ * (filesystem tree right-click menu, track editor, settings dialog).
+ *
+ * Each surface fetches `api.getRulesets()` once on mount and would otherwise
+ * miss rulesets created or renamed elsewhere — see #374. Anything that
+ * mutates the rulesets collection should call `dispatchRulesetsChanged()`;
+ * subscribers re-fetch.
+ */
+export const RULESETS_CHANGED_EVENT = "rulesets-changed";
+
+export function dispatchRulesetsChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(RULESETS_CHANGED_EVENT));
+}
+
+export function onRulesetsChanged(handler: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(RULESETS_CHANGED_EVENT, handler);
+  return () => window.removeEventListener(RULESETS_CHANGED_EVENT, handler);
+}


### PR DESCRIPTION
## Summary
- Rulesets are loaded once in several places (folder-tree right-click menu, track editor's Apply Rules popover, settings dialog's per-folder dropdowns). Creating a ruleset in Settings → Rulesets only showed up after a page reload because none of those caches were invalidated.
- Add a tiny window-event bus (`rulesets-changed`) in `lib/rulesets-events.ts`. `RulesetManager` fires it after create / save / delete; the three caches subscribe and re-run `api.getRulesets()`.

## Test plan
- [x] `npm run typecheck`, `npm run lint`.
- [x] `npx playwright test ruleset-list-refresh` — passes; verified it fails when the listener in `filesystem-view` is removed.
- [x] Manual: open `/library`, Settings → Rulesets, click "New ruleset", close the dialog, right-click a folder → "Ruleset" submenu lists the new ruleset.

Closes #374