### PR TITLE
feat(window): overlay titlebar with full-width topbar

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-is-fullscreen",
     "shell:allow-open",
     "shell:allow-spawn",
     "shell:allow-stdin-write",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,9 @@
                 "decorations": true,
                 "transparent": false,
                 "center": true,
-                "visible": true
+                "visible": true,
+                "titleBarStyle": "Overlay",
+                "hiddenTitle": true
             }
         ],
         "security": {

--- a/frontend/e2e/library-waveform.spec.ts
+++ b/frontend/e2e/library-waveform.spec.ts
@@ -135,9 +135,9 @@ test.describe("Library waveform visibility", () => {
   }) => {
     await selectFileAndWaitForPlayer(page);
 
-    // Navigate to the home page via the sidebar logo
+    // Navigate to the home page via the topbar logo
     await page
-      .locator("aside")
+      .locator("header")
       .getByRole("link", { name: /Starlib/i })
       .click();
     await expect(page).toHaveURL("/");

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -15,10 +15,10 @@ test.describe("Navigation", () => {
     await expect(page).toHaveURL(/\/library/);
   });
 
-  test("sidebar logo links to home", async ({ page }) => {
+  test("topbar logo links to home", async ({ page }) => {
     await page.goto("/library");
-    const sidebar = page.locator("aside");
-    const homeLink = sidebar.getByRole("link", { name: /Starlib/i });
+    const topbar = page.locator("header");
+    const homeLink = topbar.getByRole("link", { name: /Starlib/i });
     await homeLink.click();
     await expect(page).toHaveURL(/^http:\/\/localhost:\d+\/(\?.*)?$/);
   });

--- a/frontend/src/components/layout/top-bar.tsx
+++ b/frontend/src/components/layout/top-bar.tsx
@@ -1,14 +1,66 @@
 "use client";
 
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
 import { CommandPaletteTrigger } from "@/components/command-palette";
+import { isTauri } from "@/lib/tauri";
+import { cn } from "@/lib/utils";
 
 import { useTopBarContent } from "./top-bar-context";
 
+function useIsFullscreen() {
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    const w = getCurrentWindow();
+    let unlisten: (() => void) | undefined;
+
+    const sync = () => {
+      void w.isFullscreen().then(setFullscreen);
+    };
+    sync();
+    w.onResized(sync).then((fn) => {
+      unlisten = fn;
+    });
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  return fullscreen;
+}
+
 export function TopBar() {
   const { title, actions } = useTopBarContent();
+  const fullscreen = useIsFullscreen();
 
   return (
-    <header className="border-border bg-card fixed top-0 right-0 left-14 z-40 flex h-11 items-center gap-3 border-b px-4">
+    <header
+      data-tauri-drag-region
+      className={cn(
+        "border-border bg-card fixed top-0 right-0 left-0 z-40 flex h-11 items-center gap-3 border-b pr-4 transition-[padding]",
+        fullscreen ? "pl-4" : "pl-20",
+      )}
+    >
+      <Link href="/" aria-label="Starlib home" className="shrink-0">
+        <span
+          className="bg-primary block size-5"
+          style={{
+            maskImage: "url(/starlib-logo.svg)",
+            WebkitMaskImage: "url(/starlib-logo.svg)",
+            maskSize: "contain",
+            WebkitMaskSize: "contain",
+            maskRepeat: "no-repeat",
+            WebkitMaskRepeat: "no-repeat",
+            maskPosition: "center",
+            WebkitMaskPosition: "center",
+          }}
+        />
+      </Link>
       <div className="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium">
         {title ?? null}
       </div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -120,26 +120,7 @@ export function Sidebar() {
   }
 
   return (
-    <aside className="border-border bg-card fixed top-0 bottom-0 left-0 z-50 flex w-14 shrink-0 flex-col border-r">
-      {/* Logo */}
-      <div className="flex h-14 shrink-0 items-center justify-center">
-        <Link href="/" aria-label="Starlib home">
-          <span
-            className="bg-primary block size-6"
-            style={{
-              maskImage: "url(/starlib-logo.svg)",
-              WebkitMaskImage: "url(/starlib-logo.svg)",
-              maskSize: "contain",
-              WebkitMaskSize: "contain",
-              maskRepeat: "no-repeat",
-              WebkitMaskRepeat: "no-repeat",
-              maskPosition: "center",
-              WebkitMaskPosition: "center",
-            }}
-          />
-        </Link>
-      </div>
-
+    <aside className="border-border bg-card fixed top-11 bottom-0 left-0 z-50 flex w-14 shrink-0 flex-col border-r">
       {/* Nav links */}
       <nav className="flex flex-1 flex-col gap-1 px-2 py-3">
         {NAV_LINKS.map(({ href, label, icon: Icon }) => {


### PR DESCRIPTION
## Summary
- Enables macOS overlay title bar (`titleBarStyle: Overlay`, `hiddenTitle: true`) so traffic lights float over the webview and the "Starlib" title text is gone.
- TopBar spans full width and sits flush at top:0, with `pl-20` to clear the traffic lights and the Starlib logo moved inside it (next to the window buttons). Sidebar drops to `top-11` and loses its now-redundant logo block.
- Fullscreen-aware: `useIsFullscreen` listens for `onResized` and collapses the topbar's left padding to `pl-4` when fullscreen, sliding the logo into the space the traffic lights vacate.
- Adds `core:window:allow-start-dragging` and `core:window:allow-is-fullscreen` capabilities — required for `data-tauri-drag-region` and the fullscreen check.

## Test plan
- [ ] Launch `npm run tauri dev` (desktop) → no "Starlib" titlebar text; traffic lights overlay the topbar; logo + Library title sit immediately right of the buttons.
- [ ] Drag the window by the topbar — no `start_dragging not allowed` console error.
- [ ] Toggle macOS fullscreen (⌃⌘F) — logo + title slide left to fill the freed space; reverse on exit.
- [ ] Verify the sidebar nav still aligns correctly under the topbar at top:11.