### PR TITLE
feat(soundcloud): split feed addedAt from upload created_at; add date columns

### DIFF
--- a/frontend/e2e/sc-date-columns.spec.ts
+++ b/frontend/e2e/sc-date-columns.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SoundCloud table renders Uploaded and Added columns; Uploaded is sortable
+ * by upload date (created_at), so toggling it puts the older liked track on
+ * top. The Added column relies on `addedAt` (only set on feed-derived tracks),
+ * which the likes endpoint does not provide — covering it here would require a
+ * feed-sourced fixture.
+ */
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: 1,
+            urn: "soundcloud:tracks:1",
+            title: "Older track",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            created_at: "2023-01-15T00:00:00Z",
+            permalink_url: "https://soundcloud.com/me/older",
+          },
+          {
+            id: 2,
+            urn: "soundcloud:tracks:2",
+            title: "Newer track",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            created_at: "2024-06-01T00:00:00Z",
+            permalink_url: "https://soundcloud.com/me/newer",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+}
+
+test.describe("SoundCloud date columns", () => {
+  test("Uploaded and Added columns render and Uploaded sorts by date", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    const header = page.getByRole("row").first();
+    await expect(header.getByText("Uploaded", { exact: true })).toBeVisible();
+    await expect(header.getByText("Added", { exact: true })).toBeVisible();
+
+    // Default order matches the API response: Older then Newer.
+    await expect(page.locator('[data-index="0"]')).toContainText("Older track");
+    await expect(page.locator('[data-index="1"]')).toContainText("Newer track");
+
+    // Sort by Uploaded ascending → Older (2023) first.
+    await header.locator("button", { hasText: "Uploaded" }).click();
+    await expect(page.locator('[data-index="0"]')).toContainText("Older track");
+    await expect(page.locator('[data-index="1"]')).toContainText("Newer track");
+
+    // Toggle to descending → Newer first.
+    await header.locator("button", { hasText: "Uploaded" }).click();
+    await expect(page.locator('[data-index="0"]')).toContainText("Newer track");
+    await expect(page.locator('[data-index="1"]')).toContainText("Older track");
+  });
+});

--- a/frontend/src/app/library/utils.ts
+++ b/frontend/src/app/library/utils.ts
@@ -1,4 +1,4 @@
-import type { SCTrack } from "@/lib/soundcloud";
+import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
 
 /** Parse the backend's semicolon-delimited comment string into structured fields. */
 export function parseComment(raw: string | null | undefined): {
@@ -59,16 +59,8 @@ export function scReleaseDate(track: SCTrack): string | undefined {
       track.release_day && track.release_day > 0 ? track.release_day : 1;
     return `${track.release_year}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
   }
-  if (track.created_at) {
-    const normalized = track.created_at
-      .replace(/\//g, "-")
-      .replace(" ", "T")
-      .replace(" +0000", "Z");
-    const date = new Date(normalized);
-    if (!isNaN(date.getTime())) {
-      return date.toISOString().slice(0, 10);
-    }
-  }
+  const ts = parseSCTimestamp(track.created_at);
+  if (ts != null) return new Date(ts).toISOString().slice(0, 10);
   return undefined;
 }
 

--- a/frontend/src/app/weekly/page.tsx
+++ b/frontend/src/app/weekly/page.tsx
@@ -15,6 +15,7 @@ import { useFilterState } from "@/lib/filters/use-filter-state";
 import {
   fetchLikesPage,
   getMyLikedTracks,
+  parseSCTimestamp,
   type SCPlaylist,
   type SCTrack,
 } from "@/lib/soundcloud";
@@ -312,7 +313,7 @@ export default function WeeklyPage() {
         const end = anchor + 86400000;
         for (const t of allFilteredTracks) {
           if (!t.urn || existingUrns.has(t.urn)) continue;
-          const ts = t.created_at ? Date.parse(t.created_at) : 0;
+          const ts = parseSCTimestamp(t.addedAt ?? t.created_at) ?? 0;
           if (ts >= start && ts <= end) newCount++;
         }
       }

--- a/frontend/src/app/weekly/use-followings-tracks.ts
+++ b/frontend/src/app/weekly/use-followings-tracks.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getFeedTracksPage, type SCTrack } from "@/lib/soundcloud";
+import {
+  getFeedTracksPage,
+  parseSCTimestamp,
+  type SCTrack,
+} from "@/lib/soundcloud";
 
 interface UseFollowingsTracksResult {
   tracks: SCTrack[];
@@ -35,7 +39,7 @@ async function fetchRecentPages(
   signal: AbortSignal,
   onProgress: (tracks: SCTrack[]) => void,
 ): Promise<SCTrack[]> {
-  const cutoff = new Date(Date.now() - TWO_WEEKS_MS);
+  const cutoff = Date.now() - TWO_WEEKS_MS;
 
   // The feed can surface the same track more than once (e.g. an original post
   // and reposts from multiple followed users). Dedupe by urn so downstream
@@ -67,12 +71,13 @@ async function fetchRecentPages(
     // Feed is newest-first. Once the oldest item on this page is before the
     // cutoff we know the rest will be too – stop paging.
     const oldest = tracks[tracks.length - 1];
-    if (oldest?.created_at && new Date(oldest.created_at) < cutoff) break;
+    const oldestTs = parseSCTimestamp(oldest?.addedAt ?? oldest?.created_at);
+    if (oldestTs != null && oldestTs < cutoff) break;
   } while (nextHref);
 
   return allTracks.filter((t) => {
-    if (!t.created_at) return true;
-    return new Date(t.created_at) >= cutoff;
+    const ts = parseSCTimestamp(t.addedAt ?? t.created_at);
+    return ts == null || ts >= cutoff;
   });
 }
 

--- a/frontend/src/app/weekly/use-weekly-groups.ts
+++ b/frontend/src/app/weekly/use-weekly-groups.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { SCTrack } from "@/lib/soundcloud";
+import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
 
 export type GroupingMode = "weekly" | "biweekly";
 
@@ -159,10 +159,10 @@ export function useWeeklyGroups(
     }
 
     for (const track of tracks) {
-      if (!track.created_at) continue;
-      const created = new Date(track.created_at);
+      const ts = parseSCTimestamp(track.addedAt ?? track.created_at);
+      if (ts == null) continue;
       for (const bucket of buckets) {
-        if (created >= bucket.start && created < bucket.end) {
+        if (ts >= bucket.start.getTime() && ts < bucket.end.getTime()) {
           bucketTracks
             .get(buildKey(bucket.start, bucket.end, bucket.half))!
             .push(track);

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -54,7 +54,7 @@ import { api } from "@/lib/api";
 import type { ColumnDef } from "@/lib/columns/types";
 import { usePlayer, type PlayerTrack } from "@/lib/player-context";
 import type { SourceProfile } from "@/lib/profile-groups";
-import type { SCTrack } from "@/lib/soundcloud";
+import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
 import {
   getCachedSoundcloudPeaks,
   getCachedSoundcloudStreamUrl,
@@ -64,7 +64,14 @@ import { cn } from "@/lib/utils";
 const ROW_HEIGHT = 48;
 const DESCRIPTION_HEIGHT = 120;
 
-type SortKey = "title" | "artist" | "genre" | "duration" | "playback_count";
+type SortKey =
+  | "title"
+  | "artist"
+  | "genre"
+  | "duration"
+  | "playback_count"
+  | "uploaded"
+  | "added";
 type SortOrder = "asc" | "desc";
 
 /** A single source of truth for likes-table columns. Drives both the header
@@ -188,6 +195,24 @@ const LIKES_COLUMNS: LikesCol[] = [
     cellClassName:
       "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
     renderBody: ({ track }) => <>{formatPlays(track.playback_count)}</>,
+  },
+  {
+    id: "uploaded",
+    header: "Uploaded",
+    sortKey: "uploaded",
+    defaultWidth: 96,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatDate(track.created_at)}</>,
+  },
+  {
+    id: "added",
+    header: "Added",
+    sortKey: "added",
+    defaultWidth: 96,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatDate(track.addedAt)}</>,
   },
   {
     id: "links",
@@ -344,6 +369,20 @@ function formatDuration(ms: number | undefined): string {
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/** Render an SC timestamp as `DD.MM.YYYY`; em-dash for missing/unparseable. */
+function formatDate(value: string | undefined): string {
+  const t = parseSCTimestamp(value);
+  if (t == null) return "—";
+  const d = new Date(t);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}.${mm}.${d.getFullYear()}`;
+}
+
+function dateValue(value: string | undefined): number {
+  return parseSCTimestamp(value) ?? 0;
 }
 
 function formatPlays(count: number | undefined): string {
@@ -729,6 +768,12 @@ export function LikesTable({
           break;
         case "playback_count":
           cmp = (a.playback_count ?? 0) - (b.playback_count ?? 0);
+          break;
+        case "uploaded":
+          cmp = dateValue(a.created_at) - dateValue(b.created_at);
+          break;
+        case "added":
+          cmp = dateValue(a.addedAt) - dateValue(b.addedAt);
           break;
       }
       return sortOrder === "asc" ? cmp : -cmp;

--- a/frontend/src/components/weekly-group-card.tsx
+++ b/frontend/src/components/weekly-group-card.tsx
@@ -18,6 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   addTracksToPlaylist,
+  parseSCTimestamp,
   type SCPlaylist,
   type SCTrack,
 } from "@/lib/soundcloud";
@@ -102,8 +103,8 @@ export function WeeklyGroupCard({
       filterTrack ? filterTrack(t) : true,
     );
     const newSorted = [...newTracks].sort((a, b) => {
-      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      const ta = parseSCTimestamp(a.addedAt ?? a.created_at) ?? 0;
+      const tb = parseSCTimestamp(b.addedAt ?? b.created_at) ?? 0;
       return tb - ta;
     });
     return [...existingFiltered, ...newSorted];

--- a/frontend/src/lib/soundcloud.ts
+++ b/frontend/src/lib/soundcloud.ts
@@ -14,9 +14,30 @@ export type SCTrack = components["schemas"]["Track"] & {
   /** Set by the weekly feed parser when the activity was a track-repost
    * rather than an original release. Undefined elsewhere. */
   isRepost?: boolean;
+  /** Activity timestamp from the feed: when the track was posted/reposted
+   * into the user's feed (distinct from `created_at`, which is when the
+   * track itself was uploaded). Only set for feed-derived tracks; in
+   * other contexts (likes, playlists) this remains undefined since the
+   * SoundCloud API doesn't expose liked-at on those endpoints. */
+  addedAt?: string;
 };
 export type SCPlaylist = components["schemas"]["Playlist"];
 export type SCUser = components["schemas"]["User"];
+
+/** Parse a SoundCloud timestamp to epoch ms.
+ *
+ * Accepts both the legacy `YYYY/MM/DD HH:MM:SS +0000` format and ISO-8601.
+ * Returns `null` for missing/unparseable values so callers can branch instead
+ * of guarding `NaN`. */
+export function parseSCTimestamp(value: string | undefined): number | null {
+  if (!value) return null;
+  const normalized = value
+    .replace(/\//g, "-")
+    .replace(" ", "T")
+    .replace(" +0000", "Z");
+  const t = Date.parse(normalized);
+  return Number.isFinite(t) ? t : null;
+}
 
 function createSCClient(token: string) {
   const client = createClient<paths>({ baseUrl: "https://api.soundcloud.com" });
@@ -228,9 +249,11 @@ export type SCActivities = components["schemas"]["Activities"];
 /**
  * Fetches one page of the authenticated user's recent track feed.
  *
- * Each returned track's `created_at` is overridden with the activity timestamp
- * (i.e. when it appeared in the feed, not when it was originally uploaded), so
- * that reposts are bucketed correctly in weekly groups.
+ * Each returned track keeps its origin `created_at` (upload date) and gains an
+ * `addedAt` field carrying the feed activity timestamp — the moment the
+ * track or repost surfaced in the feed. Weekly grouping uses `addedAt` so
+ * reposts bucket by when they appeared, not when the underlying track was
+ * uploaded.
  */
 export async function getFeedTracksPage(
   limit = 50,
@@ -262,9 +285,7 @@ export async function getFeedTracksPage(
     )
     .map((item) => ({
       ...(item.origin as SCTrack),
-      // Use the activity date (when it appeared in the feed / was reposted),
-      // not the track's original upload date.
-      created_at: item.created_at ?? (item.origin as SCTrack).created_at,
+      addedAt: item.created_at ?? (item.origin as SCTrack).created_at,
       isRepost: item.type === "track:repost",
     }));
 

--- a/frontend/src/lib/sources/soundcloud.ts
+++ b/frontend/src/lib/sources/soundcloud.ts
@@ -30,15 +30,9 @@ function extractMetadata(track: SourceTrack): SourceMetadata {
       raw.release_month && raw.release_month > 0 ? raw.release_month : 1;
     const d = raw.release_day && raw.release_day > 0 ? raw.release_day : 1;
     releaseDate = `${raw.release_year}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
-  } else if (raw.created_at) {
-    const normalized = raw.created_at
-      .replace(/\//g, "-")
-      .replace(" ", "T")
-      .replace(" +0000", "Z");
-    const date = new Date(normalized);
-    if (!isNaN(date.getTime())) {
-      releaseDate = date.toISOString().slice(0, 10);
-    }
+  } else {
+    const ts = sc.parseSCTimestamp(raw.created_at);
+    if (ts != null) releaseDate = new Date(ts).toISOString().slice(0, 10);
   }
 
   // Use HQ artwork (SoundCloud serves large artwork as -large, t500x500 is the HQ version)


### PR DESCRIPTION
## Summary
- Feed tracks now keep their original `created_at` (upload date) and carry the activity timestamp on a new `addedAt` field, so reposts bucket by when they appeared in the feed rather than when the underlying track was uploaded.
- The SC likes table gains sortable **Uploaded** and **Added** columns; `addedAt` is undefined for likes/playlists by design (the SC API doesn't expose liked-at), so the Added column shows em-dashes there.
- Adds `parseSCTimestamp` in `lib/soundcloud.ts` and consolidates the four prior copies of the legacy-vs-ISO normalization (`likes-table`, weekly hooks, `library/utils.ts`, `lib/sources/soundcloud.ts`) through it.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npx playwright test sc-date-columns`
- [ ] Manual: open `/weekly`, confirm reposts bucket into the week they appeared, not their upload week
- [ ] Manual: open `/library?source=soundcloud`, sort by Uploaded and Added