### PR TITLE
fix(player): pause when audio output device disconnects

### DIFF
--- a/frontend/e2e/audio-output-disconnect.spec.ts
+++ b/frontend/e2e/audio-output-disconnect.spec.ts
@@ -113,4 +113,98 @@ test.describe("audio output disconnect", () => {
     // the toggle button flips back to "Play".
     await expect(toggle).toHaveAttribute("aria-label", "Play");
   });
+
+  test("audiooutput count drop on devicechange flips React state to paused", async ({
+    page,
+  }) => {
+    await page.route("**/api/metadata/folders/*/browse*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [MOCK_FILE],
+          total: 1,
+          page: 1,
+          size: 50,
+          pages: 1,
+        }),
+      }),
+    );
+    await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [MOCK_FILE],
+          total: 1,
+          page: 1,
+          size: 50,
+          pages: 1,
+        }),
+      }),
+    );
+    await page.route("**/api/metadata/files/*/info", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_TRACK_INFO),
+      }),
+    );
+    await page.route("**/api/metadata/files/*/peaks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ peaks: Array(200).fill(0.3) }),
+      }),
+    );
+
+    // Stub enumerateDevices BEFORE navigation so the player effect's initial
+    // count snapshot uses our two-output baseline. The listener pauses when a
+    // devicechange event fires and the count has dropped — same signal a real
+    // AirPods disconnect produces in WKWebView/Chromium.
+    await page.addInitScript(() => {
+      const w = window as unknown as { __outputCount: number };
+      w.__outputCount = 2;
+      const fakeDevices = () =>
+        Array.from({ length: w.__outputCount }, () => ({
+          deviceId: "",
+          kind: "audiooutput" as const,
+          label: "",
+          groupId: "",
+          toJSON() {
+            return {
+              deviceId: "",
+              kind: "audiooutput",
+              label: "",
+              groupId: "",
+            };
+          },
+        }));
+      navigator.mediaDevices.enumerateDevices = async () =>
+        fakeDevices() as unknown as MediaDeviceInfo[];
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+    await page.locator('[data-file-path="track.mp3"]').click();
+
+    const player = page.getByTestId("waveform-player");
+    await expect(player).toBeVisible();
+
+    const toggle = page.getByTestId("player-toggle");
+    if ((await toggle.getAttribute("aria-label")) !== "Pause") {
+      await toggle.click();
+    }
+    await expect(toggle).toHaveAttribute("aria-label", "Pause");
+
+    // Drop one output and fire devicechange — mirrors AirPods leaving the
+    // device list. The listener should observe the count decrease and pause.
+    await page.evaluate(() => {
+      const w = window as unknown as { __outputCount: number };
+      w.__outputCount = 1;
+      navigator.mediaDevices.dispatchEvent(new Event("devicechange"));
+    });
+
+    await expect(toggle).toHaveAttribute("aria-label", "Play");
+  });
 });

--- a/frontend/e2e/audio-output-disconnect.spec.ts
+++ b/frontend/e2e/audio-output-disconnect.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Bugfix: when the audio output device disconnects (headphones unplugged,
+ * Bluetooth speaker leaves the room), the OS pauses the underlying
+ * <audio> element but our React `isPlaying` state stays true — the UI shows
+ * "playing" with no sound. The fix listens for the audio element's `pause`
+ * event and propagates it to the player context when it wasn't us who
+ * initiated it.
+ */
+
+const MOCK_FILE = {
+  file_path: "track.mp3",
+  file_name: "track.mp3",
+  file_size: 5 * 1024 * 1024,
+  file_format: ".mp3",
+  has_artwork: false,
+  bpm: 120,
+};
+
+const MOCK_TRACK_INFO = {
+  file_path: "track.mp3",
+  file_name: "track.mp3",
+  title: "Test Track",
+  artist: "Test Artist",
+  bpm: 120,
+  key: null,
+  genre: null,
+  comment: null,
+  release_date: null,
+  remixers: [],
+  has_artwork: false,
+  is_ready: false,
+  missing_fields: [],
+  issues: [],
+};
+
+test.describe("audio output disconnect", () => {
+  test("OS-level pause on the <audio> element flips React state to paused", async ({
+    page,
+  }) => {
+    await page.route("**/api/metadata/folders/*/browse*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [MOCK_FILE],
+          total: 1,
+          page: 1,
+          size: 50,
+          pages: 1,
+        }),
+      }),
+    );
+    await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [MOCK_FILE],
+          total: 1,
+          page: 1,
+          size: 50,
+          pages: 1,
+        }),
+      }),
+    );
+    await page.route("**/api/metadata/files/*/info", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_TRACK_INFO),
+      }),
+    );
+    await page.route("**/api/metadata/files/*/peaks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ peaks: Array(200).fill(0.3) }),
+      }),
+    );
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+    await page.locator('[data-file-path="track.mp3"]').click();
+
+    const player = page.getByTestId("waveform-player");
+    await expect(player).toBeVisible();
+
+    // Click the toggle to start playback so isPlaying flips to true. (In
+    // headless tests the audio element may not actually emit sound, but the
+    // React state — which our pause handler reads via isPlayingRef — does.)
+    const toggle = page.getByTestId("player-toggle");
+    if ((await toggle.getAttribute("aria-label")) !== "Pause") {
+      await toggle.click();
+    }
+    await expect(toggle).toHaveAttribute("aria-label", "Pause");
+
+    // Wait until the <audio> element our handler is attached to actually
+    // exists in the DOM (it's created inside an async init effect).
+    await page.waitForFunction(() => document.querySelector("audio") !== null);
+
+    // Simulate the OS pausing the media externally — e.g. headphones unplug.
+    // Dispatching a 'pause' event mirrors what the platform does when the
+    // audio output device disappears: the element is already paused, the
+    // event fires, and our handler must propagate that to React state.
+    await page.evaluate(() => {
+      const audio = document.querySelector("audio");
+      audio?.dispatchEvent(new Event("pause"));
+    });
+
+    // The handler should call player-context's pause() → isPlaying=false →
+    // the toggle button flips back to "Play".
+    await expect(toggle).toHaveAttribute("aria-label", "Play");
+  });
+});

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -66,6 +66,7 @@ export function WaveformPlayer() {
     currentTrack,
     isPlaying,
     toggle,
+    pause,
     next,
     previous,
     peekNext,
@@ -229,7 +230,24 @@ export function WaveformPlayer() {
 
       const audio = new Audio();
       audio.preload = "auto";
+      // Attach to DOM so platform pause events (headphones unplugged, etc.)
+      // dispatch reliably and so tests can reach the element.
+      audio.hidden = true;
+      document.body.appendChild(audio);
       audioRef.current = audio;
+
+      // Sync React state when the OS pauses our audio behind our back —
+      // e.g. headphones unplugged or Bluetooth device disconnects. Without
+      // this, isPlaying stays true and the UI shows "playing" with no sound.
+      // We ignore self-initiated pauses two ways: ws.pause() fires this
+      // event, but by then isPlayingRef is already false (the [isPlaying]
+      // effect updated it). Track-change cleanup also fires pause(), but by
+      // then audioRef has been swapped to the new track's element, so the
+      // ref-equality check skips it.
+      audio.addEventListener("pause", () => {
+        if (audioRef.current !== audio) return;
+        if (isPlayingRef.current && audio.paused) pause();
+      });
 
       // Start playback as soon as the browser has enough buffered data.
       // This fires well before WaveSurfer's `ready` (which waits for peaks
@@ -472,6 +490,7 @@ export function WaveformPlayer() {
       if (audioRef.current) {
         audioRef.current.pause();
         audioRef.current.src = "";
+        audioRef.current.remove();
         audioRef.current = null;
       }
     };

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -155,8 +155,12 @@ export function WaveformPlayer() {
         : undefined,
     });
     ms.playbackState = isPlaying ? "playing" : "paused";
-    ms.setActionHandler("play", () => toggle());
-    ms.setActionHandler("pause", () => toggle());
+    ms.setActionHandler("play", () => {
+      if (!isPlayingRef.current) toggle();
+    });
+    ms.setActionHandler("pause", () => {
+      if (isPlayingRef.current) toggle();
+    });
     ms.setActionHandler("nexttrack", hasNext ? () => next() : null);
     ms.setActionHandler("previoustrack", hasPrevious ? () => previous() : null);
     return () => {
@@ -166,6 +170,35 @@ export function WaveformPlayer() {
       ms.setActionHandler("previoustrack", null);
     };
   }, [currentTrack, isPlaying, toggle, next, previous, hasNext, hasPrevious]);
+
+  // Pause when the active audio output device disappears (AirPods disconnect,
+  // headphones unplugged). The audio element's own `pause` event isn't
+  // reliable here — WKWebView/Safari pauses natively, but Chromium-based
+  // engines keep playing through the new default output. `devicechange` plus
+  // an audiooutput count drop is the canonical signal in both.
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.mediaDevices) return;
+    const md = navigator.mediaDevices;
+    let prevCount = 0;
+    let cancelled = false;
+    const countOutputs = async () => {
+      const devices = await md.enumerateDevices();
+      return devices.filter((d) => d.kind === "audiooutput").length;
+    };
+    countOutputs().then((n) => {
+      if (!cancelled) prevCount = n;
+    });
+    const onChange = async () => {
+      const next = await countOutputs();
+      if (next < prevCount && isPlayingRef.current) pause();
+      prevCount = next;
+    };
+    md.addEventListener("devicechange", onChange);
+    return () => {
+      cancelled = true;
+      md.removeEventListener("devicechange", onChange);
+    };
+  }, [pause]);
 
   useEffect(() => {
     if (!currentTrack) return;


### PR DESCRIPTION
## Summary
- Fixes the "stop audio if audio source disconnects" todo, scoped to OS audio output disconnects (headphones unplug, Bluetooth speaker drops).
- Before: the OS pauses our `<audio>` element but React `isPlaying` state stays `true` — UI shows "playing" with no sound.
- Now: a `pause` listener on the audio element calls `pause()` on the player context when the pause came from outside our state machine. Self-initiated pauses (our own `ws.pause()`) and track-change cleanup pauses are filtered out (via `isPlayingRef` and an `audioRef` equality check).
- Side effect: attach the audio element to the DOM (hidden) so platform pause events dispatch reliably and tests can reach it.

## Test plan
- [x] New Playwright spec `frontend/e2e/audio-output-disconnect.spec.ts` — opens a track, asserts isPlaying, dispatches a `pause` event on the audio element, asserts the toggle flips back to "Play".
- [x] Confirmed the spec **fails** on `main` (no listener, audio element not in DOM) and **passes** with the fix.
- [x] `bpm-pitcher` specs still pass — the audio-element-in-DOM change didn't regress existing playback flows.
- [x] `npm run lint` clean.

## Notes
- The "autoskip unplayable tracks" todo (P1) is still pending — will follow as a separate PR.
- "audio source disconnects" was originally interpreted as stream/network failure; clarified with the user it means OS-level output-device disconnect.