### PR TITLE
fix(weekly): dedupe followings feed by track urn

### DIFF
--- a/frontend/src/app/weekly/use-followings-tracks.ts
+++ b/frontend/src/app/weekly/use-followings-tracks.ts
@@ -37,7 +37,12 @@ async function fetchRecentPages(
 ): Promise<SCTrack[]> {
   const cutoff = new Date(Date.now() - TWO_WEEKS_MS);
 
-  let allTracks: SCTrack[] = [];
+  // The feed can surface the same track more than once (e.g. an original post
+  // and reposts from multiple followed users). Dedupe by urn so downstream
+  // consumers — most importantly the virtualizer keying rows by track.urn —
+  // never see duplicate identities.
+  const seen = new Set<string>();
+  const allTracks: SCTrack[] = [];
   let nextHref: string | undefined;
 
   do {
@@ -49,7 +54,14 @@ async function fetchRecentPages(
 
     if (signal.aborted) return [];
 
-    allTracks = [...allTracks, ...tracks];
+    for (const t of tracks) {
+      const key = t.urn;
+      if (key) {
+        if (seen.has(key)) continue;
+        seen.add(key);
+      }
+      allTracks.push(t);
+    }
     onProgress([...allTracks]);
 
     // Feed is newest-first. Once the oldest item on this page is before the


### PR DESCRIPTION
## Summary
- The SoundCloud followings feed surfaces the same track more than once when multiple followed users repost it (or an original post + repost). `fetchRecentPages` was concatenating pages verbatim, so duplicate urns reached the weekly buckets.
- The likes table virtualizer keys rows by `track.urn`, which produced React's `Encountered two children with the same key, soundcloud:tracks:…` warnings when navigating Likes → Weekly.
- Fix at the source: dedupe by urn inside `fetchRecentPages` with a `Set`, so downstream code (groups, virtualizer, selection sets) sees each track once.

## Test plan
- [ ] Open the app, visit Likes, then Weekly — verify no duplicate-key warnings in the console.
- [ ] Tracks reposted by multiple followed users appear exactly once in their weekly bucket.
- [ ] Existing weekly tests still pass (`npm test -- --run use-weekly-filter`).