### PR TITLE
feat(soundcloud): parse hypeddit/bandcamp/beatport links as fallback download

### DIFF
--- a/frontend/e2e/sc-fallback-download.spec.ts
+++ b/frontend/e2e/sc-fallback-download.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * #382: when a SoundCloud track has no `download_url`, parse the description
+ * for a known fallback platform link (bandcamp / beatport / hypeddit) and
+ * surface it through the existing download icon slot.
+ */
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: 100,
+            urn: "soundcloud:tracks:100",
+            title: "Direct download",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            created_at: "2024-01-01T00:00:00Z",
+            permalink_url: "https://soundcloud.com/me/direct",
+            download_url:
+              "https://api.soundcloud.com/tracks/100/download?direct=1",
+            description: null,
+          },
+          {
+            id: 200,
+            urn: "soundcloud:tracks:200",
+            title: "Bandcamp fallback",
+            user: { id: 1, username: "me" },
+            duration: 180_000,
+            created_at: "2024-02-01T00:00:00Z",
+            permalink_url: "https://soundcloud.com/me/bandcamp",
+            download_url: null,
+            description:
+              "Out now on Bandcamp: https://artist.bandcamp.com/track/the-song",
+          },
+          {
+            id: 300,
+            urn: "soundcloud:tracks:300",
+            title: "No fallback either",
+            user: { id: 1, username: "me" },
+            duration: 180_000,
+            created_at: "2024-03-01T00:00:00Z",
+            permalink_url: "https://soundcloud.com/me/none",
+            download_url: null,
+            description: "Just some text, no link here.",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+}
+
+test.describe("SoundCloud fallback download", () => {
+  test("renders parsed description link when download_url is missing", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+
+    await expect(page.locator("[data-index]")).toHaveCount(3, {
+      timeout: 5000,
+    });
+
+    // Track with direct download → uses the standard download icon, not the fallback.
+    const directRow = page.locator('[data-index="0"]');
+    await expect(
+      directRow.locator('[data-testid="sc-download-link"]'),
+    ).toHaveCount(1);
+    await expect(
+      directRow.locator('[data-testid="sc-download-fallback"]'),
+    ).toHaveCount(0);
+
+    // Bandcamp track has no download_url but the description gives us a link.
+    const bandcampRow = page.locator('[data-index="1"]');
+    const fallback = bandcampRow.locator(
+      '[data-testid="sc-download-fallback"]',
+    );
+    await expect(fallback).toHaveCount(1);
+    await expect(fallback).toHaveAttribute(
+      "href",
+      "https://artist.bandcamp.com/track/the-song",
+    );
+    await expect(fallback.locator("img")).toHaveAttribute("alt", "Bandcamp");
+
+    // Track with no download and no description link → empty slot, no link.
+    const emptyRow = page.locator('[data-index="2"]');
+    await expect(
+      emptyRow.locator('[data-testid="sc-download-fallback"]'),
+    ).toHaveCount(0);
+    await expect(
+      emptyRow.locator('[data-testid="sc-download-link"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/tooltip";
 import { api } from "@/lib/api";
 import type { ColumnDef } from "@/lib/columns/types";
+import { parseFallbackDownloadUrl } from "@/lib/parse-fallback-download";
 import { usePlayer, type PlayerTrack } from "@/lib/player-context";
 import type { SourceProfile } from "@/lib/profile-groups";
 import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
@@ -241,24 +242,53 @@ const LIKES_COLUMNS: LikesCol[] = [
           ) : (
             <div className="size-5" />
           )}
-          {track.download_url ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  href={track.download_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center transition-colors"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Download className="size-3" />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent>Download</TooltipContent>
-            </Tooltip>
-          ) : (
-            <div className="size-5" />
-          )}
+          {(() => {
+            if (track.download_url) {
+              return (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <a
+                      href={track.download_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                      data-testid="sc-download-link"
+                    >
+                      <Download className="size-3" />
+                    </a>
+                  </TooltipTrigger>
+                  <TooltipContent>Download</TooltipContent>
+                </Tooltip>
+              );
+            }
+            const fallback = parseFallbackDownloadUrl(track.description);
+            if (!fallback) return <div className="size-5" />;
+            const icon = purchaseIcon(fallback);
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a
+                    href={fallback}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center transition-colors"
+                    onClick={(e) => e.stopPropagation()}
+                    data-testid="sc-download-fallback"
+                  >
+                    {icon ? (
+                      <img src={icon.src} alt={icon.alt} className="size-3.5" />
+                    ) : (
+                      <Download className="size-3" />
+                    )}
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Download via {icon?.alt ?? "external link"}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })()}
           {track.purchase_url ? (
             (() => {
               const icon = purchaseIcon(track.purchase_url);

--- a/frontend/src/lib/parse-fallback-download.test.ts
+++ b/frontend/src/lib/parse-fallback-download.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { parseFallbackDownloadUrl } from "./parse-fallback-download";
+
+describe("parseFallbackDownloadUrl", () => {
+  it("returns null for empty / nullish input", () => {
+    expect(parseFallbackDownloadUrl(null)).toBeNull();
+    expect(parseFallbackDownloadUrl(undefined)).toBeNull();
+    expect(parseFallbackDownloadUrl("")).toBeNull();
+  });
+
+  it("returns null when no known platform URL is present", () => {
+    expect(parseFallbackDownloadUrl("Free download below!")).toBeNull();
+    expect(
+      parseFallbackDownloadUrl("Check out https://example.com/foo.zip"),
+    ).toBeNull();
+  });
+
+  it("matches bandcamp subdomains", () => {
+    expect(
+      parseFallbackDownloadUrl(
+        "Out now: https://artist.bandcamp.com/track/song-title — enjoy!",
+      ),
+    ).toBe("https://artist.bandcamp.com/track/song-title");
+  });
+
+  it("matches hypeddit URLs", () => {
+    expect(
+      parseFallbackDownloadUrl("Free DL: http://hypeddit.com/abc123"),
+    ).toBe("http://hypeddit.com/abc123");
+  });
+
+  it("matches beatport URLs", () => {
+    expect(
+      parseFallbackDownloadUrl(
+        "Buy it: https://www.beatport.com/track/foo/12345.",
+      ),
+    ).toBe("https://www.beatport.com/track/foo/12345");
+  });
+
+  it("returns the first matching URL when multiple are present", () => {
+    const desc =
+      "Bandcamp: https://artist.bandcamp.com/track/a\nBeatport: https://beatport.com/track/b/2";
+    expect(parseFallbackDownloadUrl(desc)).toBe(
+      "https://artist.bandcamp.com/track/a",
+    );
+  });
+
+  it("ignores URLs with similar-looking but unrelated hostnames", () => {
+    expect(
+      parseFallbackDownloadUrl("https://notbandcamp.fake.com/track/x"),
+    ).toBeNull();
+    expect(parseFallbackDownloadUrl("https://bandcamp.evil.com/x")).toBeNull();
+  });
+});

--- a/frontend/src/lib/parse-fallback-download.ts
+++ b/frontend/src/lib/parse-fallback-download.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse a SoundCloud track description for a fallback download link.
+ *
+ * SoundCloud tracks without a direct ``download_url`` often point at an
+ * external download/sale page in the description text. We surface the first
+ * URL we find on a known platform so the UI can render a fallback download
+ * affordance instead of an empty slot.
+ */
+
+const HOSTS = ["bandcamp.com", "beatport.com", "hypeddit.com"] as const;
+
+const URL_RE = /https?:\/\/[^\s<>"')]+/gi;
+
+export function parseFallbackDownloadUrl(
+  description: string | null | undefined,
+): string | null {
+  if (!description) return null;
+  for (const raw of description.match(URL_RE) ?? []) {
+    // Trim trailing punctuation that commonly bleeds into URL matches.
+    const candidate = raw.replace(/[.,;:!?)\]]+$/, "");
+    let host: string;
+    try {
+      host = new URL(candidate).hostname.toLowerCase();
+    } catch {
+      continue;
+    }
+    if (HOSTS.some((h) => host === h || host.endsWith(`.${h}`))) {
+      return candidate;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

When a SoundCloud track has no direct `download_url`, look at its `description` for a URL on a known fallback platform — **bandcamp.com**, **beatport.com**, or **hypeddit.com** (including subdomains) — and surface it through the existing download-icon slot in the SoundCloud likes table. The platform's brand icon is used (via the same registry that powers `purchase_url`), and the tooltip reads "Download via Bandcamp / Beatport / Hypeddit".

Tracks with a real `download_url` are unchanged. Tracks with neither a download URL nor a recognised description link keep the existing empty slot.

Closes #382.

## Decisions made (per discussion)

- **Reuse the existing download icon slot** rather than adding a new one.
- **Frontend-only parsing** — descriptions already come back on the SC track payload, no backend round-trip needed.
- Platform allowlist limited to `bandcamp.com`, `beatport.com`, `hypeddit.com`. Subdomains match (e.g. `artist.bandcamp.com`).

## What's in the PR

- `frontend/src/lib/parse-fallback-download.ts` — small, dependency-free URL extractor.
- `frontend/src/lib/parse-fallback-download.test.ts` — 7 vitest cases (subdomains, multiple URLs, similar-but-bogus hostnames, etc.).
- `frontend/src/components/likes-table.tsx` — wires the fallback into the download slot, reusing the existing `purchaseIcon` registry.
- `frontend/e2e/sc-fallback-download.spec.ts` — Playwright spec that mounts three tracks (direct download / bandcamp fallback / no link) and asserts the right slot is rendered for each.

## Test plan

- [x] `npx vitest run src/lib/parse-fallback-download.test.ts`
- [x] `npx playwright test sc-fallback-download sc-date-columns sc-link-button soundcloud-like-button sc-bpm-row-leak`
- [x] `npm run lint` / `npm run typecheck`
- [ ] Manual: open `/library?source=soundcloud`, find a track that previously had an empty download slot but mentions Bandcamp in its description — confirm the icon now appears with the right tooltip and opens the parsed URL in a new tab.