### PR TITLE
feat(library): reuse auto-hide tab label pattern in SC tabs

### DIFF
--- a/frontend/e2e/sc-tabs-auto-hide-label.spec.ts
+++ b/frontend/e2e/sc-tabs-auto-hide-label.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * The SoundCloud view's My Library / Discover / Search toggle uses the
+ * shared auto-hide label pattern: only the active tab shows its label;
+ * inactive tabs are icon-only and reveal their label on hover.
+ */
+
+async function setupAuth(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+}
+
+test("active SC tab shows label, inactive tabs collapse", async ({ page }) => {
+  await setupAuth(page);
+  await page.goto("/library?source=soundcloud&tab=me");
+
+  const myLibrary = page.getByRole("radio", { name: "My Library" });
+  const discover = page.getByRole("radio", { name: "Discover" });
+  const search = page.getByRole("radio", { name: "Search" });
+
+  await expect(myLibrary).toBeVisible();
+
+  // The auto-hide pattern animates the label span between max-w-32 (active
+  // or hovered) and max-w-0 (inactive, not hovered). Asserting on the class
+  // captures intent without flaking on transition timing.
+  const label = (tab: typeof myLibrary) =>
+    tab.locator("span").filter({ hasText: /^.+$/ }).last();
+
+  await expect(label(myLibrary)).toHaveClass(/max-w-32/);
+  await expect(label(discover)).toHaveClass(/max-w-0/);
+  await expect(label(search)).toHaveClass(/max-w-0/);
+
+  await discover.click();
+  await expect(page).toHaveURL(/tab=discover/);
+
+  await expect(label(discover)).toHaveClass(/max-w-32/);
+  await expect(label(myLibrary)).toHaveClass(/max-w-0/);
+});

--- a/frontend/src/app/library/library-title.tsx
+++ b/frontend/src/app/library/library-title.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import type { ComponentType, SVGProps } from "react";
 
+import { AutoHideTabLabel } from "@/components/auto-hide-tab-label";
 import { SoundCloudLogo } from "@/components/icons/soundcloud-logo";
 import { cn } from "@/lib/utils";
 
@@ -40,7 +41,6 @@ export function LibraryTitle({ children }: { children?: React.ReactNode }) {
         {SOURCE_IDS.map((id) => {
           const active = id === current;
           const meta = SOURCE_META[id];
-          const Icon = meta.icon;
           const href = `${pathname}?source=${id}`;
           return (
             <Link
@@ -56,17 +56,11 @@ export function LibraryTitle({ children }: { children?: React.ReactNode }) {
                   : "text-muted-foreground hover:text-foreground hover:bg-accent",
               )}
             >
-              <Icon className="size-3.5 shrink-0" />
-              <span
-                className={cn(
-                  "overflow-hidden whitespace-nowrap transition-[max-width,margin-left,opacity] duration-200 ease-out",
-                  active
-                    ? "ml-1.5 max-w-32 opacity-100"
-                    : "ml-0 max-w-0 opacity-0 group-hover:ml-1.5 group-hover:max-w-32 group-hover:opacity-100",
-                )}
-              >
-                {meta.label}
-              </span>
+              <AutoHideTabLabel
+                icon={meta.icon}
+                label={meta.label}
+                active={active}
+              />
             </Link>
           );
         })}

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { AutoHideTabLabel } from "@/components/auto-hide-tab-label";
 import { ColumnVisibilityMenu } from "@/components/columns/column-visibility-menu";
 import { useCommand } from "@/components/command-palette";
 import {
@@ -368,24 +369,36 @@ export function SoundcloudView() {
         >
           <ToggleGroupItem
             value="me"
-            className="h-7 cursor-pointer gap-1.5 px-2 text-xs"
+            aria-label="My Library"
+            className="group h-7 cursor-pointer px-2 text-xs"
           >
-            <Heart className="size-3.5" />
-            My Library
+            <AutoHideTabLabel
+              icon={Heart}
+              label="My Library"
+              active={tab === "me"}
+            />
           </ToggleGroupItem>
           <ToggleGroupItem
             value="discover"
-            className="h-7 cursor-pointer gap-1.5 px-2 text-xs"
+            aria-label="Discover"
+            className="group h-7 cursor-pointer px-2 text-xs"
           >
-            <Compass className="size-3.5" />
-            Discover
+            <AutoHideTabLabel
+              icon={Compass}
+              label="Discover"
+              active={tab === "discover"}
+            />
           </ToggleGroupItem>
           <ToggleGroupItem
             value="search"
-            className="h-7 cursor-pointer gap-1.5 px-2 text-xs"
+            aria-label="Search"
+            className="group h-7 cursor-pointer px-2 text-xs"
           >
-            <Search className="size-3.5" />
-            Search
+            <AutoHideTabLabel
+              icon={Search}
+              label="Search"
+              active={tab === "search"}
+            />
           </ToggleGroupItem>
         </ToggleGroup>
       </LibraryTitle>

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -370,7 +370,7 @@ export function SoundcloudView() {
           <ToggleGroupItem
             value="me"
             aria-label="My Library"
-            className="group h-7 cursor-pointer px-2 text-xs"
+            className="group h-7 cursor-pointer gap-0 px-2 text-xs"
           >
             <AutoHideTabLabel
               icon={Heart}
@@ -381,7 +381,7 @@ export function SoundcloudView() {
           <ToggleGroupItem
             value="discover"
             aria-label="Discover"
-            className="group h-7 cursor-pointer px-2 text-xs"
+            className="group h-7 cursor-pointer gap-0 px-2 text-xs"
           >
             <AutoHideTabLabel
               icon={Compass}
@@ -392,7 +392,7 @@ export function SoundcloudView() {
           <ToggleGroupItem
             value="search"
             aria-label="Search"
-            className="group h-7 cursor-pointer px-2 text-xs"
+            className="group h-7 cursor-pointer gap-0 px-2 text-xs"
           >
             <AutoHideTabLabel
               icon={Search}

--- a/frontend/src/components/auto-hide-tab-label.tsx
+++ b/frontend/src/components/auto-hide-tab-label.tsx
@@ -1,0 +1,38 @@
+import type { ComponentType, SVGProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+/**
+ * Tab content: icon always visible, label collapses to width 0 when inactive
+ * and expands on hover or when active. Parent must declare `group` so the
+ * hover state cascades to the label span.
+ */
+export function AutoHideTabLabel({
+  icon: Icon,
+  label,
+  active,
+  iconClassName,
+}: {
+  icon: IconComponent;
+  label: string;
+  active: boolean;
+  iconClassName?: string;
+}) {
+  return (
+    <>
+      <Icon className={cn("size-3.5 shrink-0", iconClassName)} />
+      <span
+        className={cn(
+          "overflow-hidden whitespace-nowrap transition-[max-width,margin-left,opacity] duration-200 ease-out",
+          active
+            ? "ml-1.5 max-w-32 opacity-100"
+            : "ml-0 max-w-0 opacity-0 group-hover:ml-1.5 group-hover:max-w-32 group-hover:opacity-100",
+        )}
+      >
+        {label}
+      </span>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the icon + animated-width label pattern from the Library source switcher into a reusable `AutoHideTabLabel` component.
- Apply it to the SoundCloud view's `My Library / Discover / Search` ToggleGroup so inactive tabs collapse to icon-only and reveal their label on hover (matching the source switcher's behavior).

## Test plan
- [ ] `npm run typecheck` and `npm run lint` pass.
- [ ] `npx playwright test sc-tabs-auto-hide-label` passes.
- [ ] Manually verify on `/library?source=soundcloud`: only the active tab shows its label; hovering an inactive tab reveals its label with the width transition.
- [ ] Verify the existing source switcher (Filesystem / SoundCloud) still behaves identically.