### PR TITLE
feat(library): add Tracks section to SoundCloud tree

### DIFF
--- a/frontend/e2e/soundcloud-tracks.spec.ts
+++ b/frontend/e2e/soundcloud-tracks.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SoundCloud "Tracks" section — sibling to Likes/Reposts in the library tree
+ * on the "me" tab. Fetches `/me/tracks` (or per-user equivalent on Discover)
+ * and reuses the LikesTable rendering pipeline. Ordered by created_at desc.
+ */
+
+async function setupAuth(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/reposts/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/soundcloud/system-playlists", (route) =>
+    route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "unavailable" }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+}
+
+test.describe("SoundCloud Tracks section", () => {
+  test("renders user's own tracks ordered by created_at desc", async ({
+    page,
+  }) => {
+    await setupAuth(page);
+
+    await page.route("https://api.soundcloud.com/me/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          collection: [
+            {
+              id: 301,
+              urn: "soundcloud:tracks:301",
+              title: "Older Upload",
+              user: { id: 1, username: "me" },
+              duration: 180_000,
+              permalink_url: "https://soundcloud.com/me/older",
+              artwork_url: null,
+              genre: "House",
+              created_at: "2024-01-15T10:00:00Z",
+            },
+            {
+              id: 302,
+              urn: "soundcloud:tracks:302",
+              title: "Newest Upload",
+              user: { id: 1, username: "me" },
+              duration: 200_000,
+              permalink_url: "https://soundcloud.com/me/newest",
+              artwork_url: null,
+              genre: "Techno",
+              created_at: "2025-08-01T10:00:00Z",
+            },
+            {
+              id: 303,
+              urn: "soundcloud:tracks:303",
+              title: "Middle Upload",
+              user: { id: 1, username: "me" },
+              duration: 210_000,
+              permalink_url: "https://soundcloud.com/me/middle",
+              artwork_url: null,
+              genre: "Drum & Bass",
+              created_at: "2024-09-01T10:00:00Z",
+            },
+          ],
+          next_href: null,
+        }),
+      }),
+    );
+
+    await page.goto("/library?source=soundcloud");
+
+    const tracksRow = page.getByRole("button", { name: /^Tracks/ });
+    await expect(tracksRow).toBeVisible();
+    await tracksRow.click();
+
+    await expect(page.getByText("Newest Upload")).toBeVisible();
+    await expect(page.getByText("Middle Upload")).toBeVisible();
+    await expect(page.getByText("Older Upload")).toBeVisible();
+
+    // Newest must come before Middle, which must come before Older.
+    const body = (await page.locator("body").innerText()) ?? "";
+    const newestIdx = body.indexOf("Newest Upload");
+    const middleIdx = body.indexOf("Middle Upload");
+    const olderIdx = body.indexOf("Older Upload");
+    expect(newestIdx).toBeGreaterThanOrEqual(0);
+    expect(middleIdx).toBeGreaterThan(newestIdx);
+    expect(olderIdx).toBeGreaterThan(middleIdx);
+  });
+
+  test("shows empty-state when user has no tracks", async ({ page }) => {
+    await setupAuth(page);
+    await page.route("https://api.soundcloud.com/me/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+
+    await page.goto("/library?source=soundcloud&node=tracks");
+    await expect(page.getByText(/No tracks found/)).toBeVisible();
+  });
+});

--- a/frontend/src/app/library/likes-tree-panel.tsx
+++ b/frontend/src/app/library/likes-tree-panel.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Heart, ListMusic, Repeat2, Sparkles, User } from "lucide-react";
+import {
+  AudioLines,
+  Heart,
+  ListMusic,
+  Repeat2,
+  Sparkles,
+  User,
+} from "lucide-react";
 import { useMemo } from "react";
 
 import { TreeView } from "@/components/tree/tree-view";
@@ -11,6 +18,7 @@ import type { SystemPlaylistSummary } from "./use-system-playlists";
 
 export const LIKES_NODE_ID = "likes";
 export const REPOSTS_NODE_ID = "reposts";
+export const TRACKS_NODE_ID = "tracks";
 export const PLAYLISTS_GROUP_ID = "playlists";
 export const MIXES_GROUP_ID = "mixes";
 export const playlistNodeId = (urn: string) => `pl:${urn}`;
@@ -21,6 +29,7 @@ export type LikesTreeNodeKind =
   | "root"
   | "likes"
   | "reposts"
+  | "tracks"
   | "group"
   | "member"
   | "playlist"
@@ -45,6 +54,8 @@ interface LikesTreePanelProps {
   likesCount: number;
   /** Filtered count for the Reposts node. */
   repostsCount: number;
+  /** Filtered count for the Tracks node (uploads by the user/group). */
+  tracksCount: number;
   /** Filtered count for the "Playlists" aggregate group (tracks across all). */
   combinedCount: number;
   /**
@@ -80,6 +91,7 @@ export function LikesTreePanel({
   storageKey,
   likesCount,
   repostsCount,
+  tracksCount,
   combinedCount,
   perPlaylistFilteredCount,
   mixes,
@@ -137,6 +149,13 @@ export function LikesTreePanel({
         kind: "reposts",
         trackCount: repostsCount,
       },
+      {
+        id: TRACKS_NODE_ID,
+        name: "Tracks",
+        children: [],
+        kind: "tracks",
+        trackCount: tracksCount,
+      },
     ];
     // Always surface Mixes on tabs where it applies. When the user hasn't
     // connected yet we still render the group (empty) so the CTA in the
@@ -168,6 +187,7 @@ export function LikesTreePanel({
     playlists,
     likesCount,
     repostsCount,
+    tracksCount,
     combinedCount,
     perPlaylistFilteredCount,
     mixes,
@@ -190,6 +210,11 @@ export function LikesTreePanel({
         if (node.kind === "reposts") {
           return (
             <Repeat2 className="text-muted-foreground size-3.5 shrink-0" />
+          );
+        }
+        if (node.kind === "tracks") {
+          return (
+            <AudioLines className="text-muted-foreground size-3.5 shrink-0" />
           );
         }
         // Match group headers (Mixes/Playlists) to the icon used by their

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -59,11 +59,13 @@ import {
   playlistNodeId,
   PLAYLISTS_GROUP_ID,
   REPOSTS_NODE_ID,
+  TRACKS_NODE_ID,
 } from "./likes-tree-panel";
 import { useCombinedPlaylistsTracks } from "./use-combined-playlists-tracks";
 import { useGroupLikes } from "./use-group-likes";
 import { useGroupPlaylists } from "./use-group-playlists";
 import { useGroupReposts } from "./use-group-reposts";
+import { useGroupTracks } from "./use-group-tracks";
 import { useLikes } from "./use-likes";
 import {
   filterStateToLikesOptions,
@@ -75,6 +77,7 @@ import { useReposts } from "./use-reposts";
 import { useSoundcloudTrackSearch } from "./use-soundcloud-track-search";
 import { useSystemPlaylistTracks } from "./use-system-playlist-tracks";
 import { useSystemPlaylists } from "./use-system-playlists";
+import { useTracks } from "./use-tracks";
 import { useUserPlaylists } from "./use-user-playlists";
 
 /** Hide attributes that don't apply to the current tab/context. */
@@ -174,8 +177,10 @@ export function SoundcloudView() {
 
   const myLikes = useLikes("me");
   const myReposts = useReposts("me");
+  const myTracks = useTracks("me");
   const groupLikes = useGroupLikes(tab === "discover" ? activeGroup : null);
   const groupReposts = useGroupReposts(tab === "discover" ? activeGroup : null);
+  const groupTracks = useGroupTracks(tab === "discover" ? activeGroup : null);
   const trackSearch = useSoundcloudTrackSearch(
     tab === "search" ? searchQuery : "",
   );
@@ -206,10 +211,25 @@ export function SoundcloudView() {
     }),
     [groupReposts.tracks, groupReposts.loading, groupReposts.error],
   );
+  const discoverTracks = useMemo(
+    () => ({
+      tracks: groupTracks.tracks as unknown as SCTrack[],
+      loading: groupTracks.loading,
+      hasMore: false,
+      loaded: groupTracks.tracks.length,
+      error: groupTracks.error,
+      reload: () => {
+        /* per-member cache; reload is a no-op v1. */
+      },
+    }),
+    [groupTracks.tracks, groupTracks.loading, groupTracks.error],
+  );
   const activeLikes =
     tab === "me" ? myLikes : tab === "discover" ? discoverLikes : trackSearch;
   const activeReposts =
     tab === "me" ? myReposts : tab === "discover" ? discoverReposts : null;
+  const activeTracks =
+    tab === "me" ? myTracks : tab === "discover" ? discoverTracks : null;
 
   // Autoplay the requested track once search results arrive.
   useEffect(() => {
@@ -285,6 +305,7 @@ export function SoundcloudView() {
   const isAllPlaylistsView = nodeId === PLAYLISTS_GROUP_ID;
   const isMixesGroupView = nodeId === MIXES_GROUP_ID;
   const isRepostsView = nodeId === REPOSTS_NODE_ID;
+  const isTracksView = nodeId === TRACKS_NODE_ID;
 
   const selectedPlaylist = useMemo(() => {
     if (!isPlaylistView) return null;
@@ -412,6 +433,10 @@ export function SoundcloudView() {
   const repostsCount = useMemo(
     () => (activeReposts?.tracks ?? []).filter(filterPredicate).length,
     [activeReposts, filterPredicate],
+  );
+  const tracksCount = useMemo(
+    () => (activeTracks?.tracks ?? []).filter(filterPredicate).length,
+    [activeTracks, filterPredicate],
   );
   const combinedCount = useMemo(
     () => combinedPlaylistTracks.tracks.filter(filterPredicate).length,
@@ -646,6 +671,7 @@ export function SoundcloudView() {
             storageKey={storageKey}
             likesCount={likesCount}
             repostsCount={repostsCount}
+            tracksCount={tracksCount}
             combinedCount={combinedCount}
             perPlaylistFilteredCount={perPlaylistCount}
             mixes={mixes}
@@ -659,6 +685,7 @@ export function SoundcloudView() {
             tab={tab}
             activeLikes={activeLikes}
             activeReposts={activeReposts}
+            activeTracks={activeTracks}
             playlistTracks={playlistTracks}
             combinedPlaylistTracks={combinedPlaylistTracks}
             mixTracks={mixTracks}
@@ -668,6 +695,7 @@ export function SoundcloudView() {
             isMixView={isMixView}
             isMixesGroupView={isMixesGroupView}
             isRepostsView={isRepostsView}
+            isTracksView={isTracksView}
             mixesAvailable={mixesAvailable}
             myLikedIds={myLikedIds}
             collectionIds={collectionIds}
@@ -692,6 +720,7 @@ interface LikesViewProps {
   tab: string;
   activeLikes: ReturnType<typeof useLikes>;
   activeReposts: ReturnType<typeof useLikes> | null;
+  activeTracks: ReturnType<typeof useLikes> | null;
   playlistTracks: ReturnType<typeof usePlaylistTracks>;
   combinedPlaylistTracks: ReturnType<typeof useCombinedPlaylistsTracks>;
   mixTracks: ReturnType<typeof useSystemPlaylistTracks>;
@@ -701,6 +730,7 @@ interface LikesViewProps {
   isMixView: boolean;
   isMixesGroupView: boolean;
   isRepostsView: boolean;
+  isTracksView: boolean;
   mixesAvailable: boolean;
   myLikedIds: Set<number>;
   collectionIds: Set<number>;
@@ -722,6 +752,7 @@ function LikesView({
   tab,
   activeLikes,
   activeReposts,
+  activeTracks,
   playlistTracks,
   combinedPlaylistTracks,
   mixTracks,
@@ -731,6 +762,7 @@ function LikesView({
   isMixView,
   isMixesGroupView,
   isRepostsView,
+  isTracksView,
   mixesAvailable,
   myLikedIds,
   collectionIds,
@@ -757,7 +789,9 @@ function LikesView({
         ? combinedPlaylistTracks.tracks
         : isRepostsView
           ? (activeReposts?.tracks ?? EMPTY_TRACKS)
-          : activeLikes.tracks;
+          : isTracksView
+            ? (activeTracks?.tracks ?? EMPTY_TRACKS)
+            : activeLikes.tracks;
 
   const { filteredTracks } = useLikesFilter(
     sourceTracks,
@@ -828,7 +862,9 @@ function LikesView({
         ? combinedPlaylistTracks.loading
         : isRepostsView
           ? (activeReposts?.loading ?? false)
-          : activeLikes.loading;
+          : isTracksView
+            ? (activeTracks?.loading ?? false)
+            : activeLikes.loading;
   const error = isMixView
     ? mixTracks.error
     : isPlaylistView
@@ -837,7 +873,9 @@ function LikesView({
         ? combinedPlaylistTracks.error
         : isRepostsView
           ? (activeReposts?.error ?? null)
-          : activeLikes.error;
+          : isTracksView
+            ? (activeTracks?.error ?? null)
+            : activeLikes.error;
   const loadedCount = isMixView
     ? mixTracks.tracks.length
     : isPlaylistView
@@ -846,7 +884,9 @@ function LikesView({
         ? combinedPlaylistTracks.tracks.length
         : isRepostsView
           ? (activeReposts?.loaded ?? 0)
-          : activeLikes.loaded;
+          : isTracksView
+            ? (activeTracks?.loaded ?? 0)
+            : activeLikes.loaded;
 
   // Contextual palette commands — registered only while this view is mounted
   // and a selection/filter context applies.
@@ -867,7 +907,11 @@ function LikesView({
   });
 
   const reloadActiveLikes =
-    isRepostsView && activeReposts ? activeReposts.reload : activeLikes.reload;
+    isRepostsView && activeReposts
+      ? activeReposts.reload
+      : isTracksView && activeTracks
+        ? activeTracks.reload
+        : activeLikes.reload;
   useCommand({
     id: "sc:reload",
     label:
@@ -1009,7 +1053,9 @@ function LikesView({
                       ? "No tracks matched your search"
                       : isRepostsView
                         ? "No reposted tracks found"
-                        : "No liked tracks found"}
+                        : isTracksView
+                          ? "No tracks found"
+                          : "No liked tracks found"}
             </p>
           </div>
         ) : (

--- a/frontend/src/app/library/use-group-tracks.ts
+++ b/frontend/src/app/library/use-group-tracks.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+
+import {
+  mergeGroupedLikes,
+  type GroupedTrack,
+  type ProfileGroup,
+} from "@/lib/profile-groups";
+import {
+  fetchTracksPage,
+  getUserTracks,
+  parseSCTimestamp,
+  type SCTrack,
+} from "@/lib/soundcloud";
+
+interface UseGroupTracksResult {
+  tracks: GroupedTrack[];
+  loading: boolean;
+  error: string | null;
+}
+
+const PAGE_SIZE = 200;
+
+async function fetchAllUserTracks(
+  userUrn: string,
+  isCancelled: () => boolean,
+  onPage: (tracks: SCTrack[]) => void,
+): Promise<void> {
+  const first = await getUserTracks(userUrn, PAGE_SIZE);
+  if (isCancelled()) return;
+  if (first.collection?.length) onPage(first.collection);
+  let nextUrl = first.next_href;
+  while (nextUrl && !isCancelled()) {
+    const resp = await fetchTracksPage(nextUrl);
+    if (isCancelled()) return;
+    if (resp.collection?.length) onPage(resp.collection);
+    nextUrl = resp.next_href;
+  }
+}
+
+function sortByCreatedAtDesc(tracks: GroupedTrack[]): GroupedTrack[] {
+  return [...tracks].sort((a, b) => {
+    const ta = parseSCTimestamp(a.created_at) ?? 0;
+    const tb = parseSCTimestamp(b.created_at) ?? 0;
+    return tb - ta;
+  });
+}
+
+/** Tracks equivalent of `useGroupReposts` — paginates fully per member.
+ *
+ * Each member's tracks are sorted client-side by created_at desc before merge,
+ * so the round-robin interleave surfaces the most recently uploaded track from
+ * every profile in the group at the top of the merged list. */
+export function useGroupTracks(
+  group: ProfileGroup | null,
+): UseGroupTracksResult {
+  const [tracks, setTracks] = useState<GroupedTrack[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const memberKey = group
+    ? `${group.id ?? ""}|${(group.members ?? [])
+        .map((m) => m.user_urn)
+        .join(",")}`
+    : "";
+
+  useEffect(() => {
+    const members = group?.members ?? [];
+    if (!group || members.length === 0) {
+      setTracks([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setTracks([]);
+    setLoading(true);
+    setError(null);
+
+    const perMember = members.map((m) => ({
+      source: {
+        user_urn: m.user_urn,
+        username: m.username,
+        avatar_url: m.avatar_url ?? null,
+      },
+      tracks: [] as SCTrack[],
+    }));
+
+    const recompute = () => {
+      const sorted = perMember.map((p) => ({
+        source: p.source,
+        tracks: [...p.tracks].sort((a, b) => {
+          const ta = parseSCTimestamp(a.created_at) ?? 0;
+          const tb = parseSCTimestamp(b.created_at) ?? 0;
+          return tb - ta;
+        }),
+      }));
+      setTracks(sortByCreatedAtDesc(mergeGroupedLikes(sorted)));
+    };
+
+    Promise.all(
+      members.map((m, idx) =>
+        fetchAllUserTracks(
+          m.user_urn,
+          () => cancelled,
+          (page) => {
+            if (cancelled) return;
+            perMember[idx].tracks = perMember[idx].tracks.concat(page);
+            recompute();
+          },
+        ),
+      ),
+    )
+      .then(() => {
+        if (cancelled) return;
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load tracks");
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberKey]);
+
+  return { tracks, loading, error };
+}

--- a/frontend/src/app/library/use-tracks.ts
+++ b/frontend/src/app/library/use-tracks.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  fetchTracksPage,
+  getMyTracks,
+  getUserTracks,
+  parseSCTimestamp,
+  type SCTrack,
+} from "@/lib/soundcloud";
+
+interface UseTracksResult {
+  tracks: SCTrack[];
+  loading: boolean;
+  loaded: number;
+  hasMore: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+const CACHE_TTL = 5 * 60 * 1000;
+const tracksCache = new Map<string, { tracks: SCTrack[]; fetchedAt: number }>();
+
+function getCached(key: string): SCTrack[] | null {
+  const entry = tracksCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > CACHE_TTL) {
+    tracksCache.delete(key);
+    return null;
+  }
+  return entry.tracks;
+}
+
+const PAGE_SIZE = 200;
+
+function sortByCreatedAtDesc(tracks: SCTrack[]): SCTrack[] {
+  return [...tracks].sort((a, b) => {
+    const ta = parseSCTimestamp(a.created_at) ?? 0;
+    const tb = parseSCTimestamp(b.created_at) ?? 0;
+    return tb - ta;
+  });
+}
+
+async function fetchAllPages(
+  userUrn: string | "me",
+  signal: AbortSignal,
+  onProgress: (tracks: SCTrack[]) => void,
+): Promise<SCTrack[]> {
+  const allTracks: SCTrack[] = [];
+
+  const first =
+    userUrn === "me"
+      ? await getMyTracks(PAGE_SIZE)
+      : await getUserTracks(userUrn, PAGE_SIZE);
+
+  if (signal.aborted) return allTracks;
+
+  const page = first.collection ?? [];
+  if (page.length > 0) allTracks.push(...page);
+  onProgress(sortByCreatedAtDesc(allTracks));
+
+  let nextUrl = first.next_href;
+
+  while (nextUrl && !signal.aborted) {
+    const resp = await fetchTracksPage(nextUrl);
+    if (signal.aborted) return allTracks;
+
+    const tracks = resp.collection ?? [];
+    if (tracks.length > 0) allTracks.push(...tracks);
+    onProgress(sortByCreatedAtDesc(allTracks));
+
+    nextUrl = resp.next_href;
+  }
+
+  return sortByCreatedAtDesc(allTracks);
+}
+
+export function useTracks(userUrn: string | "me" | null): UseTracksResult {
+  const [tracks, setTracks] = useState<SCTrack[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchAll = useCallback(
+    async (signal: AbortSignal, bypassCache = false) => {
+      if (!userUrn) return;
+
+      if (!bypassCache) {
+        const cached = getCached(userUrn);
+        if (cached) {
+          setTracks(cached);
+          setHasMore(false);
+          setLoading(false);
+          setError(null);
+          return;
+        }
+      }
+
+      setTracks([]);
+      setLoading(true);
+      setHasMore(true);
+      setError(null);
+
+      try {
+        const all = await fetchAllPages(userUrn, signal, (progress) => {
+          if (!signal.aborted) setTracks(progress);
+        });
+
+        if (!signal.aborted) {
+          setTracks(all);
+          setHasMore(false);
+          tracksCache.set(userUrn, { tracks: all, fetchedAt: Date.now() });
+        }
+      } catch (err) {
+        if (signal.aborted) return;
+        setError(err instanceof Error ? err.message : "Failed to fetch tracks");
+      } finally {
+        if (!signal.aborted) setLoading(false);
+      }
+    },
+    [userUrn],
+  );
+
+  useEffect(() => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    fetchAll(controller.signal);
+    return () => controller.abort();
+  }, [fetchAll]);
+
+  const reload = useCallback(() => {
+    if (userUrn) tracksCache.delete(userUrn);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    fetchAll(controller.signal, true);
+  }, [fetchAll, userUrn]);
+
+  return { tracks, loading, loaded: tracks.length, hasMore, error, reload };
+}

--- a/frontend/src/lib/soundcloud.ts
+++ b/frontend/src/lib/soundcloud.ts
@@ -262,6 +262,55 @@ export async function fetchRepostsPage(nextHref: string): Promise<SCTracks> {
   return fetchRepostsUrl(nextHref);
 }
 
+export async function getMyTracks(
+  limit = 200,
+  cursor?: string,
+): Promise<SCTracks> {
+  const client = await getClient();
+  const { data, error } = await client.GET("/me/tracks", {
+    params: {
+      query: {
+        limit,
+        linked_partitioning: true,
+        ...(cursor ? { offset: cursor } : {}),
+      } as never,
+    },
+  });
+  if (error)
+    throw new Error(`Failed to fetch my tracks: ${JSON.stringify(error)}`);
+  return data as SCTracks;
+}
+
+export async function getUserTracks(
+  userUrn: string,
+  limit = 200,
+  cursor?: string,
+): Promise<SCTracks> {
+  const client = await getClient();
+  const { data, error } = await client.GET("/users/{user_urn}/tracks", {
+    params: {
+      path: { user_urn: userUrn },
+      query: {
+        limit,
+        linked_partitioning: true,
+        ...(cursor ? { offset: cursor } : {}),
+      } as never,
+    },
+  });
+  if (error)
+    throw new Error(`Failed to fetch user tracks: ${JSON.stringify(error)}`);
+  return data as SCTracks;
+}
+
+export async function fetchTracksPage(nextHref: string): Promise<SCTracks> {
+  const token = await ensureValidToken();
+  const resp = await fetch(nextHref, {
+    headers: { Authorization: `OAuth ${token}` },
+  });
+  if (!resp.ok) throw new Error(`Failed to fetch tracks page: ${resp.status}`);
+  return (await resp.json()) as SCTracks;
+}
+
 export async function getUser(userUrn: string): Promise<SCUser | null> {
   const client = await getClient();
   const { data, error } = await client.GET("/users/{user_urn}", {


### PR DESCRIPTION
## Summary
- New `Tracks` tree node in the SoundCloud library, sibling to Likes and Reposts.
- On **My Library** (`tab=me`): user's own uploads via `/me/tracks`.
- On **Discover** (`tab=discover`): tracks from a single profile or merged across a profile group via `/users/{user_urn}/tracks`, with the same per-member round-robin merge used by Likes/Reposts.
- Tracks are sorted client-side by `created_at` desc, both per-member and after merge.
- Reuses the LikesTable rendering pipeline, filters, columns, and selection — only the data source changes.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npx prettier --check`
- [x] `npx playwright test e2e/soundcloud-tracks.spec.ts` — renders ordered by `created_at` desc + empty state
- [x] `npx playwright test e2e/soundcloud-reposts.spec.ts e2e/command-palette-catalog.spec.ts` — adjacent specs still green
- [ ] Manual: open `/library?source=soundcloud`, click `Tracks`, confirm uploads appear newest-first
- [ ] Manual: switch to Discover, pick a user / saved group, confirm their uploads load and merge correctly