### PR TITLE
fix(library): align SC table header with rows on horizontal scroll

### DIFF
--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -872,209 +872,213 @@ export function LikesTable({
   return (
     <SoundcloudBpmCacheContext.Provider value={bpmCache}>
       <div className="flex h-full min-h-0 flex-col">
-        {/* Header */}
-        <div
-          role="row"
-          className="border-border text-muted-foreground flex h-9 shrink-0 items-center gap-2 border-b bg-[var(--surface-2)] px-3 text-xs font-medium"
-        >
-          {reorderable && <div className="size-4 shrink-0" aria-hidden />}
-          <div
-            className="flex w-6 shrink-0 items-center justify-center"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Checkbox
-              checked={
-                allSelected ? true : someSelected ? "indeterminate" : false
-              }
-              onCheckedChange={(checked) =>
-                checked ? onSelectAll() : onDeselectAll()
-              }
-              aria-label="Select all"
-              className={cn(
-                "size-3.5 cursor-pointer",
-                "data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:text-primary-foreground",
-                allSelected &&
-                  "data-[state=checked]:bg-primary data-[state=checked]:border-primary",
-              )}
-            />
-          </div>
-          <div className="size-7 shrink-0" aria-hidden />
-          <div className="size-6 shrink-0" aria-hidden />
-          <SortableColumnHeader
-            ids={visibleColumns.map((c) => c.id)}
-            onOrderChange={(nextIds) => {
-              if (!onColumnOrderChange) return;
-              const hidden = LIKES_COLUMNS.map((c) => c.id).filter(
-                (id) => !visibleColumns.some((v) => v.id === id),
-              );
-              onColumnOrderChange([...nextIds, ...hidden]);
-            }}
-          >
-            {visibleColumns.map((col) => (
-              <SortableHeaderCell
-                key={col.id}
-                id={col.id}
-                className={col.cellClassName}
-                style={{ width: col.width }}
-                onResize={(w, phase) => {
-                  if (phase === "drag") {
-                    setLiveWidths((p) => ({ ...p, [col.id]: w }));
-                  } else {
-                    onColumnWidthChange?.(col.id, w);
-                    setLiveWidths((p) => {
-                      const { [col.id]: _omit, ...rest } = p;
-                      return rest;
-                    });
-                  }
-                }}
-                onResetWidth={() => onColumnWidthReset?.(col.id)}
-              >
-                {col.renderHeader ? (
-                  col.renderHeader()
-                ) : col.sortKey ? (
-                  <button
-                    className="hover:text-foreground flex w-full cursor-pointer items-center gap-0.5 transition-colors"
-                    onClick={() => col.sortKey && handleSort(col.sortKey)}
-                  >
-                    {col.header}
-                    <SortIcon
-                      col={col.sortKey}
-                      sortBy={sortBy}
-                      sortOrder={sortOrder}
-                    />
-                  </button>
-                ) : (
-                  <span>{col.header}</span>
-                )}
-              </SortableHeaderCell>
-            ))}
-          </SortableColumnHeader>
-        </div>
-
-        {/* Virtual scroll */}
+        {/* Scrollable area — single container owns both axes so header and
+            rows share one horizontal scroll context and stay aligned. */}
         <div
           ref={scrollParentRef}
-          className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
+          className="min-h-0 flex-1 overflow-auto overscroll-contain"
         >
-          {(() => {
-            const body = (
+          <div className="w-max min-w-full">
+            {/* Header */}
+            <div
+              role="row"
+              className="border-border text-muted-foreground sticky top-0 z-20 flex h-9 items-center gap-2 border-b bg-[var(--surface-2)] px-3 text-xs font-medium"
+            >
+              {reorderable && <div className="size-4 shrink-0" aria-hidden />}
               <div
-                style={{
-                  height: `${virtualizer.getTotalSize()}px`,
-                  position: "relative",
+                className="flex w-6 shrink-0 items-center justify-center"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Checkbox
+                  checked={
+                    allSelected ? true : someSelected ? "indeterminate" : false
+                  }
+                  onCheckedChange={(checked) =>
+                    checked ? onSelectAll() : onDeselectAll()
+                  }
+                  aria-label="Select all"
+                  className={cn(
+                    "size-3.5 cursor-pointer",
+                    "data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:text-primary-foreground",
+                    allSelected &&
+                      "data-[state=checked]:bg-primary data-[state=checked]:border-primary",
+                  )}
+                />
+              </div>
+              <div className="size-7 shrink-0" aria-hidden />
+              <div className="size-6 shrink-0" aria-hidden />
+              <SortableColumnHeader
+                ids={visibleColumns.map((c) => c.id)}
+                onOrderChange={(nextIds) => {
+                  if (!onColumnOrderChange) return;
+                  const hidden = LIKES_COLUMNS.map((c) => c.id).filter(
+                    (id) => !visibleColumns.some((v) => v.id === id),
+                  );
+                  onColumnOrderChange([...nextIds, ...hidden]);
                 }}
               >
-                {virtualItems.map((virtualRow) => {
-                  const track = sortedTracks[virtualRow.index];
-                  if (!track) return null;
-                  const id = extractId(track);
-                  const sortableId = reorderable
-                    ? (track.urn ?? `__idx_${virtualRow.index}`)
-                    : undefined;
+                {visibleColumns.map((col) => (
+                  <SortableHeaderCell
+                    key={col.id}
+                    id={col.id}
+                    className={col.cellClassName}
+                    style={{ width: col.width }}
+                    onResize={(w, phase) => {
+                      if (phase === "drag") {
+                        setLiveWidths((p) => ({ ...p, [col.id]: w }));
+                      } else {
+                        onColumnWidthChange?.(col.id, w);
+                        setLiveWidths((p) => {
+                          const { [col.id]: _omit, ...rest } = p;
+                          return rest;
+                        });
+                      }
+                    }}
+                    onResetWidth={() => onColumnWidthReset?.(col.id)}
+                  >
+                    {col.renderHeader ? (
+                      col.renderHeader()
+                    ) : col.sortKey ? (
+                      <button
+                        className="hover:text-foreground flex w-full cursor-pointer items-center gap-0.5 transition-colors"
+                        onClick={() => col.sortKey && handleSort(col.sortKey)}
+                      >
+                        {col.header}
+                        <SortIcon
+                          col={col.sortKey}
+                          sortBy={sortBy}
+                          sortOrder={sortOrder}
+                        />
+                      </button>
+                    ) : (
+                      <span>{col.header}</span>
+                    )}
+                  </SortableHeaderCell>
+                ))}
+              </SortableColumnHeader>
+            </div>
 
-                  return (
-                    <div
-                      key={virtualRow.key}
-                      data-index={virtualRow.index}
-                      ref={virtualizer.measureElement}
-                      style={{
-                        position: "absolute",
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        transform: `translateY(${virtualRow.start}px)`,
-                      }}
-                    >
-                      <TrackRow
-                        sortableId={sortableId}
-                        track={track}
-                        isSelected={selectedIds.has(id)}
-                        isExpanded={expandedId === id}
-                        inCollection={collectionIds?.has(id) ?? false}
-                        isLiked={
-                          likedIds?.has(id) ?? track.user_favorite === true
-                        }
-                        isNew={
-                          newTrackUrns
-                            ? track.urn
-                              ? newTrackUrns.has(track.urn)
-                              : false
-                            : undefined
-                        }
-                        onToggleSelect={(shiftKey) => {
-                          const currentIndex = virtualRow.index;
-                          if (
-                            shiftKey &&
-                            lastSelectedIndexRef.current !== null
-                          ) {
-                            const start = Math.min(
-                              lastSelectedIndexRef.current,
-                              currentIndex,
-                            );
-                            const end = Math.max(
-                              lastSelectedIndexRef.current,
-                              currentIndex,
-                            );
-                            const rangeIds = sortedTracks
-                              .slice(start, end + 1)
-                              .map(extractId)
-                              .filter(Boolean);
-                            onRangeSelect(rangeIds);
-                          } else {
-                            onToggleSelect(id);
-                            lastSelectedIndexRef.current = currentIndex;
-                          }
-                        }}
-                        onExpand={() => handleExpand(track)}
-                        onStartPlay={() => handleStartPlay(virtualRow.index)}
-                        visibleColumns={visibleColumns}
-                      />
-                    </div>
-                  );
-                })}
-              </div>
-            );
-            if (!reorderable) return body;
-            return (
-              <DndContext
-                sensors={dndSensors}
-                collisionDetection={closestCenter}
-                onDragStart={handleReorderDragStart}
-                onDragEnd={handleReorderDragEnd}
-                onDragCancel={() => setActiveDragId(null)}
-              >
-                <SortableContext
-                  items={sortableIds}
-                  strategy={verticalListSortingStrategy}
+            {/* Virtual scroll body */}
+            {(() => {
+              const body = (
+                <div
+                  style={{
+                    height: `${virtualizer.getTotalSize()}px`,
+                    position: "relative",
+                  }}
                 >
-                  {body}
-                </SortableContext>
-                <DragOverlay>
-                  {activeDragTrack ? (
-                    <div className="bg-[var(--surface-2)] opacity-95 shadow-lg">
-                      <TrackRowInner
-                        track={activeDragTrack}
-                        isSelected={false}
-                        isExpanded={false}
-                        inCollection={false}
-                        isLiked={false}
-                        isNew={false}
-                        onToggleSelect={() => undefined}
-                        onExpand={() => undefined}
-                        onStartPlay={() => undefined}
-                        visibleColumns={visibleColumns}
-                        dragHandle={{
-                          attributes: {},
-                          listeners: undefined,
-                          isDragging: false,
+                  {virtualItems.map((virtualRow) => {
+                    const track = sortedTracks[virtualRow.index];
+                    if (!track) return null;
+                    const id = extractId(track);
+                    const sortableId = reorderable
+                      ? (track.urn ?? `__idx_${virtualRow.index}`)
+                      : undefined;
+
+                    return (
+                      <div
+                        key={virtualRow.key}
+                        data-index={virtualRow.index}
+                        ref={virtualizer.measureElement}
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          transform: `translateY(${virtualRow.start}px)`,
                         }}
-                      />
-                    </div>
-                  ) : null}
-                </DragOverlay>
-              </DndContext>
-            );
-          })()}
+                      >
+                        <TrackRow
+                          sortableId={sortableId}
+                          track={track}
+                          isSelected={selectedIds.has(id)}
+                          isExpanded={expandedId === id}
+                          inCollection={collectionIds?.has(id) ?? false}
+                          isLiked={
+                            likedIds?.has(id) ?? track.user_favorite === true
+                          }
+                          isNew={
+                            newTrackUrns
+                              ? track.urn
+                                ? newTrackUrns.has(track.urn)
+                                : false
+                              : undefined
+                          }
+                          onToggleSelect={(shiftKey) => {
+                            const currentIndex = virtualRow.index;
+                            if (
+                              shiftKey &&
+                              lastSelectedIndexRef.current !== null
+                            ) {
+                              const start = Math.min(
+                                lastSelectedIndexRef.current,
+                                currentIndex,
+                              );
+                              const end = Math.max(
+                                lastSelectedIndexRef.current,
+                                currentIndex,
+                              );
+                              const rangeIds = sortedTracks
+                                .slice(start, end + 1)
+                                .map(extractId)
+                                .filter(Boolean);
+                              onRangeSelect(rangeIds);
+                            } else {
+                              onToggleSelect(id);
+                              lastSelectedIndexRef.current = currentIndex;
+                            }
+                          }}
+                          onExpand={() => handleExpand(track)}
+                          onStartPlay={() => handleStartPlay(virtualRow.index)}
+                          visibleColumns={visibleColumns}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+              if (!reorderable) return body;
+              return (
+                <DndContext
+                  sensors={dndSensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleReorderDragStart}
+                  onDragEnd={handleReorderDragEnd}
+                  onDragCancel={() => setActiveDragId(null)}
+                >
+                  <SortableContext
+                    items={sortableIds}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {body}
+                  </SortableContext>
+                  <DragOverlay>
+                    {activeDragTrack ? (
+                      <div className="bg-[var(--surface-2)] opacity-95 shadow-lg">
+                        <TrackRowInner
+                          track={activeDragTrack}
+                          isSelected={false}
+                          isExpanded={false}
+                          inCollection={false}
+                          isLiked={false}
+                          isNew={false}
+                          onToggleSelect={() => undefined}
+                          onExpand={() => undefined}
+                          onStartPlay={() => undefined}
+                          visibleColumns={visibleColumns}
+                          dragHandle={{
+                            attributes: {},
+                            listeners: undefined,
+                            isDragging: false,
+                          }}
+                        />
+                      </div>
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
+              );
+            })()}
+          </div>
         </div>
       </div>
     </SoundcloudBpmCacheContext.Provider>


### PR DESCRIPTION
## Summary
- The SoundCloud `likes-table` rendered its header as a sibling of the (y-only) scroll container, so when rows overflowed horizontally the header didn't move with them and the columns drifted out of alignment.
- Restructured to match the `collection-table` (filesystem) pattern: a single `overflow-auto` scroll container wraps a `w-max min-w-full` div that holds both the body and a `sticky top-0 z-20` header. Both axes now share one scroll context.

## Test plan
- [ ] `/library?source=soundcloud`, open the editor panel to force horizontal overflow → scroll horizontally and confirm the header tracks the rows.
- [ ] Vertical scroll still pins the header at the top.
- [ ] Compare against `/library?source=filesystem` — same scroll behavior.