### PR TITLE
fix(rekordbox): USB player waveform + waveform-style setting

### DIFF
--- a/backend/api/rekordbox.py
+++ b/backend/api/rekordbox.py
@@ -152,14 +152,25 @@ def get_track_artwork(track_id: str, small: bool = True, device: str | None = De
 
 
 @router.get("/tracks/{track_id}/waveform")
-def get_track_waveform(track_id: str, device: str | None = DeviceParam) -> Response:
-    """Serve the raw PWV4 color preview entries (7200 bytes: 1200 x 6).
+def get_track_waveform(
+    track_id: str,
+    device: str | None = DeviceParam,
+    variant: str = Query("color", pattern="^(color|blue)$"),
+) -> Response:
+    """Serve a track's raw ANLZ preview waveform bytes.
 
-    The frontend decodes the byte stream onto a small canvas to render an inline
-    RGB waveform matching what Rekordbox shows in its track list.
+    ``variant=color`` (default) returns the PWV4 colour preview (7200 bytes:
+    1200 x 6). ``variant=blue`` returns the PWAV monochrome preview (400 bytes:
+    400 x 1, 5-bit height + 3-bit whiteness). The frontend decodes the byte
+    stream onto a canvas to render the waveform.
     """
+    source = rb_service.get_source(device)
     try:
-        data = rb_service.get_source(device).get_track_waveform_preview(track_id)
+        data = (
+            source.get_track_waveform_blue(track_id)
+            if variant == "blue"
+            else source.get_track_waveform_preview(track_id)
+        )
     except rb_service.RekordboxUnavailable as exc:
         raise _unavailable(str(exc)) from exc
     if data is None:

--- a/backend/core/services/rekordbox/base.py
+++ b/backend/core/services/rekordbox/base.py
@@ -98,6 +98,10 @@ class RekordboxSource(ABC):
     def get_track_waveform_preview(self, track_id: str) -> bytes | None:
         """Return the raw PWV4 color-preview entry bytes, or ``None``."""
 
+    @abstractmethod
+    def get_track_waveform_blue(self, track_id: str) -> bytes | None:
+        """Return the raw PWAV monochrome-preview entry bytes, or ``None``."""
+
 
 def extract_soundcloud_id(comment: str | None) -> int | None:
     """Extract a SoundCloud track id stored in the track comment.
@@ -179,5 +183,61 @@ def read_pwv4(path: str, mtime_ns: int) -> bytes | None:
     """
     try:
         return extract_pwv4(Path(path).read_bytes())
+    except OSError:
+        return None
+
+
+def extract_pwav(data: bytes) -> bytes | None:
+    """Extract the PWAV entry bytes from raw ANLZ file contents.
+
+    PWAV is the classic monochrome ("blue") preview waveform, stored in the
+    ``.DAT`` file (unlike the colour PWV4/PWV5, which live in ``.EXT``). It is
+    400 single-byte columns; each byte packs a 5-bit height (low bits, 0-31)
+    and a 3-bit whiteness (high bits, 0-7). Layout after the section header
+    (fourcc + len_header + len_tag, all big-endian u32): len_preview + unknown +
+    entries.
+
+    Args:
+        data: Full contents of an ANLZ ``.DAT`` file.
+
+    Returns:
+        The raw entry bytes (``len_preview`` of them, normally 400), or ``None``
+        if no PWAV section exists or the file is malformed.
+    """
+    if len(data) < 8 or data[:4] != b"PMAI":
+        return None
+    pos = int.from_bytes(data[4:8], "big")
+    while pos + 12 <= len(data):
+        fourcc = data[pos : pos + 4]
+        len_tag = int.from_bytes(data[pos + 8 : pos + 12], "big")
+        if len_tag <= 0:
+            return None
+        if fourcc == b"PWAV":
+            if pos + 20 > len(data):
+                return None
+            len_preview = int.from_bytes(data[pos + 12 : pos + 16], "big")
+            start = pos + 20
+            end = start + len_preview
+            if len_preview <= 0 or end > len(data):
+                return None
+            return data[start:end]
+        pos += len_tag
+    return None
+
+
+@lru_cache(maxsize=1024)
+def read_pwav(path: str, mtime_ns: int) -> bytes | None:
+    """Read and extract PWAV bytes from an ANLZ ``.DAT`` file, cached.
+
+    Args:
+        path: Absolute path to the ``.DAT`` ANLZ file.
+        mtime_ns: File modification time; part of the cache key so re-analysis
+            invalidates the entry.
+
+    Returns:
+        The raw PWAV entry bytes, or ``None`` if absent/unreadable.
+    """
+    try:
+        return extract_pwav(Path(path).read_bytes())
     except OSError:
         return None

--- a/backend/core/services/rekordbox/local.py
+++ b/backend/core/services/rekordbox/local.py
@@ -20,6 +20,7 @@ from .base import (
     RekordboxTrack,
     RekordboxUnavailable,
     extract_soundcloud_id,
+    read_pwav,
     read_pwv4,
 )
 
@@ -213,6 +214,26 @@ class LocalMasterDbSource(RekordboxSource):
         except OSError:
             return None
         return read_pwv4(str(ext), mtime_ns)
+
+    def get_track_waveform_blue(self, track_id: str) -> bytes | None:
+        """Return the raw PWAV monochrome preview bytes (400 x 1 byte).
+
+        Each byte packs a 5-bit height (low) and 3-bit whiteness (high). The
+        PWAV tag lives in the ``.DAT`` ANLZ file (colour PWV4 is in ``.EXT``).
+        """
+        db = self._open_db()
+        row = db.get_content(ID=track_id)
+        if row is None:
+            return None
+        rel = getattr(row, "AnalysisDataPath", None)
+        if not rel:
+            return None
+        dat = self._resolve_relative(str(rel)).with_suffix(".DAT")
+        try:
+            mtime_ns = dat.stat().st_mtime_ns
+        except OSError:
+            return None
+        return read_pwav(str(dat), mtime_ns)
 
     def list_all_tracks(self, limit: int | None = None) -> list[RekordboxTrack]:
         """Return all tracks in the collection."""

--- a/backend/core/services/rekordbox/usb.py
+++ b/backend/core/services/rekordbox/usb.py
@@ -28,6 +28,7 @@ from .base import (
     RekordboxTrack,
     RekordboxUnavailable,
     extract_soundcloud_id,
+    read_pwav,
     read_pwv4,
 )
 
@@ -243,3 +244,22 @@ class UsbExportSource(RekordboxSource):
         except OSError:
             return None
         return read_pwv4(str(ext), mtime_ns)
+
+    def get_track_waveform_blue(self, track_id: str) -> bytes | None:
+        """Return the raw PWAV monochrome preview bytes for a track, or ``None``.
+
+        The PWAV tag lives in the ``.DAT`` ANLZ file referenced by
+        ``analysisDataFilePath`` (the colour PWV4 is in the ``.EXT`` sidecar).
+        """
+        rows = self._query("SELECT analysisDataFilePath FROM content WHERE content_id = ?", (track_id,))
+        if not rows:
+            return None
+        rel = _clean(rows[0]["analysisDataFilePath"])
+        if not rel:
+            return None
+        dat = self._resolve(rel).with_suffix(".DAT")
+        try:
+            mtime_ns = dat.stat().st_mtime_ns
+        except OSError:
+            return None
+        return read_pwav(str(dat), mtime_ns)

--- a/frontend/e2e/library-rekordbox-usb.spec.ts
+++ b/frontend/e2e/library-rekordbox-usb.spec.ts
@@ -141,6 +141,58 @@ test.describe("Library: Rekordbox USB export", () => {
       .toMatch(/\/api\/rekordbox\/tracks\/u-1\/audio\?device=/);
   });
 
+  test("waveform-style setting switches the player to the Rekordbox coloured waveform", async ({
+    page,
+  }) => {
+    const waveformVariants: string[] = [];
+    await mockLibrary(page);
+    await page.route(
+      /\/api\/rekordbox\/usb\/devices/,
+      jsonRoute({ devices: [DEVICE] }),
+    );
+    await page.route(/\/api\/rekordbox\/tracks\/[^/]+\/audio/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        body: makeSilentWav(),
+      }),
+    );
+    // Re-route waveform to record the requested variant (color | blue).
+    await page.route(/\/api\/rekordbox\/tracks\/[^/]+\/waveform/, (route) => {
+      const v =
+        new URL(route.request().url()).searchParams.get("variant") ?? "color";
+      waveformVariants.push(v);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/octet-stream",
+        body: WAVEFORM_BYTES,
+      });
+    });
+
+    await page.goto("/library?source=rekordbox");
+    await selectDevice(page);
+    await page.getByText("USB Set").click();
+    const tracks = page.getByTestId("rekordbox-tracks");
+    await tracks.getByRole("button", { name: "Play On The Stick" }).click();
+    await expect(page.getByTestId("waveform-player")).toBeVisible();
+
+    // Default style: the Starlib (WaveSurfer) waveform, no Rekordbox overlay.
+    await expect(page.getByTestId("player-rekordbox-waveform")).toHaveCount(0);
+
+    // Switch to Rekordbox Blue via Settings → Library.
+    await page.locator('button[aria-label="Settings"]').click();
+    const dialog = page.locator('[data-slot="dialog-content"]');
+    await dialog.getByText("Library", { exact: true }).click();
+    await dialog.getByRole("radio", { name: "Rekordbox Blue" }).click();
+    await page.keyboard.press("Escape");
+
+    // The coloured overlay renders and the blue PWAV variant is fetched.
+    const overlay = page.getByTestId("player-rekordbox-waveform");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toHaveAttribute("data-variant", "blue");
+    await expect.poll(() => waveformVariants).toContain("blue");
+  });
+
   test("eject button unmounts the device and returns to the local install", async ({
     page,
   }) => {

--- a/frontend/src/components/player-rekordbox-waveform.tsx
+++ b/frontend/src/components/player-rekordbox-waveform.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  loadWaveform,
+  type WaveformVariant,
+} from "@/components/rekordbox-waveform";
+import { usePlayer } from "@/lib/player-context";
+import { cn } from "@/lib/utils";
+
+interface PlayerRekordboxWaveformProps {
+  trackId: string;
+  device?: string;
+  /** `"color"` renders the PWV4 RGB preview; `"blue"` the PWAV monochrome one. */
+  variant: WaveformVariant;
+  /** Track length in seconds, for the hover time label. */
+  durationSec: number;
+  className?: string;
+}
+
+const COLOR_COLS = 1200; // PWV4 columns (6 bytes each)
+const BLUE_COLS = 400; // PWAV columns (1 byte each)
+
+function formatTime(s: number): string {
+  if (!isFinite(s) || s < 0) return "0:00";
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Full-width Rekordbox waveform for the bottom player, drawn from Rekordbox's
+ * own PWV4 (RGB) or PWAV (blue) analysis. Layered over the WaveSurfer container
+ * (which stays mounted, invisible, to keep driving audio) and owns its own
+ * click-to-seek, played overlay, and hover cursor + time label.
+ */
+export function PlayerRekordboxWaveform({
+  trackId,
+  device,
+  variant,
+  durationSec,
+  className,
+}: PlayerRekordboxWaveformProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [data, setData] = useState<Uint8Array | null>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  const { subscribeProgress, seek } = usePlayer();
+  const progressRef = useRef(0);
+  const hoverXRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadWaveform(trackId, device, variant).then((d) => {
+      if (!cancelled) setData(d);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [trackId, device, variant]);
+
+  // Track the wrapper's pixel box so the canvas fills the fluid player width.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (r) setSize({ w: Math.round(r.width), h: Math.round(r.height) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const draw = useCallback(
+    (progress: number, hoverX: number | null) => {
+      const canvas = canvasRef.current;
+      const { w: cssW, h: cssH } = size;
+      if (!canvas || cssW === 0 || cssH === 0) return;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, cssW, cssH);
+
+      const mid = cssH / 2;
+      const halfH = cssH / 2;
+      const cols = variant === "color" ? COLOR_COLS : BLUE_COLS;
+      const stride = variant === "color" ? 6 : 1;
+
+      if (data && data.length >= cols * stride) {
+        const step = cols / cssW;
+        for (let x = 0; x < cssW; x++) {
+          const start = Math.floor(x * step);
+          const end = Math.max(start + 1, Math.floor((x + 1) * step));
+          let r = 0,
+            g = 0,
+            b = 0,
+            h = 0,
+            n = 0;
+          for (let i = start; i < end && i < cols; i++) {
+            const o = i * stride;
+            if (variant === "color") {
+              const d3 = data[o + 3] & 0x7f;
+              const d4 = data[o + 4] & 0x7f;
+              const d5 = data[o + 5] & 0x7f;
+              r += (d3 / 127) * 255;
+              g += (d4 / 127) * 255;
+              b += (d5 / 127) * 255;
+              h += Math.max(d3, d4, d5) / 127;
+            } else {
+              const height = (data[o] & 0x1f) / 31;
+              const white = ((data[o] >> 5) & 0x07) / 7;
+              // Rekordbox blue: dim blue silhouette brightening toward cyan-white
+              // where the whiteness bits are set.
+              r += 40 + white * 150;
+              g += 120 + white * 110;
+              b += 220 + white * 35;
+              h += height;
+            }
+            n++;
+          }
+          if (n === 0) continue;
+          const norm = h / n; // 0..1
+          const barH = Math.max(1, Math.round(norm * halfH));
+          ctx.fillStyle = `rgb(${(r / n) | 0}, ${(g / n) | 0}, ${(b / n) | 0})`;
+          ctx.fillRect(x, mid - barH, 1, barH * 2);
+        }
+      }
+
+      // Played overlay up to the current position.
+      if (progress > 0) {
+        const playedX = Math.round(progress * cssW);
+        ctx.save();
+        ctx.globalCompositeOperation = "source-atop";
+        ctx.fillStyle = "rgba(255, 255, 255, 0.4)";
+        ctx.fillRect(0, 0, playedX, cssH);
+        ctx.restore();
+      }
+
+      // Hover cursor + time label.
+      if (hoverX !== null) {
+        const isDark = document.documentElement.classList.contains("dark");
+        ctx.save();
+        ctx.strokeStyle = isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.4)";
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(hoverX + 0.5, 0);
+        ctx.lineTo(hoverX + 0.5, cssH);
+        ctx.stroke();
+        const label = formatTime((hoverX / cssW) * durationSec);
+        ctx.font = "9px ui-sans-serif, system-ui, sans-serif";
+        const tw = ctx.measureText(label).width + 6;
+        const preferLeft = hoverX > cssW - tw - 2;
+        const bx = preferLeft ? hoverX - tw - 2 : hoverX + 2;
+        ctx.fillStyle = isDark
+          ? "rgba(12,16,25,0.82)"
+          : "rgba(255,255,255,0.82)";
+        ctx.fillRect(bx, 1, tw, 12);
+        ctx.fillStyle = isDark
+          ? "rgba(184,188,198,0.95)"
+          : "rgba(51,51,51,0.9)";
+        ctx.textBaseline = "top";
+        ctx.fillText(label, bx + 3, 2);
+        ctx.restore();
+      }
+    },
+    [data, size, variant, durationSec],
+  );
+
+  // Redraw on data/size/variant change and subscribe to live progress.
+  useEffect(() => {
+    draw(progressRef.current, hoverXRef.current);
+    return subscribeProgress((p) => {
+      progressRef.current = p;
+      draw(p, hoverXRef.current);
+    });
+  }, [draw, subscribeProgress]);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      hoverXRef.current = e.clientX - rect.left;
+      draw(progressRef.current, hoverXRef.current);
+    },
+    [draw],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverXRef.current === null) return;
+    hoverXRef.current = null;
+    draw(progressRef.current, null);
+  }, [draw]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const frac = Math.max(
+        0,
+        Math.min(1, (e.clientX - rect.left) / rect.width),
+      );
+      seek(frac);
+    },
+    [seek],
+  );
+
+  return (
+    <div ref={wrapRef} className={cn("size-full", className)}>
+      <canvas
+        ref={canvasRef}
+        className="block size-full cursor-pointer"
+        onClick={handleClick}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        aria-hidden
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/rekordbox-waveform.tsx
+++ b/frontend/src/components/rekordbox-waveform.tsx
@@ -36,21 +36,32 @@ const SOURCE_COLS = 1200;
 const cache = new Map<string, Uint8Array | null>();
 const inflight = new Map<string, Promise<Uint8Array | null>>();
 
-function cacheKey(trackId: string, device?: string): string {
-  return device ? `${device}:${trackId}` : trackId;
+/** Waveform byte variant: PWV4 colour preview or PWAV monochrome preview. */
+export type WaveformVariant = "color" | "blue";
+
+function cacheKey(
+  trackId: string,
+  device: string | undefined,
+  variant: WaveformVariant,
+): string {
+  const base = device ? `${device}:${trackId}` : trackId;
+  return variant === "color" ? base : `${variant}:${base}`;
 }
 
 export async function loadWaveform(
   trackId: string,
   device?: string,
+  variant: WaveformVariant = "color",
 ): Promise<Uint8Array | null> {
-  const key = cacheKey(trackId, device);
+  const key = cacheKey(trackId, device, variant);
   if (cache.has(key)) return cache.get(key) ?? null;
   let p = inflight.get(key);
   if (!p) {
     p = (async () => {
       try {
-        const res = await fetch(api.getRekordboxWaveformUrl(trackId, device));
+        const res = await fetch(
+          api.getRekordboxWaveformUrl(trackId, device, variant),
+        );
         if (!res.ok) return null;
         const buf = await res.arrayBuffer();
         return new Uint8Array(buf);

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -51,9 +51,10 @@ import {
   type Ruleset,
 } from "@/lib/api";
 import { onRulesetsChanged } from "@/lib/rulesets-events";
-import { getSetting, setSetting } from "@/lib/settings";
+import { getSetting, setSetting, type WaveformStyle } from "@/lib/settings";
 import { isTauri } from "@/lib/tauri";
 import { checkForUpdate, type UpdateResult } from "@/lib/updater";
+import { saveWaveformStyle } from "@/lib/use-waveform-style";
 import { cn } from "@/lib/utils";
 
 type SectionId =
@@ -114,6 +115,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [preferredOutputFormat, setPreferredOutputFormat] = useState<
     "aiff" | "mp3"
   >("aiff");
+  const [waveformStyle, setWaveformStyleState] =
+    useState<WaveformStyle>("starlib");
   const [loaded, setLoaded] = useState(false);
   const [checking, setChecking] = useState(false);
   const [updateResult, setUpdateResult] = useState<UpdateResult | null>(null);
@@ -169,6 +172,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     Promise.all([
       getSetting("autoUpdate"),
       getSetting("preferredOutputFormat"),
+      getSetting("waveformStyle"),
       api.getRootMusicFolder(),
       api.getAiSettings(),
       api.getAiStatus(),
@@ -178,6 +182,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       ([
         autoUpdate,
         outputFormat,
+        waveform,
         rootPath,
         settings,
         status,
@@ -186,6 +191,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       ]) => {
         setAutoUpdate(autoUpdate);
         setPreferredOutputFormat(outputFormat);
+        setWaveformStyleState(waveform);
         setRootFolder(rootPath);
         setRootFolderDraft(rootPath);
         setAiSettings(settings);
@@ -225,6 +231,11 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     window.dispatchEvent(
       new CustomEvent("preferred-format-changed", { detail: format }),
     );
+  }
+
+  async function handleWaveformStyleChange(style: WaveformStyle) {
+    setWaveformStyleState(style);
+    await saveWaveformStyle(style);
   }
 
   async function handleSaveRootFolder() {
@@ -463,6 +474,32 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </ToggleGroupItem>
                     <ToggleGroupItem value="mp3" className="font-mono">
                       MP3
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <Label className="text-sm">Rekordbox waveform</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Which waveform the player shows for Rekordbox tracks.
+                    Rekordbox styles use its own analysis; other sources always
+                    use the Starlib waveform.
+                  </p>
+                  <ToggleGroup
+                    type="single"
+                    variant="outline"
+                    value={waveformStyle}
+                    onValueChange={(val) => {
+                      if (val) handleWaveformStyleChange(val as WaveformStyle);
+                    }}
+                    className="w-fit"
+                  >
+                    <ToggleGroupItem value="starlib">Starlib</ToggleGroupItem>
+                    <ToggleGroupItem value="rekordbox_rgb">
+                      Rekordbox RGB
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="rekordbox_blue">
+                      Rekordbox Blue
                     </ToggleGroupItem>
                   </ToggleGroup>
                 </div>

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -7,9 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import type WaveSurferType from "wavesurfer.js";
 
 import { BpmPitcher, computePlaybackRate } from "@/components/bpm-pitcher";
+import { PlayerRekordboxWaveform } from "@/components/player-rekordbox-waveform";
 import { loadWaveform, pwv4ToPeaks } from "@/components/rekordbox-waveform";
 import { api } from "@/lib/api";
 import { usePlayer } from "@/lib/player-context";
+import { selectPeaksSource } from "@/lib/player-peaks";
 import { markScUnplayable } from "@/lib/sc-unplayable";
 import {
   getCachedSoundcloudPeaks,
@@ -17,6 +19,7 @@ import {
   invalidateSoundcloudStreamUrl,
 } from "@/lib/soundcloud-cache";
 import { useResizableWidth } from "@/lib/use-resizable";
+import { useWaveformStyle } from "@/lib/use-waveform-style";
 import { cn } from "@/lib/utils";
 
 /** Heuristic: URL is an HLS playlist (by extension). */
@@ -93,6 +96,7 @@ export function WaveformPlayer() {
   const [expanded, setExpanded] = useState(false);
 
   const treeWidth = useResizableWidth("tree-panel-width", 240);
+  const waveformStyle = useWaveformStyle();
 
   useEffect(() => {
     isPlayingRef.current = isPlaying;
@@ -226,12 +230,6 @@ export function WaveformPlayer() {
       // gaps between bars.
       const numPeaks = 2000;
 
-      // Skeleton SoundCloud entries from the queue have no `streamUrl` yet —
-      // `streamRefreshKey` is the durable marker that this is a SC track.
-      const isStream =
-        !!currentTrack!.streamUrl ||
-        currentTrack!.streamRefreshKey !== undefined;
-
       // Kick off all network-bound work in parallel:
       //   - WaveSurfer module imports (cached after first track)
       //   - peaks fetch (backend or SC CDN)
@@ -242,24 +240,29 @@ export function WaveformPlayer() {
       const wsImportPromise = import("wavesurfer.js");
       const hoverImportPromise =
         import("wavesurfer.js/dist/plugins/hover.esm.js");
-      const peaksPromise: Promise<number[]> = isStream
-        ? currentTrack!.waveformUrl
-          ? getCachedSoundcloudPeaks(currentTrack!.waveformUrl, numPeaks).then(
-              (p) => p ?? new Array<number>(numPeaks).fill(0.5),
-            )
-          : Promise.resolve(new Array<number>(numPeaks).fill(0.5))
-        : currentTrack!.rekordboxId
+      const peaksSource = selectPeaksSource(currentTrack!);
+      const peaksPromise: Promise<number[]> =
+        peaksSource.kind === "rekordbox"
           ? // Rekordbox already analyzed this track — its PWV4 preview is a
             // ~2ms fetch vs an ~1s ffmpeg decode for backend peaks.
-            loadWaveform(
-              currentTrack!.rekordboxId,
-              currentTrack!.rekordboxDevice,
-            ).then((data) =>
+            loadWaveform(peaksSource.id, peaksSource.device).then((data) =>
               data
                 ? pwv4ToPeaks(data)
-                : api.getFilePeaks(currentTrack!.filePath, numPeaks),
+                : // No PWV4 for this track: local-install tracks resolve to a
+                  // real file we can decode; USB tracks live off-root, so fall
+                  // back to a flat placeholder rather than a doomed ffmpeg call.
+                  peaksSource.device
+                  ? new Array<number>(numPeaks).fill(0.5)
+                  : api.getFilePeaks(currentTrack!.filePath, numPeaks),
             )
-          : api.getFilePeaks(currentTrack!.filePath, numPeaks);
+          : peaksSource.kind === "soundcloud"
+            ? peaksSource.waveformUrl
+              ? getCachedSoundcloudPeaks(
+                  peaksSource.waveformUrl,
+                  numPeaks,
+                ).then((p) => p ?? new Array<number>(numPeaks).fill(0.5))
+              : Promise.resolve(new Array<number>(numPeaks).fill(0.5))
+            : api.getFilePeaks(currentTrack!.filePath, numPeaks);
       const streamUrlPromise: Promise<string | undefined> = currentTrack!
         .streamUrl
         ? Promise.resolve(currentTrack!.streamUrl)
@@ -642,6 +645,14 @@ export function WaveformPlayer() {
   const artistText = currentTrack.artist ?? "";
   const loadingProgress = duration > 0 ? currentTime / duration : 0;
 
+  // Colour the bottom waveform with Rekordbox's own analysis when the user
+  // picked a Rekordbox style and the current track carries one. Non-Rekordbox
+  // sources always fall through to the default WaveSurfer render.
+  const rekColored =
+    !!currentTrack.rekordboxId &&
+    (waveformStyle === "rekordbox_rgb" || waveformStyle === "rekordbox_blue");
+  const rekVariant = waveformStyle === "rekordbox_blue" ? "blue" : "color";
+
   const morphTransition = {
     type: "spring" as const,
     stiffness: 380,
@@ -910,9 +921,27 @@ export function WaveformPlayer() {
             <div className="relative flex min-w-0 flex-1 items-center px-3">
               <div
                 ref={containerRef}
-                className="min-w-0 flex-1"
+                className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
                 style={{ cursor: "pointer" }}
               />
+              {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
+                  to keep driving audio + progress; this canvas paints the
+                  coloured waveform and owns seek/hover. */}
+              {rekColored && currentTrack.rekordboxId && (
+                <div
+                  data-testid="player-rekordbox-waveform"
+                  data-variant={rekVariant}
+                  className="absolute inset-y-0 right-3 left-3 flex items-center"
+                >
+                  <PlayerRekordboxWaveform
+                    trackId={currentTrack.rekordboxId}
+                    device={currentTrack.rekordboxDevice}
+                    variant={rekVariant}
+                    durationSec={duration}
+                    className="h-8"
+                  />
+                </div>
+              )}
               {/* Loading-state fallback progress — fades out once waveform is ready. */}
               <div
                 className={cn(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -438,9 +438,16 @@ export const api = {
   },
 
   // Rekordbox PWV4 color preview entries (raw 1200 × 6 bytes)
-  getRekordboxWaveformUrl(trackId: string, device?: string): string {
-    const q = device ? `?device=${encodeURIComponent(device)}` : "";
-    return `${API_BASE_URL}/api/rekordbox/tracks/${encodeURIComponent(trackId)}/waveform${q}`;
+  getRekordboxWaveformUrl(
+    trackId: string,
+    device?: string,
+    variant: "color" | "blue" = "color",
+  ): string {
+    const params = new URLSearchParams();
+    if (device) params.set("device", device);
+    if (variant !== "color") params.set("variant", variant);
+    const q = params.toString();
+    return `${API_BASE_URL}/api/rekordbox/tracks/${encodeURIComponent(trackId)}/waveform${q ? `?${q}` : ""}`;
   },
 
   // Audio stream for a track on a mounted USB export.

--- a/frontend/src/lib/player-peaks.test.ts
+++ b/frontend/src/lib/player-peaks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlayerTrack } from "@/lib/player-context";
+import { selectPeaksSource } from "@/lib/player-peaks";
+
+function track(overrides: Partial<PlayerTrack>): PlayerTrack {
+  return { filePath: "/x.mp3", fileName: "x.mp3", ...overrides };
+}
+
+describe("selectPeaksSource", () => {
+  it("uses Rekordbox PWV4 for a USB export track even though it has a streamUrl", () => {
+    // Regression: USB tracks set `streamUrl` (device audio endpoint) *and*
+    // `rekordboxId`. The old `isStream`-first ordering routed them to the
+    // SoundCloud branch → flat placeholder. Analysis must win.
+    const src = selectPeaksSource(
+      track({
+        rekordboxId: "u-1",
+        rekordboxDevice: "/Volumes/USB",
+        streamUrl: "/api/rekordbox/tracks/u-1/audio?device=/Volumes/USB",
+      }),
+    );
+    expect(src).toEqual({
+      kind: "rekordbox",
+      id: "u-1",
+      device: "/Volumes/USB",
+    });
+  });
+
+  it("uses Rekordbox PWV4 for a local-install track (no device)", () => {
+    const src = selectPeaksSource(track({ rekordboxId: "l-1" }));
+    expect(src).toEqual({ kind: "rekordbox", id: "l-1", device: undefined });
+  });
+
+  it("uses the SoundCloud branch for a stream track with a waveform URL", () => {
+    const src = selectPeaksSource(
+      track({ streamRefreshKey: 42, waveformUrl: "https://cdn/wave.png" }),
+    );
+    expect(src).toEqual({
+      kind: "soundcloud",
+      waveformUrl: "https://cdn/wave.png",
+    });
+  });
+
+  it("uses the file (ffmpeg) branch for a plain local file", () => {
+    const src = selectPeaksSource(track({}));
+    expect(src).toEqual({ kind: "file" });
+  });
+});

--- a/frontend/src/lib/player-peaks.ts
+++ b/frontend/src/lib/player-peaks.ts
@@ -1,0 +1,31 @@
+import type { PlayerTrack } from "@/lib/player-context";
+
+/** Which analysis source the player derives its waveform peaks from. */
+export type PeaksSource =
+  | { kind: "rekordbox"; id: string; device?: string }
+  | { kind: "soundcloud"; waveformUrl?: string }
+  | { kind: "file" };
+
+/**
+ * Pick the peaks source for a track.
+ *
+ * Rekordbox analysis (PWV4) wins whenever a track carries a `rekordboxId`. USB
+ * export tracks also set `streamUrl` to route *audio* through the device
+ * endpoint, so keying the peaks decision off `streamUrl`/`isStream` first would
+ * misroute them into the SoundCloud branch — which, lacking a `waveformUrl`,
+ * falls back to a flat placeholder and renders a peakless waveform. Checking
+ * `rekordboxId` before the stream heuristic keeps that from happening while
+ * leaving audio routing (which still uses `streamUrl`) untouched.
+ */
+export function selectPeaksSource(track: PlayerTrack): PeaksSource {
+  if (track.rekordboxId) {
+    return {
+      kind: "rekordbox",
+      id: track.rekordboxId,
+      device: track.rekordboxDevice,
+    };
+  }
+  const isStream = !!track.streamUrl || track.streamRefreshKey !== undefined;
+  if (isStream) return { kind: "soundcloud", waveformUrl: track.waveformUrl };
+  return { kind: "file" };
+}

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -6,14 +6,19 @@
 
 import { isTauri } from "./tauri";
 
+/** Which waveform the bottom player renders for Rekordbox tracks. */
+export type WaveformStyle = "starlib" | "rekordbox_rgb" | "rekordbox_blue";
+
 export interface Settings {
   autoUpdate: boolean;
   preferredOutputFormat: "aiff" | "mp3";
+  waveformStyle: WaveformStyle;
 }
 
 const DEFAULTS: Settings = {
   autoUpdate: true,
   preferredOutputFormat: "aiff",
+  waveformStyle: "starlib",
 };
 
 const STORAGE_KEY = "starlib_settings";

--- a/frontend/src/lib/use-waveform-style.ts
+++ b/frontend/src/lib/use-waveform-style.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getSetting, setSetting, type WaveformStyle } from "@/lib/settings";
+
+/** Dispatched on `window` when the waveform style changes, for live sync
+ * across the settings dialog and every mounted player/waveform. */
+export const WAVEFORM_STYLE_EVENT = "waveform-style-changed";
+
+/** Persist a new waveform style and notify listeners in the same tab. */
+export async function saveWaveformStyle(style: WaveformStyle): Promise<void> {
+  await setSetting("waveformStyle", style);
+  window.dispatchEvent(
+    new CustomEvent<WaveformStyle>(WAVEFORM_STYLE_EVENT, { detail: style }),
+  );
+}
+
+/**
+ * Read the current waveform style, kept in sync via {@link WAVEFORM_STYLE_EVENT}.
+ * Returns the default (`"starlib"`) until the async store load resolves.
+ */
+export function useWaveformStyle(): WaveformStyle {
+  const [style, setStyle] = useState<WaveformStyle>("starlib");
+
+  useEffect(() => {
+    let cancelled = false;
+    getSetting("waveformStyle")
+      .then((s) => {
+        if (!cancelled) setStyle(s);
+      })
+      .catch(() => {});
+    const onChange = (e: Event) => {
+      setStyle((e as CustomEvent<WaveformStyle>).detail);
+    };
+    window.addEventListener(WAVEFORM_STYLE_EVENT, onChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(WAVEFORM_STYLE_EVENT, onChange);
+    };
+  }, []);
+
+  return style;
+}

--- a/tests/test_rekordbox_usb.py
+++ b/tests/test_rekordbox_usb.py
@@ -45,6 +45,13 @@ def _anlz_ext_with_pwv4(entries: bytes) -> bytes:
     return header + tag
 
 
+def _anlz_dat_with_pwav(entries: bytes) -> bytes:
+    """Build a minimal ANLZ ``.DAT`` payload carrying one PWAV tag."""
+    tag = b"PWAV" + struct.pack(">III", 20, 20 + len(entries), len(entries)) + struct.pack(">I", 0) + entries
+    header = b"PMAI" + struct.pack(">II", 16, 16 + len(tag)) + struct.pack(">I", 0)
+    return header + tag
+
+
 @pytest.fixture
 def device(tmp_path: Path) -> Path:
     """Create a temp USB tree with an encrypted exportLibrary.db + assets."""
@@ -61,6 +68,8 @@ def device(tmp_path: Path) -> Path:
     anlz_dir.mkdir(parents=True)
     pwv4 = bytes(range(12))  # 2 entries x 6 bytes
     (anlz_dir / "ANLZ0000.EXT").write_bytes(_anlz_ext_with_pwv4(pwv4))
+    pwav = bytes(range(8))  # 8 single-byte columns
+    (anlz_dir / "ANLZ0000.DAT").write_bytes(_anlz_dat_with_pwav(pwav))
 
     # The audio file track 10 points at.
     audio_dir = root / "Contents" / "BoC" / "Music"
@@ -192,6 +201,8 @@ def test_artwork_and_waveform_bytes(device: Path) -> None:
     assert src.get_track_artwork("11") is None  # no image
     assert src.get_track_waveform_preview("10") == bytes(range(12))
     assert src.get_track_waveform_preview("11") is None  # no analysis path
+    assert src.get_track_waveform_blue("10") == bytes(range(8))
+    assert src.get_track_waveform_blue("11") is None  # no analysis path
 
 
 def test_audio_path_resolves_within_device(device: Path) -> None:


### PR DESCRIPTION
USB tracks carry a \`streamUrl\`, so the player's peaks logic routed them into the SoundCloud branch and rendered a flat waveform; now Rekordbox PWV4 analysis wins whenever a track has a \`rekordboxId\`.
Adds a **Settings → Library → Rekordbox waveform** picker so the bottom player renders as Starlib, Rekordbox RGB (PWV4), or Rekordbox Blue (PWAV, new backend parsing + \`?variant=\` endpoint).
Setting is player-only; row waveforms stay RGB.

**Test plan:** \`vitest\` (selectPeaksSource), \`pytest\` (PWAV extraction), and a Playwright spec driving Settings → Rekordbox Blue → asserting the coloured overlay + blue variant fetch; validated end-to-end against a real USB export.