### PR TITLE
ci: don't cancel test runs on main pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
         branches: [main]
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     changes:


### PR DESCRIPTION
Scope the tests workflow's concurrency group by SHA on push events and only cancel in-progress runs for pull_request events. Back-to-back PR merges no longer cancel earlier main commits' test runs.

## Test plan
- [ ] Merge two PRs in quick succession; confirm both main runs complete instead of one being cancelled.