### PR TITLE
fix(weekly): correctly filter for reposts

### DIFF
--- a/frontend/e2e/weekly-release-type-filter.spec.ts
+++ b/frontend/e2e/weekly-release-type-filter.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Weekly view: the new "release_type" filter (release vs repost). The feed
+ * now includes both `track` and `track-repost` activities and tags each
+ * track with `isRepost`; the schema-driven filter narrows the visible feed
+ * to one or the other.
+ *
+ * This spec exercises the user-visible URL wiring — same pattern as the
+ * existing weekly search/clear-all spec.
+ */
+
+async function mockSoundCloud(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+  });
+
+  await page.route(/api\.soundcloud\.com\/me\/feed\/tracks/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route(/api\.soundcloud\.com\/me\/playlists/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/collection/soundcloud-ids", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ids: [] }),
+    }),
+  );
+}
+
+test.describe("weekly release_type filter", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSoundCloud(page);
+  });
+
+  test("clear-all removes the release_type URL param", async ({ page }) => {
+    await page.goto("/weekly?release_type=repost");
+    await expect(page).toHaveURL(/release_type=repost/);
+
+    await page.getByRole("button", { name: /clear all/i }).click();
+    await expect(page).not.toHaveURL(/release_type/);
+  });
+});

--- a/frontend/src/app/weekly/build-weekly-schema.ts
+++ b/frontend/src/app/weekly/build-weekly-schema.ts
@@ -25,6 +25,7 @@ export function buildWeeklySchema(
   let durationMax = -Infinity;
   let hasDuration = false;
   const trackTypeCounts: Record<string, number> = { track: 0, set: 0 };
+  const releaseTypeCounts: Record<string, number> = { release: 0, repost: 0 };
 
   for (const t of tracks) {
     if (t.genre) genreCounts[t.genre] = (genreCounts[t.genre] ?? 0) + 1;
@@ -36,6 +37,8 @@ export function buildWeeklySchema(
       if (s < 720) trackTypeCounts.track += 1;
       else trackTypeCounts.set += 1;
     }
+    if (t.isRepost) releaseTypeCounts.repost += 1;
+    else releaseTypeCounts.release += 1;
   }
 
   const genres = Object.keys(genreCounts).sort((a, b) => a.localeCompare(b));
@@ -70,6 +73,13 @@ export function buildWeeklySchema(
         kind: "enum",
         options: ["track", "set"],
         counts: trackTypeCounts,
+      },
+      {
+        id: "release_type",
+        label: "Source",
+        kind: "enum",
+        options: ["release", "repost"],
+        counts: releaseTypeCounts,
       },
       { id: "include_seen", label: "Include previously added", kind: "bool" },
       {

--- a/frontend/src/app/weekly/use-weekly-filter.test.ts
+++ b/frontend/src/app/weekly/use-weekly-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { SCTrack } from "@/lib/soundcloud";
+
+import {
+  makeWeeklyFilterPredicate,
+  type WeeklyFilterOptions,
+} from "./use-weekly-filter";
+
+const baseOptions: WeeklyFilterOptions = {
+  search: "",
+  genres: [],
+  minDuration: null,
+  maxDuration: null,
+  trackType: null,
+  releaseType: null,
+  excludeSeen: false,
+  inCollection: null,
+  excludeOwnLikes: false,
+};
+
+function makeTrack(overrides: Partial<SCTrack>): SCTrack {
+  return {
+    urn: "soundcloud:tracks:1",
+    title: "Track",
+    duration: 200_000,
+    ...overrides,
+  } as SCTrack;
+}
+
+describe("weekly filter — release_type", () => {
+  const release = makeTrack({
+    urn: "soundcloud:tracks:1",
+    title: "Original",
+    isRepost: false,
+  });
+  const repost = makeTrack({
+    urn: "soundcloud:tracks:2",
+    title: "Reposted",
+    isRepost: true,
+  });
+
+  it("passes both when filter is null", () => {
+    const predicate = makeWeeklyFilterPredicate(baseOptions);
+    expect(predicate(release)).toBe(true);
+    expect(predicate(repost)).toBe(true);
+  });
+
+  it("passes only releases when filter is 'release'", () => {
+    const predicate = makeWeeklyFilterPredicate({
+      ...baseOptions,
+      releaseType: "release",
+    });
+    expect(predicate(release)).toBe(true);
+    expect(predicate(repost)).toBe(false);
+  });
+
+  it("passes only reposts when filter is 'repost'", () => {
+    const predicate = makeWeeklyFilterPredicate({
+      ...baseOptions,
+      releaseType: "repost",
+    });
+    expect(predicate(release)).toBe(false);
+    expect(predicate(repost)).toBe(true);
+  });
+
+  it("treats undefined isRepost as a release", () => {
+    const untagged = makeTrack({ urn: "soundcloud:tracks:3" });
+    const releaseOnly = makeWeeklyFilterPredicate({
+      ...baseOptions,
+      releaseType: "release",
+    });
+    const repostOnly = makeWeeklyFilterPredicate({
+      ...baseOptions,
+      releaseType: "repost",
+    });
+    expect(releaseOnly(untagged)).toBe(true);
+    expect(repostOnly(untagged)).toBe(false);
+  });
+});

--- a/frontend/src/app/weekly/use-weekly-filter.ts
+++ b/frontend/src/app/weekly/use-weekly-filter.ts
@@ -9,6 +9,7 @@ export interface WeeklyFilterOptions {
   minDuration: number | null;
   maxDuration: number | null;
   trackType: "track" | "set" | null;
+  releaseType: "release" | "repost" | null;
   excludeSeen: boolean;
   inCollection: boolean | null;
   excludeOwnLikes: boolean;
@@ -28,12 +29,19 @@ export function filterStateToWeeklyOptions(
     (trackTypes[0] === "track" || trackTypes[0] === "set")
       ? (trackTypes[0] as "track" | "set")
       : null;
+  const releaseTypes = (state.release_type as string[] | undefined) ?? [];
+  const releaseType =
+    releaseTypes.length === 1 &&
+    (releaseTypes[0] === "release" || releaseTypes[0] === "repost")
+      ? (releaseTypes[0] as "release" | "repost")
+      : null;
   return {
     search: (state.search as string | undefined) ?? "",
     genres: (state.genre as string[] | undefined) ?? [],
     minDuration: duration[0],
     maxDuration: duration[1],
     trackType,
+    releaseType,
     // Default is EXCLUDE; user opts into including previously-added tracks.
     excludeSeen: state.include_seen !== true,
     inCollection:
@@ -89,6 +97,8 @@ export function makeWeeklyFilterPredicate(
       if (options.trackType === "track" && durationSec >= 720) return false;
       if (options.trackType === "set" && durationSec < 720) return false;
     }
+    if (options.releaseType === "release" && track.isRepost) return false;
+    if (options.releaseType === "repost" && !track.isRepost) return false;
     if (options.excludeSeen && seenTrackIds) {
       const id = extractId(track);
       if (id && seenTrackIds.has(id)) return false;

--- a/frontend/src/lib/soundcloud.ts
+++ b/frontend/src/lib/soundcloud.ts
@@ -258,14 +258,14 @@ export async function getFeedTracksPage(
   const tracks = (data.collection ?? [])
     .filter(
       (item) =>
-        (item.type === "track" || item.type === "track-repost") && item.origin,
+        (item.type === "track" || item.type === "track:repost") && item.origin,
     )
     .map((item) => ({
       ...(item.origin as SCTrack),
       // Use the activity date (when it appeared in the feed / was reposted),
       // not the track's original upload date.
       created_at: item.created_at ?? (item.origin as SCTrack).created_at,
-      isRepost: item.type === "track-repost",
+      isRepost: item.type === "track:repost",
     }));
 
   return { tracks, nextHref: data.next_href ?? undefined };

--- a/frontend/src/lib/soundcloud.ts
+++ b/frontend/src/lib/soundcloud.ts
@@ -10,7 +10,11 @@ import type { components, paths } from "@/generated/soundcloud";
 
 import { ensureValidToken } from "./auth";
 
-export type SCTrack = components["schemas"]["Track"];
+export type SCTrack = components["schemas"]["Track"] & {
+  /** Set by the weekly feed parser when the activity was a track-repost
+   * rather than an original release. Undefined elsewhere. */
+  isRepost?: boolean;
+};
 export type SCPlaylist = components["schemas"]["Playlist"];
 export type SCUser = components["schemas"]["User"];
 
@@ -252,12 +256,16 @@ export async function getFeedTracksPage(
   }
 
   const tracks = (data.collection ?? [])
-    .filter((item) => item.type === "track" && item.origin)
+    .filter(
+      (item) =>
+        (item.type === "track" || item.type === "track-repost") && item.origin,
+    )
     .map((item) => ({
       ...(item.origin as SCTrack),
       // Use the activity date (when it appeared in the feed / was reposted),
       // not the track's original upload date.
       created_at: item.created_at ?? (item.origin as SCTrack).created_at,
+      isRepost: item.type === "track-repost",
     }));
 
   return { tracks, nextHref: data.next_href ?? undefined };


### PR DESCRIPTION
## Summary
- Closes the "Weekly releases filter (releases only, reposts only)" todo.
- Feed parser now includes both `track` and `track-repost` activities (previously reposts were silently dropped) and tags each emitted track with `isRepost`.
- New schema attribute `release_type` (label: "Source") with options `release` / `repost` and per-option counts. Same enum-multiselect UX as the existing `track_type` filter.
- Filter predicate (`makeWeeklyFilterPredicate`) honors a single-value selection just like `trackType`. URL state inherits from the schema-driven filter machinery — no extra wiring.

## Test plan
- [x] New vitest spec `src/app/weekly/use-weekly-filter.test.ts` — covers predicate behavior for `release`, `repost`, and untagged tracks.
- [x] New Playwright spec `e2e/weekly-release-type-filter.spec.ts` — visits `/weekly?release_type=repost`, asserts URL → state binding via the Clear All button. Confirmed it **fails** without the schema change (Clear All never appears because the URL param has no parser binding) and **passes** with it.
- [x] `npm run lint` clean.