### PR TITLE
feat(library): one-click Fetch from Downloads into selected folder

### DIFF
--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -3,6 +3,8 @@
 import asyncio
 import base64
 import logging
+import shutil
+import time
 from datetime import date
 from pathlib import Path
 from typing import Annotated
@@ -20,6 +22,8 @@ from backend.schemas.metadata import (
     BatchResultItem,
     BatchUpdateRequest,
     BatchUpdateResponse,
+    FetchFromDownloadsRequest,
+    FetchFromDownloadsResponse,
     FileInfoResponse,
     FileReadinessResponse,
     FilterValuesResponse,
@@ -99,6 +103,87 @@ def initialize_folders(
     for subfolder in ["prepare", "collection", "cleaned", "archive"]:
         (root_folder / subfolder).mkdir(exist_ok=True)
     return OperationResponse(success=True, message=f"Folders created under {root_folder}")
+
+
+# Audio file extensions accepted by the Fetch-from-Downloads action.
+# Mirrors the keys of AUDIO_MIME_TYPES in backend.api.metadata.audio without
+# importing that module (avoids cross-router coupling).
+_FETCH_AUDIO_EXTENSIONS = frozenset({".mp3", ".aiff", ".aif", ".wav", ".flac", ".m4a"})
+
+
+def _is_recent_audio(src: Path, cutoff: float) -> bool:
+    """True if *src* is a non-hidden audio file modified at or after *cutoff*."""
+    if not src.is_file() or src.name.startswith("."):
+        return False
+    if src.suffix.lower() not in _FETCH_AUDIO_EXTENSIONS:
+        return False
+    try:
+        return src.stat().st_mtime >= cutoff
+    except OSError:
+        return False
+
+
+@router.post("/folders/fetch-from-downloads", response_model=FetchFromDownloadsResponse)
+def fetch_from_downloads(
+    request: FetchFromDownloadsRequest,
+    root_folder: Annotated[Path, Depends(get_root_folder)],
+) -> FetchFromDownloadsResponse:
+    """Move recent audio files from ~/Downloads into a library subfolder.
+
+    Files are filtered by extension (audio formats only) and mtime (within
+    ``window_days`` of now). A file is skipped when the destination already
+    contains an entry with the same name — making the operation idempotent.
+    """
+    downloads = (Path.home() / "Downloads").resolve()
+    if not downloads.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Downloads folder not found at {downloads}",
+        )
+
+    dest = Path(request.dest_path).resolve()
+    resolved_root = root_folder.resolve()
+    try:
+        dest.relative_to(resolved_root)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Destination is outside the music library root.",
+        ) from e
+    if not dest.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Destination folder does not exist: {dest}",
+        )
+
+    cutoff = time.time() - request.window_days * 86400
+    moved: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []
+
+    for src in downloads.iterdir():
+        if not _is_recent_audio(src, cutoff):
+            continue
+
+        target = dest / src.name
+        if target.exists():
+            skipped.append(src.name)
+            continue
+
+        try:
+            shutil.move(str(src), str(target))
+        except Exception as e:
+            logger.exception("Failed to move %s to %s", src, target)
+            errors.append(f"{src.name}: {e}")
+            continue
+
+        try:
+            collection.reindex_file(resolved_root, target)
+        except Exception:
+            logger.exception("Failed to reindex %s after move", target)
+        moved.append(src.name)
+
+    return FetchFromDownloadsResponse(moved=moved, skipped=skipped, errors=errors)
 
 
 @router.get("/folders/tree", response_model=TreeNode)

--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -22,6 +22,8 @@ from backend.schemas.metadata import (
     BatchResultItem,
     BatchUpdateRequest,
     BatchUpdateResponse,
+    FetchCandidate,
+    FetchFromDownloadsPreview,
     FetchFromDownloadsRequest,
     FetchFromDownloadsResponse,
     FileInfoResponse,
@@ -34,7 +36,7 @@ from backend.schemas.metadata import (
 )
 from backend.schemas.tree import TreeNode
 from soundcloud_tools.handler.folder import FolderHandler
-from soundcloud_tools.handler.track import SIMPLE_TAG_FIELDS, TrackHandler, TrackInfo
+from soundcloud_tools.handler.track import FILETYPE_MAP, SIMPLE_TAG_FIELDS, TrackHandler, TrackInfo
 
 logger = logging.getLogger(__name__)
 
@@ -106,9 +108,9 @@ def initialize_folders(
 
 
 # Audio file extensions accepted by the Fetch-from-Downloads action.
-# Mirrors the keys of AUDIO_MIME_TYPES in backend.api.metadata.audio without
-# importing that module (avoids cross-router coupling).
-_FETCH_AUDIO_EXTENSIONS = frozenset({".mp3", ".aiff", ".aif", ".wav", ".flac", ".m4a"})
+# Aligned with FILETYPE_MAP (the formats the indexer/handler can actually
+# read) so we never move a file the library would then fail to surface.
+_FETCH_AUDIO_EXTENSIONS = frozenset(FILETYPE_MAP.keys())
 
 
 def _is_recent_audio(src: Path, cutoff: float) -> bool:
@@ -123,17 +125,8 @@ def _is_recent_audio(src: Path, cutoff: float) -> bool:
         return False
 
 
-@router.post("/folders/fetch-from-downloads", response_model=FetchFromDownloadsResponse)
-def fetch_from_downloads(
-    request: FetchFromDownloadsRequest,
-    root_folder: Annotated[Path, Depends(get_root_folder)],
-) -> FetchFromDownloadsResponse:
-    """Move recent audio files from ~/Downloads into a library subfolder.
-
-    Files are filtered by extension (audio formats only) and mtime (within
-    ``window_days`` of now). A file is skipped when the destination already
-    contains an entry with the same name — making the operation idempotent.
-    """
+def _resolve_fetch_paths(dest_path: str, root_folder: Path) -> tuple[Path, Path, Path]:
+    """Validate Downloads + destination and return (downloads, dest, resolved_root)."""
     downloads = (Path.home() / "Downloads").resolve()
     if not downloads.is_dir():
         raise HTTPException(
@@ -141,7 +134,7 @@ def fetch_from_downloads(
             detail=f"Downloads folder not found at {downloads}",
         )
 
-    dest = Path(request.dest_path).resolve()
+    dest = Path(dest_path).resolve()
     resolved_root = root_folder.resolve()
     try:
         dest.relative_to(resolved_root)
@@ -155,14 +148,66 @@ def fetch_from_downloads(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Destination folder does not exist: {dest}",
         )
+    return downloads, dest, resolved_root
+
+
+@router.get("/folders/fetch-from-downloads/preview", response_model=FetchFromDownloadsPreview)
+def fetch_from_downloads_preview(
+    root_folder: Annotated[Path, Depends(get_root_folder)],
+    dest_path: str = Query(..., description="Destination folder under the music root"),
+    window_days: int = Query(1, ge=1, le=365),
+) -> FetchFromDownloadsPreview:
+    """List recent audio files in ~/Downloads that would be moved into *dest_path*.
+
+    Files already present in the destination (collisions) are reported under
+    ``skipped`` and are not part of ``candidates``.
+    """
+    downloads, dest, _ = _resolve_fetch_paths(dest_path, root_folder)
+
+    cutoff = time.time() - window_days * 86400
+    candidates: list[FetchCandidate] = []
+    skipped: list[str] = []
+
+    for src in downloads.iterdir():
+        if not _is_recent_audio(src, cutoff):
+            continue
+        if (dest / src.name).exists():
+            skipped.append(src.name)
+            continue
+        try:
+            stat = src.stat()
+        except OSError:
+            continue
+        candidates.append(FetchCandidate(name=src.name, size=stat.st_size, mtime=stat.st_mtime))
+
+    candidates.sort(key=lambda c: c.mtime, reverse=True)
+    return FetchFromDownloadsPreview(candidates=candidates, skipped=sorted(skipped))
+
+
+@router.post("/folders/fetch-from-downloads", response_model=FetchFromDownloadsResponse)
+def fetch_from_downloads(
+    request: FetchFromDownloadsRequest,
+    root_folder: Annotated[Path, Depends(get_root_folder)],
+) -> FetchFromDownloadsResponse:
+    """Move recent audio files from ~/Downloads into a library subfolder.
+
+    Files are filtered by extension (audio formats only) and mtime (within
+    ``window_days`` of now). A file is skipped when the destination already
+    contains an entry with the same name — making the operation idempotent.
+    When ``request.file_names`` is set, only those names are eligible to move.
+    """
+    downloads, dest, resolved_root = _resolve_fetch_paths(request.dest_path, root_folder)
 
     cutoff = time.time() - request.window_days * 86400
+    selection = set(request.file_names) if request.file_names is not None else None
     moved: list[str] = []
     skipped: list[str] = []
     errors: list[str] = []
 
     for src in downloads.iterdir():
         if not _is_recent_audio(src, cutoff):
+            continue
+        if selection is not None and src.name not in selection:
             continue
 
         target = dest / src.name

--- a/backend/schemas/metadata.py
+++ b/backend/schemas/metadata.py
@@ -257,6 +257,24 @@ class FetchFromDownloadsRequest(BaseModel):
 
     dest_path: str
     window_days: int = Field(1, ge=1, le=365)
+    # When provided, only files whose names appear here are moved. None = move
+    # every eligible candidate (back-compat with one-shot callers).
+    file_names: list[str] | None = None
+
+
+class FetchCandidate(BaseModel):
+    """One candidate audio file under ~/Downloads for the preview dialog."""
+
+    name: str
+    size: int
+    mtime: float
+
+
+class FetchFromDownloadsPreview(BaseModel):
+    """Preview of what a Fetch-from-Downloads call would do."""
+
+    candidates: list[FetchCandidate] = []
+    skipped: list[str] = []
 
 
 class FetchFromDownloadsResponse(BaseModel):

--- a/backend/schemas/metadata.py
+++ b/backend/schemas/metadata.py
@@ -250,3 +250,18 @@ class RenameResponse(BaseModel):
     old_path: str
     new_path: str
     message: str
+
+
+class FetchFromDownloadsRequest(BaseModel):
+    """Request to move recent audio files from ~/Downloads into a folder."""
+
+    dest_path: str
+    window_days: int = Field(1, ge=1, le=365)
+
+
+class FetchFromDownloadsResponse(BaseModel):
+    """Result of a Fetch-from-Downloads operation."""
+
+    moved: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []

--- a/docs/guide/command-palette.md
+++ b/docs/guide/command-palette.md
@@ -20,6 +20,7 @@ Commands are grouped the same way they appear in the palette. The **When** colum
 | `sc:create-playlist-from-selection` | Create playlist from N selected tracks | on `/library?source=soundcloud`, 1 ≤ selection ≤ 500 | `app/library/soundcloud-view.tsx` |
 | `sc:reload` | Reload SoundCloud library / Re-run search | on `/library?source=soundcloud` (search tab also requires a non-empty query) | `app/library/soundcloud-view.tsx` |
 | `pitcher.toggle` | Enable/Disable target-BPM pitching | a track is loaded in the player | `components/bpm-pitcher.tsx` |
+| `library.fetch-from-downloads` | Fetch audio files from Downloads | a library folder is selected | `components/fetch-from-downloads-button.tsx` |
 
 ### Go to
 

--- a/frontend/e2e/command-palette-catalog.spec.ts
+++ b/frontend/e2e/command-palette-catalog.spec.ts
@@ -26,6 +26,7 @@ const KNOWN_COMMAND_IDS = new Set<string>([
   "sc:create-playlist-from-selection",
   "sc:reload",
   "pitcher.toggle",
+  "library.fetch-from-downloads",
   // Nav / Go to
   "nav:/library",
   "nav:/weekly",

--- a/frontend/e2e/fetch-from-downloads.spec.ts
+++ b/frontend/e2e/fetch-from-downloads.spec.ts
@@ -37,13 +37,44 @@ async function setupBrowse(page: import("@playwright/test").Page) {
   );
 }
 
+interface PreviewBody {
+  candidates: { name: string; size: number; mtime: number }[];
+  skipped: string[];
+}
+
+async function setupPreview(
+  page: import("@playwright/test").Page,
+  preview: PreviewBody,
+) {
+  await page.route(
+    "**/api/metadata/folders/fetch-from-downloads/preview**",
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(preview),
+      }),
+  );
+}
+
 test.describe("Fetch from Downloads", () => {
-  test("opens dialog, posts request with selected window, shows summary", async ({
+  test("shows preview, posts request with selected window, sends file_names", async ({
     page,
   }) => {
     await setupBrowse(page);
+    await setupPreview(page, {
+      candidates: [
+        { name: "recent.mp3", size: 1, mtime: 0 },
+        { name: "another.flac", size: 2, mtime: 0 },
+      ],
+      skipped: ["already-there.mp3"],
+    });
 
-    let postedBody: { dest_path: string; window_days: number } | null = null;
+    let postedBody: {
+      dest_path: string;
+      window_days: number;
+      file_names?: string[];
+    } | null = null;
     await page.route(
       "**/api/metadata/folders/fetch-from-downloads",
       (route) => {
@@ -67,23 +98,77 @@ test.describe("Fetch from Downloads", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await expect(dialog.getByText("Fetch from Downloads")).toBeVisible();
 
     // Pick the 7-day preset.
     await dialog.getByRole("radio", { name: "7d" }).click();
+
+    // Preview surfaces the count + per-file list.
+    await expect(dialog.getByTestId("fetch-preview-summary")).toContainText(
+      "2 of 2",
+    );
+    await expect(dialog.getByText("1 already in folder")).toBeVisible();
+    await expect(dialog.getByTestId("fetch-preview-item")).toHaveCount(2);
 
     await dialog.getByTestId("fetch-confirm").click();
 
     await expect.poll(() => postedBody?.window_days).toBe(7);
     expect(postedBody!.dest_path).toMatch(/\/music$/);
+    expect(postedBody!.file_names).toEqual(["recent.mp3", "another.flac"]);
 
-    // Toast surfaces the summary.
     await expect(page.getByText(/Moved 2 files/)).toBeVisible();
     await expect(dialog).not.toBeVisible();
   });
 
+  test("excluding a file via x removes it from the request", async ({
+    page,
+  }) => {
+    await setupBrowse(page);
+    await setupPreview(page, {
+      candidates: [
+        { name: "keep.mp3", size: 1, mtime: 0 },
+        { name: "drop.mp3", size: 2, mtime: 0 },
+      ],
+      skipped: [],
+    });
+
+    let posted: { file_names?: string[] } | null = null;
+    await page.route(
+      "**/api/metadata/folders/fetch-from-downloads",
+      (route) => {
+        posted = route.request().postDataJSON();
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            moved: ["keep.mp3"],
+            skipped: [],
+            errors: [],
+          }),
+        });
+      },
+    );
+
+    await page.goto("/library");
+    await page.getByTestId("fetch-from-downloads-trigger").first().click();
+    const dialog = page.getByRole("dialog");
+
+    await dialog.getByTestId("fetch-preview-toggle-drop.mp3").click();
+    await expect(dialog.getByTestId("fetch-preview-summary")).toContainText(
+      "1 of 2",
+    );
+    await expect(dialog.getByTestId("fetch-confirm")).toContainText("Fetch 1");
+
+    await dialog.getByTestId("fetch-confirm").click();
+
+    await expect.poll(() => posted?.file_names).toEqual(["keep.mp3"]);
+  });
+
   test("custom window posts the typed number of days", async ({ page }) => {
     await setupBrowse(page);
+    await setupPreview(page, {
+      candidates: [{ name: "x.mp3", size: 1, mtime: 0 }],
+      skipped: [],
+    });
 
     let posted: { window_days: number } | null = null;
     await page.route(
@@ -104,6 +189,7 @@ test.describe("Fetch from Downloads", () => {
     const dialog = page.getByRole("dialog");
     await dialog.getByRole("radio", { name: "Custom" }).click();
     await dialog.getByTestId("fetch-custom-days").fill("14");
+    await expect(dialog.getByTestId("fetch-preview-item")).toHaveCount(1);
     await dialog.getByTestId("fetch-confirm").click();
 
     await expect.poll(() => posted?.window_days).toBe(14);

--- a/frontend/e2e/fetch-from-downloads.spec.ts
+++ b/frontend/e2e/fetch-from-downloads.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "./fixtures";
+
+const MOCK_FILE = {
+  file_path: "track.mp3",
+  file_name: "track.mp3",
+  file_size: 5 * 1024 * 1024,
+  file_format: ".mp3",
+  has_artwork: false,
+};
+
+async function setupBrowse(page: import("@playwright/test").Page) {
+  await page.route("**/api/metadata/folders/*/browse*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [MOCK_FILE],
+        total: 1,
+        page: 1,
+        size: 50,
+        pages: 1,
+      }),
+    }),
+  );
+  await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [MOCK_FILE],
+        total: 1,
+        page: 1,
+        size: 50,
+        pages: 1,
+      }),
+    }),
+  );
+}
+
+test.describe("Fetch from Downloads", () => {
+  test("opens dialog, posts request with selected window, shows summary", async ({
+    page,
+  }) => {
+    await setupBrowse(page);
+
+    let postedBody: { dest_path: string; window_days: number } | null = null;
+    await page.route(
+      "**/api/metadata/folders/fetch-from-downloads",
+      (route) => {
+        postedBody = route.request().postDataJSON();
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            moved: ["recent.mp3", "another.flac"],
+            skipped: ["already-there.mp3"],
+            errors: [],
+          }),
+        });
+      },
+    );
+
+    await page.goto("/library");
+    await expect(page.locator("[data-index]")).toHaveCount(1);
+
+    await page.getByTestId("fetch-from-downloads-trigger").first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Fetch from Downloads")).toBeVisible();
+
+    // Pick the 7-day preset.
+    await dialog.getByRole("radio", { name: "7d" }).click();
+
+    await dialog.getByTestId("fetch-confirm").click();
+
+    await expect.poll(() => postedBody?.window_days).toBe(7);
+    expect(postedBody!.dest_path).toMatch(/\/music$/);
+
+    // Toast surfaces the summary.
+    await expect(page.getByText(/Moved 2 files/)).toBeVisible();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("custom window posts the typed number of days", async ({ page }) => {
+    await setupBrowse(page);
+
+    let posted: { window_days: number } | null = null;
+    await page.route(
+      "**/api/metadata/folders/fetch-from-downloads",
+      (route) => {
+        posted = route.request().postDataJSON();
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ moved: [], skipped: [], errors: [] }),
+        });
+      },
+    );
+
+    await page.goto("/library");
+    await page.getByTestId("fetch-from-downloads-trigger").first().click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("radio", { name: "Custom" }).click();
+    await dialog.getByTestId("fetch-custom-days").fill("14");
+    await dialog.getByTestId("fetch-confirm").click();
+
+    await expect.poll(() => posted?.window_days).toBe(14);
+  });
+});

--- a/frontend/src/app/library/filesystem-view.tsx
+++ b/frontend/src/app/library/filesystem-view.tsx
@@ -18,6 +18,7 @@ import {
   FILESYSTEM_COLUMN_DEFS,
 } from "@/components/collection-table";
 import { ColumnVisibilityMenu } from "@/components/columns/column-visibility-menu";
+import { FetchFromDownloadsButton } from "@/components/fetch-from-downloads-button";
 import { FilesystemBatchAnalyzeButton } from "@/components/filesystem-batch-analyze-button";
 import { FiltersToolbar } from "@/components/filters/filters-toolbar";
 import { SoundCloudLogo } from "@/components/icons/soundcloud-logo";
@@ -669,6 +670,10 @@ export function FilesystemView() {
               cacheLoading={tableCacheLoading}
               actions={
                 <>
+                  <FetchFromDownloadsButton
+                    folderPath={selectedNodeId ?? undefined}
+                    onComplete={() => setRefreshToken((t) => t + 1)}
+                  />
                   <FilesystemBatchAnalyzeButton
                     folderPath={selectedNodeId ?? undefined}
                     onComplete={() => setRefreshToken((t) => t + 1)}

--- a/frontend/src/components/fetch-from-downloads-button.tsx
+++ b/frontend/src/components/fetch-from-downloads-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Download } from "lucide-react";
-import { useCallback, useState } from "react";
+import { Download, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { useCommand } from "@/components/command-palette/use-command";
@@ -17,7 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { api } from "@/lib/api";
+import { api, type FetchCandidate } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface FetchFromDownloadsButtonProps {
@@ -39,20 +39,64 @@ export function FetchFromDownloadsButton({
   const [preset, setPreset] = useState<string>("1");
   const [customDays, setCustomDays] = useState<string>("");
   const [busy, setBusy] = useState(false);
+  const [candidates, setCandidates] = useState<FetchCandidate[]>([]);
+  const [skipped, setSkipped] = useState<string[]>([]);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
 
   const disabled = !folderPath;
 
-  const handleFetch = useCallback(async () => {
-    if (!folderPath) return;
+  const resolvedDays = (() => {
     const raw = preset === "custom" ? customDays : preset;
-    const days = Number.parseInt(raw, 10);
-    if (!Number.isFinite(days) || days < 1) {
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n >= 1 ? n : null;
+  })();
+
+  // Fetch the preview whenever the dialog is open and we have a valid window.
+  useEffect(() => {
+    if (!open || !folderPath || resolvedDays === null) return;
+    const ctrl = new AbortController();
+    setPreviewLoading(true);
+    setPreviewError(null);
+    api
+      .fetchFromDownloadsPreview(folderPath, resolvedDays, ctrl.signal)
+      .then((res) => {
+        setCandidates(res.candidates);
+        setSkipped(res.skipped);
+        setExcluded(new Set());
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setPreviewError(
+          err instanceof Error ? err.message : "Failed to load preview",
+        );
+        setCandidates([]);
+        setSkipped([]);
+      })
+      .finally(() => setPreviewLoading(false));
+    return () => ctrl.abort();
+  }, [open, folderPath, resolvedDays]);
+
+  const selected = candidates.filter((c) => !excluded.has(c.name));
+  const selectedCount = selected.length;
+
+  const handleFetch = useCallback(async () => {
+    if (!folderPath || resolvedDays === null) {
       toast.error("Enter a positive number of days");
+      return;
+    }
+    if (selectedCount === 0) {
+      toast.message("Nothing selected");
       return;
     }
     setBusy(true);
     try {
-      const result = await api.fetchFromDownloads(folderPath, days);
+      const result = await api.fetchFromDownloads(
+        folderPath,
+        resolvedDays,
+        selected.map((c) => c.name),
+      );
       const movedN = result.moved.length;
       const skippedN = result.skipped.length;
       const errorN = result.errors.length;
@@ -79,7 +123,7 @@ export function FetchFromDownloadsButton({
     } finally {
       setBusy(false);
     }
-  }, [folderPath, preset, customDays, onComplete]);
+  }, [folderPath, resolvedDays, selected, selectedCount, onComplete]);
 
   useCommand({
     id: "library.fetch-from-downloads",
@@ -160,6 +204,76 @@ export function FetchFromDownloadsButton({
                 <span className="text-muted-foreground text-xs">days</span>
               </div>
             )}
+
+            <div
+              className="border-border/50 mt-2 rounded-md border"
+              data-testid="fetch-preview"
+            >
+              <div className="text-muted-foreground flex items-center justify-between px-3 py-2 text-xs">
+                <span data-testid="fetch-preview-summary">
+                  {previewLoading
+                    ? "Scanning Downloads…"
+                    : previewError
+                      ? previewError
+                      : candidates.length === 0
+                        ? "No matching audio files in Downloads"
+                        : `${selectedCount} of ${candidates.length} file${
+                            candidates.length === 1 ? "" : "s"
+                          } will be moved`}
+                </span>
+                {skipped.length > 0 && !previewLoading && !previewError && (
+                  <span title={skipped.join("\n")}>
+                    {skipped.length} already in folder
+                  </span>
+                )}
+              </div>
+
+              {candidates.length > 0 && (
+                <ul
+                  className="border-border/50 max-h-48 overflow-y-auto border-t"
+                  data-testid="fetch-preview-list"
+                >
+                  {candidates.map((c) => {
+                    const isExcluded = excluded.has(c.name);
+                    return (
+                      <li
+                        key={c.name}
+                        className={cn(
+                          "flex items-center gap-2 px-3 py-1.5 text-xs",
+                          isExcluded && "text-muted-foreground line-through",
+                        )}
+                        data-testid="fetch-preview-item"
+                        data-excluded={isExcluded ? "true" : "false"}
+                      >
+                        <span className="flex-1 truncate" title={c.name}>
+                          {c.name}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExcluded((prev) => {
+                              const next = new Set(prev);
+                              if (next.has(c.name)) next.delete(c.name);
+                              else next.add(c.name);
+                              return next;
+                            })
+                          }
+                          className="text-muted-foreground hover:text-foreground rounded p-0.5"
+                          aria-label={
+                            isExcluded
+                              ? `Include ${c.name}`
+                              : `Exclude ${c.name}`
+                          }
+                          data-testid={`fetch-preview-toggle-${c.name}`}
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
           </div>
 
           <DialogFooter>
@@ -176,10 +290,14 @@ export function FetchFromDownloadsButton({
               type="button"
               size="sm"
               onClick={handleFetch}
-              disabled={busy || disabled}
+              disabled={busy || disabled || selectedCount === 0}
               data-testid="fetch-confirm"
             >
-              {busy ? "Fetching…" : "Fetch"}
+              {busy
+                ? "Fetching…"
+                : selectedCount > 0
+                  ? `Fetch ${selectedCount}`
+                  : "Fetch"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/fetch-from-downloads-button.tsx
+++ b/frontend/src/components/fetch-from-downloads-button.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { useCommand } from "@/components/command-palette/use-command";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface FetchFromDownloadsButtonProps {
+  /** Tree-selected destination folder. Button is disabled when undefined. */
+  folderPath?: string;
+  /** Bumped after a successful fetch so the table reloads. */
+  onComplete?: () => void;
+  className?: string;
+}
+
+const PRESETS = ["1", "3", "7"] as const;
+
+export function FetchFromDownloadsButton({
+  folderPath,
+  onComplete,
+  className,
+}: FetchFromDownloadsButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [preset, setPreset] = useState<string>("1");
+  const [customDays, setCustomDays] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+
+  const disabled = !folderPath;
+
+  const handleFetch = useCallback(async () => {
+    if (!folderPath) return;
+    const raw = preset === "custom" ? customDays : preset;
+    const days = Number.parseInt(raw, 10);
+    if (!Number.isFinite(days) || days < 1) {
+      toast.error("Enter a positive number of days");
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await api.fetchFromDownloads(folderPath, days);
+      const movedN = result.moved.length;
+      const skippedN = result.skipped.length;
+      const errorN = result.errors.length;
+      const summary =
+        movedN === 0
+          ? skippedN > 0
+            ? `Nothing new — ${skippedN} already in folder`
+            : "No matching audio files in Downloads"
+          : `Moved ${movedN} file${movedN === 1 ? "" : "s"}` +
+            (skippedN ? ` · skipped ${skippedN}` : "");
+      if (errorN > 0) {
+        toast.warning(`${summary} · ${errorN} error${errorN === 1 ? "" : "s"}`);
+      } else if (movedN === 0) {
+        toast.message(summary);
+      } else {
+        toast.success(summary);
+      }
+      setOpen(false);
+      onComplete?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Fetch from Downloads failed",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [folderPath, preset, customDays, onComplete]);
+
+  useCommand({
+    id: "library.fetch-from-downloads",
+    label: "Fetch audio files from Downloads",
+    description: "Move recent audio files from ~/Downloads into this folder",
+    icon: Download,
+    group: "Library",
+    keywords: ["fetch", "download", "import", "ingest"],
+    when: !disabled,
+    run: ({ close }) => {
+      setOpen(true);
+      close();
+    },
+  });
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+        title={
+          disabled
+            ? "Select a folder first"
+            : "Move recent audio files from ~/Downloads"
+        }
+        className={cn("text-muted-foreground h-7 gap-1.5 text-xs", className)}
+        data-testid="fetch-from-downloads-trigger"
+      >
+        <Download className="size-3.5" />
+        Fetch from Downloads
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Fetch from Downloads</DialogTitle>
+            <DialogDescription>
+              Move recent audio files from <code>~/Downloads</code> into{" "}
+              <span className="text-foreground font-medium">
+                {folderPath ?? "—"}
+              </span>
+              . Files already present are skipped.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 py-2">
+            <Label className="text-muted-foreground text-xs">Time window</Label>
+            <ToggleGroup
+              type="single"
+              value={preset}
+              onValueChange={(v) => v && setPreset(v)}
+              className="justify-start"
+            >
+              {PRESETS.map((d) => (
+                <ToggleGroupItem key={d} value={d} className="h-8 px-3 text-xs">
+                  {d}d
+                </ToggleGroupItem>
+              ))}
+              <ToggleGroupItem value="custom" className="h-8 px-3 text-xs">
+                Custom
+              </ToggleGroupItem>
+            </ToggleGroup>
+            {preset === "custom" && (
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  max={365}
+                  value={customDays}
+                  onChange={(e) => setCustomDays(e.target.value)}
+                  placeholder="Days"
+                  className="h-8 w-24 text-xs"
+                  data-testid="fetch-custom-days"
+                />
+                <span className="text-muted-foreground text-xs">days</span>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleFetch}
+              disabled={busy || disabled}
+              data-testid="fetch-confirm"
+            >
+              {busy ? "Fetching…" : "Fetch"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/generated/backend-openapi.json
+++ b/frontend/src/generated/backend-openapi.json
@@ -375,6 +375,48 @@
         }
       }
     },
+    "/api/metadata/folders/fetch-from-downloads": {
+      "post": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Fetch From Downloads",
+        "description": "Move recent audio files from ~/Downloads into a library subfolder.\n\nFiles are filtered by extension (audio formats only) and mtime (within\n``window_days`` of now). A file is skipped when the destination already\ncontains an entry with the same name \u2014 making the operation idempotent.",
+        "operationId": "fetch_from_downloads_api_metadata_folders_fetch_from_downloads_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FetchFromDownloadsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchFromDownloadsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/metadata/folders/tree": {
       "get": {
         "tags": [
@@ -4089,6 +4131,58 @@
         ],
         "title": "CollectionStatsResponse",
         "description": "Response containing collection statistics."
+      },
+      "FetchFromDownloadsRequest": {
+        "properties": {
+          "dest_path": {
+            "type": "string",
+            "title": "Dest Path"
+          },
+          "window_days": {
+            "type": "integer",
+            "maximum": 365.0,
+            "minimum": 1.0,
+            "title": "Window Days",
+            "default": 1
+          }
+        },
+        "type": "object",
+        "required": [
+          "dest_path"
+        ],
+        "title": "FetchFromDownloadsRequest",
+        "description": "Request to move recent audio files from ~/Downloads into a folder."
+      },
+      "FetchFromDownloadsResponse": {
+        "properties": {
+          "moved": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Moved",
+            "default": []
+          },
+          "skipped": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Skipped",
+            "default": []
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "FetchFromDownloadsResponse",
+        "description": "Result of a Fetch-from-Downloads operation."
       },
       "FileInfoResponse": {
         "properties": {

--- a/frontend/src/generated/backend-openapi.json
+++ b/frontend/src/generated/backend-openapi.json
@@ -375,13 +375,70 @@
         }
       }
     },
+    "/api/metadata/folders/fetch-from-downloads/preview": {
+      "get": {
+        "tags": [
+          "metadata"
+        ],
+        "summary": "Fetch From Downloads Preview",
+        "description": "List recent audio files in ~/Downloads that would be moved into *dest_path*.\n\nFiles already present in the destination (collisions) are reported under\n``skipped`` and are not part of ``candidates``.",
+        "operationId": "fetch_from_downloads_preview_api_metadata_folders_fetch_from_downloads_preview_get",
+        "parameters": [
+          {
+            "name": "dest_path",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Destination folder under the music root",
+              "title": "Dest Path"
+            },
+            "description": "Destination folder under the music root"
+          },
+          {
+            "name": "window_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 1,
+              "title": "Window Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchFromDownloadsPreview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/metadata/folders/fetch-from-downloads": {
       "post": {
         "tags": [
           "metadata"
         ],
         "summary": "Fetch From Downloads",
-        "description": "Move recent audio files from ~/Downloads into a library subfolder.\n\nFiles are filtered by extension (audio formats only) and mtime (within\n``window_days`` of now). A file is skipped when the destination already\ncontains an entry with the same name \u2014 making the operation idempotent.",
+        "description": "Move recent audio files from ~/Downloads into a library subfolder.\n\nFiles are filtered by extension (audio formats only) and mtime (within\n``window_days`` of now). A file is skipped when the destination already\ncontains an entry with the same name \u2014 making the operation idempotent.\nWhen ``request.file_names`` is set, only those names are eligible to move.",
         "operationId": "fetch_from_downloads_api_metadata_folders_fetch_from_downloads_post",
         "requestBody": {
           "content": {
@@ -4132,6 +4189,53 @@
         "title": "CollectionStatsResponse",
         "description": "Response containing collection statistics."
       },
+      "FetchCandidate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "mtime": {
+            "type": "number",
+            "title": "Mtime"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "size",
+          "mtime"
+        ],
+        "title": "FetchCandidate",
+        "description": "One candidate audio file under ~/Downloads for the preview dialog."
+      },
+      "FetchFromDownloadsPreview": {
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/FetchCandidate"
+            },
+            "type": "array",
+            "title": "Candidates",
+            "default": []
+          },
+          "skipped": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Skipped",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "FetchFromDownloadsPreview",
+        "description": "Preview of what a Fetch-from-Downloads call would do."
+      },
       "FetchFromDownloadsRequest": {
         "properties": {
           "dest_path": {
@@ -4144,6 +4248,20 @@
             "minimum": 1.0,
             "title": "Window Days",
             "default": 1
+          },
+          "file_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Names"
           }
         },
         "type": "object",

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -285,6 +285,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/metadata/folders/fetch-from-downloads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fetch From Downloads
+         * @description Move recent audio files from ~/Downloads into a library subfolder.
+         *
+         *     Files are filtered by extension (audio formats only) and mtime (within
+         *     ``window_days`` of now). A file is skipped when the destination already
+         *     contains an entry with the same name — making the operation idempotent.
+         */
+        post: operations["fetch_from_downloads_api_metadata_folders_fetch_from_downloads_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/metadata/folders/tree": {
         parameters: {
             query?: never;
@@ -1925,6 +1949,40 @@ export interface components {
             bpm_max?: number | null;
         };
         /**
+         * FetchFromDownloadsRequest
+         * @description Request to move recent audio files from ~/Downloads into a folder.
+         */
+        FetchFromDownloadsRequest: {
+            /** Dest Path */
+            dest_path: string;
+            /**
+             * Window Days
+             * @default 1
+             */
+            window_days: number;
+        };
+        /**
+         * FetchFromDownloadsResponse
+         * @description Result of a Fetch-from-Downloads operation.
+         */
+        FetchFromDownloadsResponse: {
+            /**
+             * Moved
+             * @default []
+             */
+            moved: string[];
+            /**
+             * Skipped
+             * @default []
+             */
+            skipped: string[];
+            /**
+             * Errors
+             * @default []
+             */
+            errors: string[];
+        };
+        /**
          * FileInfoResponse
          * @description Response containing basic file information.
          */
@@ -2947,6 +3005,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OperationResponse"];
+                };
+            };
+        };
+    };
+    fetch_from_downloads_api_metadata_folders_fetch_from_downloads_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FetchFromDownloadsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FetchFromDownloadsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -285,6 +285,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/metadata/folders/fetch-from-downloads/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch From Downloads Preview
+         * @description List recent audio files in ~/Downloads that would be moved into *dest_path*.
+         *
+         *     Files already present in the destination (collisions) are reported under
+         *     ``skipped`` and are not part of ``candidates``.
+         */
+        get: operations["fetch_from_downloads_preview_api_metadata_folders_fetch_from_downloads_preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/metadata/folders/fetch-from-downloads": {
         parameters: {
             query?: never;
@@ -301,6 +324,7 @@ export interface paths {
          *     Files are filtered by extension (audio formats only) and mtime (within
          *     ``window_days`` of now). A file is skipped when the destination already
          *     contains an entry with the same name — making the operation idempotent.
+         *     When ``request.file_names`` is set, only those names are eligible to move.
          */
         post: operations["fetch_from_downloads_api_metadata_folders_fetch_from_downloads_post"];
         delete?: never;
@@ -1949,6 +1973,34 @@ export interface components {
             bpm_max?: number | null;
         };
         /**
+         * FetchCandidate
+         * @description One candidate audio file under ~/Downloads for the preview dialog.
+         */
+        FetchCandidate: {
+            /** Name */
+            name: string;
+            /** Size */
+            size: number;
+            /** Mtime */
+            mtime: number;
+        };
+        /**
+         * FetchFromDownloadsPreview
+         * @description Preview of what a Fetch-from-Downloads call would do.
+         */
+        FetchFromDownloadsPreview: {
+            /**
+             * Candidates
+             * @default []
+             */
+            candidates: components["schemas"]["FetchCandidate"][];
+            /**
+             * Skipped
+             * @default []
+             */
+            skipped: string[];
+        };
+        /**
          * FetchFromDownloadsRequest
          * @description Request to move recent audio files from ~/Downloads into a folder.
          */
@@ -1960,6 +2012,8 @@ export interface components {
              * @default 1
              */
             window_days: number;
+            /** File Names */
+            file_names?: string[] | null;
         };
         /**
          * FetchFromDownloadsResponse
@@ -3005,6 +3059,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OperationResponse"];
+                };
+            };
+        };
+    };
+    fetch_from_downloads_preview_api_metadata_folders_fetch_from_downloads_preview_get: {
+        parameters: {
+            query: {
+                /** @description Destination folder under the music root */
+                dest_path: string;
+                window_days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FetchFromDownloadsPreview"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -103,6 +103,11 @@ export type OperationResponse = components["schemas"]["OperationResponse"];
 export type FetchFromDownloadsResponse =
   components["schemas"]["FetchFromDownloadsResponse"];
 
+export type FetchFromDownloadsPreview =
+  components["schemas"]["FetchFromDownloadsPreview"];
+
+export type FetchCandidate = components["schemas"]["FetchCandidate"];
+
 export type ApplyRulesResponse = components["schemas"]["ApplyRulesResponse"] & {
   steps?: {
     id: string;
@@ -461,11 +466,31 @@ export const api = {
   async fetchFromDownloads(
     destPath: string,
     windowDays: number,
+    fileNames?: string[],
   ): Promise<FetchFromDownloadsResponse> {
     return fetchApi("/api/metadata/folders/fetch-from-downloads", {
       method: "POST",
-      body: JSON.stringify({ dest_path: destPath, window_days: windowDays }),
+      body: JSON.stringify({
+        dest_path: destPath,
+        window_days: windowDays,
+        ...(fileNames !== undefined ? { file_names: fileNames } : {}),
+      }),
     });
+  },
+
+  async fetchFromDownloadsPreview(
+    destPath: string,
+    windowDays: number,
+    signal?: AbortSignal,
+  ): Promise<FetchFromDownloadsPreview> {
+    const qs = new URLSearchParams({
+      dest_path: destPath,
+      window_days: String(windowDays),
+    });
+    return fetchApi(
+      `/api/metadata/folders/fetch-from-downloads/preview?${qs.toString()}`,
+      { signal },
+    );
   },
   // Browse (view mode) — full metadata with filtering, sorting, pagination
   async browseFiles(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,6 +100,9 @@ export type TrackInfoUpdateRequest =
 
 export type OperationResponse = components["schemas"]["OperationResponse"];
 
+export type FetchFromDownloadsResponse =
+  components["schemas"]["FetchFromDownloadsResponse"];
+
 export type ApplyRulesResponse = components["schemas"]["ApplyRulesResponse"] & {
   steps?: {
     id: string;
@@ -454,6 +457,15 @@ export const api = {
 
   async initializeFolders(): Promise<OperationResponse> {
     return fetchApi("/api/metadata/folders/initialize", { method: "POST" });
+  },
+  async fetchFromDownloads(
+    destPath: string,
+    windowDays: number,
+  ): Promise<FetchFromDownloadsResponse> {
+    return fetchApi("/api/metadata/folders/fetch-from-downloads", {
+      method: "POST",
+      body: JSON.stringify({ dest_path: destPath, window_days: windowDays }),
+    });
   },
   // Browse (view mode) — full metadata with filtering, sorting, pagination
   async browseFiles(

--- a/tests/api/test_fetch_from_downloads.py
+++ b/tests/api/test_fetch_from_downloads.py
@@ -86,6 +86,59 @@ def test_skips_files_already_present(
     assert (downloads / "track.mp3").exists()
 
 
+def test_preview_lists_recent_audio_and_collisions(
+    patched_client: TestClient,
+    tmp_music_folder: Path,
+    fake_downloads: Path,
+):
+    downloads = fake_downloads / "Downloads"
+    _touch(downloads / "recent.mp3")
+    _touch(downloads / "another.wav")
+    _touch(downloads / "old.mp3", mtime_offset_s=-3 * 86400)
+    _touch(downloads / "doc.pdf")
+    _touch(downloads / "unsupported.m4a")  # not in FILETYPE_MAP
+    dest = tmp_music_folder / "prepare"
+    _touch(dest / "another.wav")  # collision
+
+    resp = patched_client.get(
+        "/api/metadata/folders/fetch-from-downloads/preview",
+        params={"dest_path": str(dest), "window_days": 1},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [c["name"] for c in body["candidates"]] == ["recent.mp3"]
+    assert body["candidates"][0]["size"] == len(b"data")
+    assert body["skipped"] == ["another.wav"]
+
+
+def test_post_with_file_names_only_moves_selected(
+    patched_client: TestClient,
+    tmp_music_folder: Path,
+    fake_downloads: Path,
+):
+    downloads = fake_downloads / "Downloads"
+    _touch(downloads / "keep.mp3")
+    _touch(downloads / "drop.mp3")
+    dest = tmp_music_folder / "prepare"
+
+    with patch("backend.api.metadata.files.collection.reindex_file"):
+        resp = patched_client.post(
+            "/api/metadata/folders/fetch-from-downloads",
+            json={
+                "dest_path": str(dest),
+                "window_days": 1,
+                "file_names": ["keep.mp3"],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["moved"] == ["keep.mp3"]
+    assert (dest / "keep.mp3").is_file()
+    # Excluded file stays in Downloads.
+    assert (downloads / "drop.mp3").exists()
+    assert not (dest / "drop.mp3").exists()
+
+
 def test_rejects_destination_outside_root(
     patched_client: TestClient,
     fake_downloads: Path,

--- a/tests/api/test_fetch_from_downloads.py
+++ b/tests/api/test_fetch_from_downloads.py
@@ -1,0 +1,101 @@
+"""Tests for the Fetch-from-Downloads endpoint."""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def fake_downloads(tmp_path: Path) -> Path:
+    """Stand in for ``~/Downloads`` via a patched ``Path.home()``."""
+    home = tmp_path / "home"
+    (home / "Downloads").mkdir(parents=True)
+    return home
+
+
+@pytest.fixture
+def patched_client(client: TestClient, fake_downloads: Path):
+    """Client with ``Path.home()`` redirected to a temp dir."""
+    with patch("backend.api.metadata.files.Path.home", return_value=fake_downloads):
+        yield client
+
+
+def _touch(path: Path, mtime_offset_s: float = 0) -> Path:
+    path.write_bytes(b"data")
+    if mtime_offset_s:
+        ts = time.time() + mtime_offset_s
+        os.utime(path, (ts, ts))
+    return path
+
+
+def test_moves_recent_audio_into_destination(
+    patched_client: TestClient,
+    tmp_music_folder: Path,
+    fake_downloads: Path,
+):
+    downloads = fake_downloads / "Downloads"
+    _touch(downloads / "recent.mp3")
+    _touch(downloads / "old.mp3", mtime_offset_s=-3 * 86400)
+    _touch(downloads / "doc.pdf")  # non-audio
+    _touch(downloads / ".hidden.mp3")
+
+    dest = tmp_music_folder / "prepare"
+
+    with patch("backend.api.metadata.files.collection.reindex_file"):
+        resp = patched_client.post(
+            "/api/metadata/folders/fetch-from-downloads",
+            json={"dest_path": str(dest), "window_days": 1},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["moved"] == ["recent.mp3"]
+    assert body["skipped"] == []
+    assert body["errors"] == []
+    assert (dest / "recent.mp3").is_file()
+    assert not (downloads / "recent.mp3").exists()
+    # Old, non-audio, hidden files stay put.
+    assert (downloads / "old.mp3").exists()
+    assert (downloads / "doc.pdf").exists()
+
+
+def test_skips_files_already_present(
+    patched_client: TestClient,
+    tmp_music_folder: Path,
+    fake_downloads: Path,
+):
+    downloads = fake_downloads / "Downloads"
+    _touch(downloads / "track.mp3")
+    dest = tmp_music_folder / "prepare"
+    _touch(dest / "track.mp3")  # collision
+
+    with patch("backend.api.metadata.files.collection.reindex_file"):
+        resp = patched_client.post(
+            "/api/metadata/folders/fetch-from-downloads",
+            json={"dest_path": str(dest), "window_days": 7},
+        )
+
+    body = resp.json()
+    assert body["moved"] == []
+    assert body["skipped"] == ["track.mp3"]
+    # Source preserved — not clobbered.
+    assert (downloads / "track.mp3").exists()
+
+
+def test_rejects_destination_outside_root(
+    patched_client: TestClient,
+    fake_downloads: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+):
+    (fake_downloads / "Downloads" / "x.mp3").write_bytes(b"")
+    # Distinct temp dir — outside the music root.
+    outside = tmp_path_factory.mktemp("outside-root")
+    resp = patched_client.post(
+        "/api/metadata/folders/fetch-from-downloads",
+        json={"dest_path": str(outside), "window_days": 1},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- New **Fetch from Downloads** button in the library toolbar (and a `library.fetch-from-downloads` command-palette entry). Opens a dialog with **1d / 3d / 7d** presets plus a **Custom** day input, then moves matching audio files from `~/Downloads` into the tree-selected folder.
- Backend endpoint `POST /api/metadata/folders/fetch-from-downloads` filters by audio extension (mp3/aiff/aif/wav/flac/m4a) and mtime window, validates the destination sits under the music root, moves via `shutil.move`, **skips by filename** if the destination already has the file (idempotent), reindexes each moved file, and returns `{ moved, skipped, errors }`.
- Frontend toast surfaces the summary; the library table refresh token is bumped so the new files appear immediately.

Closes #379.

## Decisions made (per discussion)

- **Move**, not copy.
- Source is hardcoded to `~/Downloads` for now — making it configurable is a follow-up.
- Destination = the **tree-selected folder**.
- Dedup is by **filename** in the destination directory (no hashing).

## Tests

- Backend: `tests/api/test_fetch_from_downloads.py` covers the happy path (recent audio moves; old / non-audio / hidden files left alone), filename-collision skip, and the path-outside-root 403.
- Playwright: `frontend/e2e/fetch-from-downloads.spec.ts` clicks the button, picks the 7-day preset, asserts the request body, asserts the summary toast, plus a custom-days variant.
- `command-palette-catalog.spec.ts` updated to include the new command id; `docs/guide/command-palette.md` documents it.

## Test plan

- [x] `uv run pytest tests/api/test_fetch_from_downloads.py tests/api/ tests/test_smoke.py`
- [x] `uv run ruff check backend/`
- [x] `npm run lint`
- [x] `npx playwright test fetch-from-downloads command-palette-catalog library-waveform navigation`
- [ ] Manual: drop a couple of `.mp3` / `.flac` files into `~/Downloads`, click the button on a folder, confirm files move and the table refreshes; click again, confirm "Nothing new — N already in folder".