### PR TITLE
feat(weekly): place NEW tag before track title

### DIFF
--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -129,16 +129,16 @@ const LIKES_COLUMNS: LikesCol[] = [
     renderBody: ({ track, isExpanded, isNew }) => (
       <>
         <UnstreamableBadge track={track} />
-        <span
-          className={`truncate text-xs leading-tight font-medium ${isExpanded ? "text-primary" : ""}`}
-        >
-          {track.title || "—"}
-        </span>
         {isNew && (
           <span className="shrink-0 rounded bg-[var(--brand-soft)] px-1 py-0.5 text-xs leading-none font-semibold text-[var(--brand)]">
             NEW
           </span>
         )}
+        <span
+          className={`truncate text-xs leading-tight font-medium ${isExpanded ? "text-primary" : ""}`}
+        >
+          {track.title || "—"}
+        </span>
       </>
     ),
   },


### PR DESCRIPTION
Closes #407

## Summary
- Reorder the title cell in `likes-table.tsx` so the `NEW` badge renders to the left of the track title, making it scannable at a glance in the weekly view (the same cell is reused for SoundCloud likes/weekly rows).

## Test plan
- [ ] Open `/weekly` and confirm the NEW badge sits left of the title for new tracks
- [ ] Open `/library?source=soundcloud` and confirm the same row layout still renders correctly when no NEW badge is present

Note: no Playwright test added — this is a positional tweak to an existing element. Happy to add one if preferred.