### PR TITLE
feat(library): reanalyze + manual BPM edit

### DIFF
--- a/frontend/e2e/sc-bpm-edit.spec.ts
+++ b/frontend/e2e/sc-bpm-edit.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SC view BPM cell: manual override via popover.
+ *
+ * Reanalyze is gated on the Tauri WebView (analyzeSc uses tauri invoke),
+ * so we cover only the manual edit path here. The popover trigger and
+ * Save button are reachable in the browser fixture; the Reanalyze button
+ * is hidden when isTauri() is false.
+ */
+
+const TRACK_ID = 42;
+const TRACK_URN = `soundcloud:tracks:${TRACK_ID}`;
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: TRACK_ID,
+            urn: TRACK_URN,
+            title: "Edit me",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/edit-me",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/tracks*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  // Track already has a cached BPM of 120 so the cell renders as a popover
+  // trigger (rather than the "Detect" icon-only button).
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: { [String(TRACK_ID)]: 120 } }),
+    }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+}
+
+test.describe("SC view — BPM edit popover", () => {
+  test("manual override saves to backend and updates the row", async ({
+    page,
+  }) => {
+    await setup(page);
+
+    let lastSavedBpm: number | null = null;
+    await page.route("**/api/bpm/soundcloud", (route) => {
+      const req = route.request();
+      const body = req.postDataJSON() as { track_id: number; bpm: number };
+      lastSavedBpm = body.bpm;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ track_id: body.track_id, bpm: body.bpm }),
+      });
+    });
+
+    await page.goto("/library?source=soundcloud");
+
+    const row = page.locator("[data-index]").first();
+    await expect(row).toContainText("Edit me");
+    await expect(row).toContainText("120");
+
+    // Open the popover from the BPM cell.
+    await row.getByTestId("sc-bpm-edit-trigger").click();
+    await expect(page.getByTestId("sc-bpm-edit-input")).toBeVisible();
+
+    // react-aria-components NumberField commits on Enter/blur. Click the
+    // increment button so the field state ticks 120 → 121 without having
+    // to negotiate keyboard formatting locale rules.
+    await page.getByRole("button", { name: "Increase BPM" }).click();
+    await page.getByTestId("sc-bpm-save").click();
+
+    // Backend was called with the override (120 + 1 increment = 121).
+    await expect.poll(() => lastSavedBpm).toBe(121);
+
+    // Row reflects the new value (popover closes; cell shows 121).
+    await expect(row).toContainText("121");
+  });
+});

--- a/frontend/src/components/soundcloud-bpm-cell.tsx
+++ b/frontend/src/components/soundcloud-bpm-cell.tsx
@@ -10,6 +10,12 @@ import {
 } from "@/components/soundcloud-batch-analyze-button";
 import { Spinner } from "@/components/spinner";
 import { Button } from "@/components/ui/button";
+import { NumberInput } from "@/components/ui/number-input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { api } from "@/lib/api";
 import { analyzeSc, TrackUnanalysableError } from "@/lib/sc-bpm";
 import { markScUnplayable, useIsScUnplayable } from "@/lib/sc-unplayable";
@@ -29,30 +35,37 @@ export const SoundcloudBpmCacheContext = React.createContext<
   Map<number, number>
 >(new Map());
 
+function dispatchBpmUpdate(trackId: number, bpm: number) {
+  window.dispatchEvent(
+    new CustomEvent<ScBpmUpdatedDetail>(SC_BPM_UPDATED_EVENT, {
+      detail: { trackId, bpm },
+    }),
+  );
+}
+
 /** BPM cell for SoundCloud library rows.
  *
  * Precedence: locally-computed cached BPM (this session) > backend-cached
  * BPM (set by a previous analyze) > metadata-supplied BPM > "Detect" button.
  *
- * On click: fetches a Client-Credentials token from the backend, invokes the
- * Rust BPM command via Tauri, persists the result to the cache DB, and
- * shows the new value. Hidden outside the Tauri WebView.
+ * When a BPM is shown, clicking it opens a popover that supports both
+ * re-analyzing (re-runs the Tauri BPM pipeline) and a manual override
+ * (for cases where detection was wrong). Outside the Tauri WebView the
+ * popover is suppressed because analyze + save round-trip via Tauri/IPC.
  */
 export function SoundcloudBpmCell({ trackId, metadataBpm }: Props) {
   const [analyzedBpm, setAnalyzedBpm] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
-  // Sticky once SC refuses analysis — prevents the user from spamming the
-  // Detect button on a track SoundCloud will never let us stream.
   const [unanalysable, setUnanalysable] = useState(false);
-  // Read the global session set so a track flagged unplayable elsewhere
-  // (player, batch, pitcher) immediately reflects in this cell too.
   const sessionUnplayable = useIsScUnplayable(trackId);
   const bpmCache = useContext(SoundcloudBpmCacheContext);
 
   const cachedBpm = bpmCache.get(trackId);
   const displayBpm = analyzedBpm ?? cachedBpm ?? metadataBpm ?? null;
 
-  // Listen for batch-analyze results so visible rows fill in live.
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [draft, setDraft] = useState<string>("");
+
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<ScBpmUpdatedDetail>).detail;
@@ -64,22 +77,37 @@ export function SoundcloudBpmCell({ trackId, metadataBpm }: Props) {
     return () => window.removeEventListener(SC_BPM_UPDATED_EVENT, handler);
   }, [trackId]);
 
-  async function handleAnalyze() {
+  // Seed the draft from the currently shown BPM each time the popover opens
+  // so the user's starting point is what they see in the cell.
+  useEffect(() => {
+    if (popoverOpen) {
+      setDraft(displayBpm != null ? String(displayBpm) : "");
+    }
+  }, [popoverOpen, displayBpm]);
+
+  async function persistBpm(bpm: number) {
+    await api.saveSoundcloudBpm(trackId, bpm);
+    setAnalyzedBpm(bpm);
+    dispatchBpmUpdate(trackId, bpm);
+  }
+
+  async function handleAnalyze(closeOnDone: boolean) {
     if (!isTauri() || !trackId || loading) return;
     setLoading(true);
     try {
       const result = await analyzeSc(trackId);
       const rounded = Math.round(result.bpm);
-      await api.saveSoundcloudBpm(trackId, result.bpm);
-      setAnalyzedBpm(rounded);
+      await persistBpm(rounded);
       toast.success(
         `Detected ${rounded} BPM (${result.confidence} confidence)`,
       );
+      if (closeOnDone) setPopoverOpen(false);
     } catch (err) {
       if (err instanceof TrackUnanalysableError) {
         setUnanalysable(true);
         markScUnplayable(trackId);
         toast.warning(err.message);
+        setPopoverOpen(false);
       } else {
         toast.error(
           `BPM detection failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -90,8 +118,83 @@ export function SoundcloudBpmCell({ trackId, metadataBpm }: Props) {
     }
   }
 
+  async function handleSaveManual() {
+    const n = Number(draft);
+    if (!Number.isFinite(n) || n <= 0) {
+      toast.error("Enter a positive BPM value");
+      return;
+    }
+    const rounded = Math.round(n);
+    setLoading(true);
+    try {
+      await persistBpm(rounded);
+      toast.success(`BPM set to ${rounded}`);
+      setPopoverOpen(false);
+    } catch (err) {
+      toast.error(
+        `Failed to save BPM: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   if (displayBpm != null) {
-    return <>{displayBpm}</>;
+    return (
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="hover:bg-accent hover:text-foreground -mx-1 cursor-pointer rounded px-1 tabular-nums transition-colors"
+            title="Edit or reanalyze BPM"
+            data-testid="sc-bpm-edit-trigger"
+          >
+            {displayBpm}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-56 p-3">
+          <div className="flex flex-col gap-2">
+            <span className="text-2xs text-muted-foreground font-medium tracking-wider uppercase">
+              BPM
+            </span>
+            <div className="flex items-center gap-2">
+              <NumberInput
+                value={draft}
+                onChange={setDraft}
+                min={1}
+                max={400}
+                ariaLabel="BPM"
+                testId="sc-bpm-edit-input"
+                className="h-8 text-xs"
+                placeholder="—"
+              />
+              <Button
+                size="sm"
+                onClick={handleSaveManual}
+                disabled={
+                  loading || draft === "" || draft === String(displayBpm)
+                }
+                data-testid="sc-bpm-save"
+              >
+                Save
+              </Button>
+            </div>
+            {isTauri() && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleAnalyze(true)}
+                disabled={loading || unanalysable || sessionUnplayable}
+                data-testid="sc-bpm-reanalyze"
+              >
+                {loading ? <Spinner /> : <Waves />}
+                Reanalyze
+              </Button>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
   }
   if (!isTauri()) {
     return <>—</>;
@@ -110,9 +213,10 @@ export function SoundcloudBpmCell({ trackId, metadataBpm }: Props) {
     <Button
       variant="ghost"
       size="icon-xs"
-      onClick={handleAnalyze}
+      onClick={() => handleAnalyze(false)}
       disabled={loading}
       title="Detect BPM"
+      data-testid="sc-bpm-detect"
     >
       {loading ? <Spinner /> : <Waves />}
     </Button>


### PR DESCRIPTION
Closes #388.

When a SoundCloud row has a BPM, clicking the cell opens a popover with a number input (manual override — for incorrect detections) and a Reanalyze button. Reanalyze requires Tauri; manual override works anywhere. Both persist via the existing `/api/bpm/soundcloud` endpoint and broadcast `sc-bpm-updated` so other visible cells refresh in-session.

## Test plan
- [x] `npx playwright test sc-bpm-edit` — covers popover open + manual save + row update
- [x] `npx playwright test sc-bpm-row-leak` — existing virtualizer regression still green
- [ ] Manual: reanalyze path in Tauri build