### PR TITLE
feat: add duration as library field + sortable column (#377)

### DIFF
--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -46,7 +46,7 @@ router = APIRouter()
 # unbounded ffmpeg conversions in parallel.
 _apply_rules_semaphore = asyncio.Semaphore(2)
 
-_SORT_BY_PATTERN = "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size)$"
+_SORT_BY_PATTERN = "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size|duration)$"
 
 
 def _row_value(row, key, default=None):

--- a/backend/core/services/cache_db.py
+++ b/backend/core/services/cache_db.py
@@ -61,8 +61,9 @@ _SORT_COLS: dict[str, str] = {
     "mtime": "mtime",
     "file_format": "file_format",
     "file_size": "file_size",
+    "duration": "duration",
 }
-_NULLABLE_SORT_COLS = {"bpm", "release_date", "release_year", "file_format", "file_size"}
+_NULLABLE_SORT_COLS = {"bpm", "release_date", "release_year", "file_format", "file_size", "duration"}
 
 # Columns matched by search_query LIKE clauses — derived from registry.
 _SEARCH_COLS: tuple[str, ...] = tuple(_REGISTRY_COL.get(f.name, f.name) for f in SIMPLE_TAG_FIELDS if f.searchable)

--- a/frontend/e2e/library-duration-column.spec.ts
+++ b/frontend/e2e/library-duration-column.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "./fixtures";
+
+const FILE_A = {
+  file_path: "alpha.flac",
+  file_name: "alpha.flac",
+  file_size: 20 * 1024 * 1024,
+  file_format: ".flac",
+  has_artwork: false,
+  title: "Alpha",
+  artist: "Alpha",
+  duration: 245,
+};
+
+const FILE_B = {
+  file_path: "bravo.mp3",
+  file_name: "bravo.mp3",
+  file_size: 5 * 1024 * 1024,
+  file_format: ".mp3",
+  has_artwork: false,
+  title: "Bravo",
+  artist: "Bravo",
+  duration: 65,
+};
+
+test.describe("Library Duration column", () => {
+  test.beforeEach(async ({ page }) => {
+    const handleBrowse = (route: import("@playwright/test").Route) => {
+      const url = new URL(route.request().url());
+      const sortBy = url.searchParams.get("sort_by");
+      const sortOrder = url.searchParams.get("sort_order") ?? "asc";
+      let items = [FILE_A, FILE_B];
+      if (sortBy === "duration") {
+        items = [...items].sort((a, b) => a.duration - b.duration);
+        if (sortOrder === "desc") items.reverse();
+      }
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items,
+          total: items.length,
+          page: 1,
+          size: 50,
+          pages: 1,
+        }),
+      });
+    };
+    await page.route("**/api/metadata/folders/*/browse*", handleBrowse);
+    await page.route(/\/api\/metadata\/folders\/browse-path\?/, handleBrowse);
+
+    await page.route(/filter-values/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          genres: [],
+          genre_counts: {},
+          artists: [],
+          keys: [],
+          key_counts: {},
+          bpm_min: null,
+          bpm_max: null,
+          file_formats: ["flac", "mp3"],
+          file_format_counts: { flac: 1, mp3: 1 },
+          file_size_min: 0,
+          file_size_max: 0,
+        }),
+      }),
+    );
+  });
+
+  test("renders M:SS values and sorts by duration", async ({ page }) => {
+    await page.goto("/library");
+    await expect(page.locator("[data-index]")).toHaveCount(2);
+
+    const header = page.getByRole("row").first();
+    await expect(header.getByText("Duration", { exact: true })).toBeVisible();
+
+    const cells = page.locator("[data-duration-cell]");
+    await expect(cells).toHaveCount(2);
+    // Default sort is mtime desc → server returns insertion order.
+    await expect(
+      page.locator('[data-index="0"] [data-duration-cell]'),
+    ).toHaveText("4:05");
+    await expect(
+      page.locator('[data-index="1"] [data-duration-cell]'),
+    ).toHaveText("1:05");
+
+    // Click Duration header → ascending by duration → bravo (1:05) first.
+    const sortRequest = page.waitForRequest((req) =>
+      req.url().includes("sort_by=duration"),
+    );
+    await header.locator("button", { hasText: "Duration" }).click();
+    await sortRequest;
+
+    await expect(
+      page.locator('[data-index="0"] [data-duration-cell]'),
+    ).toHaveText("1:05");
+    await expect(
+      page.locator('[data-index="1"] [data-duration-cell]'),
+    ).toHaveText("4:05");
+
+    // Toggle to descending → alpha first.
+    await header.locator("button", { hasText: "Duration" }).click();
+    await expect(
+      page.locator('[data-index="0"] [data-duration-cell]'),
+    ).toHaveText("4:05");
+  });
+});

--- a/frontend/src/app/library/utils.ts
+++ b/frontend/src/app/library/utils.ts
@@ -69,3 +69,14 @@ export function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
+
+/** Format a duration in seconds as M:SS or H:MM:SS. */
+export function formatDuration(seconds: number): string {
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0)
+    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/frontend/src/components/collection-table.tsx
+++ b/frontend/src/components/collection-table.tsx
@@ -20,7 +20,11 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { formatFileSize, serializeComment } from "@/app/library/utils";
+import {
+  formatDuration,
+  formatFileSize,
+  serializeComment,
+} from "@/app/library/utils";
 import {
   SortableColumnHeader,
   SortableHeaderCell,
@@ -98,7 +102,8 @@ type FieldKey =
   | "folder"
   | "soundcloud_linked"
   | "file_format"
-  | "file_size";
+  | "file_size"
+  | "duration";
 
 /** Fields shown in the table — editable or read-only. Order here is the
  * default render order; user reorders persist via the column-prefs store.
@@ -133,6 +138,7 @@ const COLUMN_FIELDS: {
   { key: "release_date", label: "Release", defaultWidth: 96, editable: true },
   { key: "file_format", label: "Format", defaultWidth: 64, editable: false },
   { key: "file_size", label: "Size", defaultWidth: 72, editable: false },
+  { key: "duration", label: "Duration", defaultWidth: 72, editable: false },
 ];
 
 type ResolvedField = (typeof COLUMN_FIELDS)[number] & { width: number };
@@ -152,6 +158,7 @@ export const FILESYSTEM_COLUMN_DEFS: import("@/lib/columns/types").ColumnDef[] =
     { id: "release_date", header: "Release" },
     { id: "file_format", header: "Format" },
     { id: "file_size", header: "Size" },
+    { id: "duration", header: "Duration" },
   ];
 
 /** Fields not stored in the API — remix composition helpers (not remixer itself, which is a real field) */
@@ -206,6 +213,7 @@ const SORTABLE_FIELDS: Partial<Record<FieldKey, SortBy>> = {
   release_date: "release_date",
   file_format: "file_format",
   file_size: "file_size",
+  duration: "duration",
 };
 
 function getMissingAttributes(
@@ -529,6 +537,19 @@ function EditRow({
               title={bytes ? `${bytes.toLocaleString()} bytes` : ""}
             >
               {bytes ? formatFileSize(bytes) : "—"}
+            </span>
+          );
+        }
+        if (f.key === "duration") {
+          const secs = item.duration ?? null;
+          return (
+            <span
+              key={f.key}
+              data-duration-cell
+              className="text-muted-foreground min-w-0 shrink-0 truncate text-right text-xs tabular-nums"
+              style={{ width: f.width }}
+            >
+              {secs != null ? formatDuration(secs) : "—"}
             </span>
           );
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -90,7 +90,8 @@ export interface BrowseParams {
     | "folder"
     | "mtime"
     | "file_format"
-    | "file_size";
+    | "file_size"
+    | "duration";
   sort_order?: "asc" | "desc";
 }
 

--- a/frontend/src/lib/search-params.ts
+++ b/frontend/src/lib/search-params.ts
@@ -14,6 +14,7 @@ export const SORT_FIELDS = [
   "mtime",
   "file_format",
   "file_size",
+  "duration",
 ] as const;
 export const SORT_ORDERS = ["asc", "desc"] as const;
 


### PR DESCRIPTION
Closes #377.

## Summary
- Duration was already extracted via mutagen and persisted in the cache DB, but it wasn't sortable or shown in the library table.
- Backend: register `duration` in the cache_db sort column registry (nullable) and add it to the `sort_by` validation pattern.
- Frontend: render a Duration column (M:SS formatting) in the collection table, register it in `FILESYSTEM_COLUMN_DEFS`, `SORTABLE_FIELDS`, the URL sort literals, and the `BrowseParams.sort_by` union.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] New Playwright spec: `e2e/library-duration-column.spec.ts` (rendering + sort)
- [ ] Manual: open `/library`, confirm Duration column appears and sorts asc/desc