### PR TITLE
fix(settings): stop UI store and backend sharing settings.json (#515)

### DIFF
--- a/backend/core/services/settings.py
+++ b/backend/core/services/settings.py
@@ -163,13 +163,19 @@ def load() -> Settings:
 
 
 def save(settings: Settings) -> Settings:
-    """Atomically persist settings to disk and return them."""
+    """Atomically persist settings to disk and return them.
+
+    Writes to a temp file in the same directory and ``os.replace``s it over the
+    target so a crash or concurrent write can never leave a truncated file.
+    """
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    _SETTINGS_FILE.write_text(settings.model_dump_json(indent=2))
+    tmp = _SETTINGS_FILE.with_name(f"{_SETTINGS_FILE.name}.{os.getpid()}.tmp")
+    tmp.write_text(settings.model_dump_json(indent=2))
     try:
-        os.chmod(_SETTINGS_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600 — owner-only
+        os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)  # 0o600 — owner-only
     except OSError:
         pass
+    os.replace(tmp, _SETTINGS_FILE)
     return settings
 
 

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -97,6 +97,25 @@ async function mockBackendApi(page: Page) {
     }),
   );
 
+  // App settings + root folder (needed when the settings dialog loads)
+  await page.route(/\/api\/settings$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        preferred_output_format: "aiff",
+        root_music_folder: "/music",
+      }),
+    }),
+  );
+  await page.route(/\/api\/settings\/root-folder$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+
   // AI settings (needed to avoid errors when settings dialog loads)
   await page.route("**/api/ai/settings", (route) =>
     route.fulfill({

--- a/frontend/e2e/settings-output-format.spec.ts
+++ b/frontend/e2e/settings-output-format.spec.ts
@@ -1,0 +1,82 @@
+import { type Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
+
+/**
+ * Output format is backend-owned (single source of truth read by the rule
+ * engine). These tests pin that the settings dialog reads it from
+ * `GET /api/settings` and writes it via `PUT /api/settings` — never a
+ * frontend-local copy that could drift.
+ */
+async function mockSettings(page: Page, format: "aiff" | "mp3") {
+  const puts: Array<Record<string, unknown>> = [];
+  await page.route(/\/api\/settings\/root-folder$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+  await page.route(/\/api\/settings$/, (route) => {
+    const req = route.request();
+    let outFormat = format;
+    if (req.method() === "PUT") {
+      const body = JSON.parse(req.postData() ?? "{}");
+      puts.push(body);
+      if (body.preferred_output_format)
+        outFormat = body.preferred_output_format;
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        preferred_output_format: outFormat,
+        root_music_folder: "/music",
+      }),
+    });
+  });
+  return puts;
+}
+
+async function openLibrarySettings(page: Page) {
+  await page.goto("/library");
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("button", { name: "Settings" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Library" }).click();
+  return dialog;
+}
+
+test.describe("Settings — output format (backend-owned)", () => {
+  test("reads the current format from the backend", async ({ page }) => {
+    await mockSettings(page, "mp3");
+    const dialog = await openLibrarySettings(page);
+
+    // The backend says mp3 → the MP3 toggle is active, not the store default.
+    await expect(dialog.getByRole("radio", { name: "MP3" })).toHaveAttribute(
+      "data-state",
+      "on",
+    );
+  });
+
+  test("writing the format persists to the backend", async ({ page }) => {
+    const puts = await mockSettings(page, "aiff");
+    const dialog = await openLibrarySettings(page);
+
+    await expect(dialog.getByRole("radio", { name: "AIFF" })).toHaveAttribute(
+      "data-state",
+      "on",
+    );
+    await dialog.getByRole("radio", { name: "MP3" }).click();
+
+    // A PUT /api/settings carried the new format.
+    await expect
+      .poll(() => puts.find((b) => b.preferred_output_format === "mp3"))
+      .toBeTruthy();
+    await expect(dialog.getByRole("radio", { name: "MP3" })).toHaveAttribute(
+      "data-state",
+      "on",
+    );
+  });
+});

--- a/frontend/src/components/rulesets/ruleset-editor.tsx
+++ b/frontend/src/components/rulesets/ruleset-editor.tsx
@@ -29,6 +29,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  api,
   REQUIRED_ATTRIBUTES,
   RULE_OUTPUTS,
   type RequiredAttribute,
@@ -36,7 +37,6 @@ import {
   type Ruleset,
   type RuleType,
 } from "@/lib/api";
-import { getSetting } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 
 import { RULE_ICON_COLORS, RuleCard, type InputOption } from "./rule-card";
@@ -184,7 +184,9 @@ export function RulesetEditor({
   );
 
   useEffect(() => {
-    getSetting("preferredOutputFormat").then(setPreferredFormat);
+    api
+      .getAppSettings()
+      .then((s) => setPreferredFormat(s.preferred_output_format));
     function onFormatChanged(e: Event) {
       setPreferredFormat((e as CustomEvent<string>).detail);
     }

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -171,7 +171,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     if (!open) return;
     Promise.all([
       getSetting("autoUpdate"),
-      getSetting("preferredOutputFormat"),
+      api.getAppSettings(),
       getSetting("waveformStyle"),
       api.getRootMusicFolder(),
       api.getAiSettings(),
@@ -181,7 +181,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     ]).then(
       ([
         autoUpdate,
-        outputFormat,
+        appSettings,
         waveform,
         rootPath,
         settings,
@@ -190,7 +190,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
         rulesetsData,
       ]) => {
         setAutoUpdate(autoUpdate);
-        setPreferredOutputFormat(outputFormat);
+        setPreferredOutputFormat(
+          appSettings.preferred_output_format === "mp3" ? "mp3" : "aiff",
+        );
         setWaveformStyleState(waveform);
         setRootFolder(rootPath);
         setRootFolderDraft(rootPath);
@@ -226,7 +228,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
   async function handlePreferredOutputFormatChange(format: "aiff" | "mp3") {
     setPreferredOutputFormat(format);
-    await setSetting("preferredOutputFormat", format);
     await api.updateAppSettings({ preferred_output_format: format });
     window.dispatchEvent(
       new CustomEvent("preferred-format-changed", { detail: format }),

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -1,7 +1,14 @@
 /**
- * User settings store.
- * Uses Tauri Store plugin when running inside the desktop app,
- * falls back to localStorage in browser/dev.
+ * Client/UI preferences store. Owns presentation-only state (window/UI prefs)
+ * that never needs to reach the Python backend and must survive the backend
+ * being down or still booting.
+ *
+ * Persists to its OWN file (`ui.json`) — the backend owns `settings.json` in the
+ * same config dir, so the two must never share a filename. Uses the Tauri Store
+ * plugin inside the desktop app, falls back to localStorage in browser/dev.
+ *
+ * Domain/path config (root music folder, rulesets, folders, output format, AI)
+ * is owned by the backend and read/written via `lib/api.ts`, not here.
  */
 
 import { isTauri } from "./tauri";
@@ -11,17 +18,19 @@ export type WaveformStyle = "starlib" | "rekordbox_rgb" | "rekordbox_blue";
 
 export interface Settings {
   autoUpdate: boolean;
-  preferredOutputFormat: "aiff" | "mp3";
   waveformStyle: WaveformStyle;
 }
 
 const DEFAULTS: Settings = {
   autoUpdate: true,
-  preferredOutputFormat: "aiff",
   waveformStyle: "starlib",
 };
 
-const STORAGE_KEY = "starlib_settings";
+const STORAGE_KEY = "starlib_ui";
+
+const UI_STORE_FILE = "ui.json";
+/** Legacy file the UI store shared with the backend — read once to migrate. */
+const LEGACY_STORE_FILE = "settings.json";
 
 let storeInstance: Awaited<
   ReturnType<(typeof import("@tauri-apps/plugin-store"))["load"]>
@@ -30,11 +39,45 @@ let storeInstance: Awaited<
 async function getTauriStore() {
   if (storeInstance) return storeInstance;
   const { load } = await import("@tauri-apps/plugin-store");
-  storeInstance = await load("settings.json", {
+  const store = await load(UI_STORE_FILE, {
     autoSave: true,
     defaults: { ...DEFAULTS } as Record<string, unknown>,
   });
+  await migrateFromLegacyStore(store);
+  storeInstance = store;
   return storeInstance;
+}
+
+/**
+ * One-time move of UI keys out of the legacy `settings.json` (which the backend
+ * also writes) into `ui.json`. Reads the old file but never writes to it, so the
+ * backend's keys are left untouched. Runs until the marker key is set.
+ */
+async function migrateFromLegacyStore(
+  store: Awaited<ReturnType<typeof getTauriStore>>,
+): Promise<void> {
+  const MARKER = "__ui_migrated";
+  if (await store.get(MARKER)) return;
+  try {
+    const { load } = await import("@tauri-apps/plugin-store");
+    const legacy = await load(LEGACY_STORE_FILE, {
+      autoSave: false,
+      defaults: {},
+    });
+    for (const key of await legacy.keys()) {
+      // Only carry over UI-owned keys; leave backend keys (app, rulesets, …).
+      const isUiKey =
+        key === "autoUpdate" ||
+        key === "waveformStyle" ||
+        key.startsWith("columns.");
+      if (isUiKey && (await store.get(key)) === undefined) {
+        await store.set(key, await legacy.get(key));
+      }
+    }
+  } catch {
+    // No legacy file / not in Tauri — nothing to migrate.
+  }
+  await store.set(MARKER, true);
 }
 
 export async function getSetting<K extends keyof Settings>(

--- a/tests/test_settings_store.py
+++ b/tests/test_settings_store.py
@@ -1,0 +1,60 @@
+"""Tests for the consolidated settings store: atomic writes + single source.
+
+Regression coverage for the "Path Settings keep resetting" bug, whose root
+cause was the frontend UI store and this backend store sharing one file. These
+tests lock in the backend-side guarantees of the fix: writes are atomic (no
+truncated file / leftover temp), a configured path survives a save/load cycle,
+and the preferred output format has exactly one home (the one the rule engine
+reads).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from backend.core.services import app_settings as app_settings_service
+from backend.core.services import settings as settings_service
+
+
+def _patched(tmp_path: Path):
+    return (
+        patch.object(settings_service, "_SETTINGS_FILE", tmp_path / "settings.json"),
+        patch.object(settings_service, "_CONFIG_DIR", tmp_path),
+    )
+
+
+def test_save_is_atomic_and_leaves_no_temp_file(tmp_path: Path) -> None:
+    file_patch, dir_patch = _patched(tmp_path)
+    with file_patch, dir_patch:
+        settings = settings_service._defaults()
+        settings.app.root_music_folder = "/music/library"
+        settings_service.save(settings)
+
+        settings_file = tmp_path / "settings.json"
+        # A valid, fully-written JSON file — never a truncated fragment.
+        assert json.loads(settings_file.read_text())["app"]["root_music_folder"] == "/music/library"
+        # The temp file used for the atomic replace is gone.
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_configured_root_survives_save_load_cycle(tmp_path: Path) -> None:
+    file_patch, dir_patch = _patched(tmp_path)
+    with file_patch, dir_patch:
+        settings = settings_service._defaults()
+        settings.app.root_music_folder = "/music/library"
+        settings_service.save(settings)
+
+        # Reload from disk — the path must not be reset back to ~/Music.
+        reloaded = settings_service.load()
+        assert reloaded.app.root_music_folder == "/music/library"
+
+
+def test_output_format_has_single_source_of_truth(tmp_path: Path) -> None:
+    file_patch, dir_patch = _patched(tmp_path)
+    with file_patch, dir_patch:
+        settings_service.save(settings_service._defaults())
+
+        # Writing via the app-settings facade (what the PUT /api/settings route
+        # uses) is exactly what the rule engine reads back.
+        app_settings_service.save({"preferred_output_format": "mp3"})
+        assert app_settings_service.get_preferred_output_format() == "mp3"


### PR DESCRIPTION
The Tauri UI store and the Python backend both persisted to `settings.json` in the same config dir (identical on macOS/Linux), so their writes clobbered each other and the backend healed a missing `root_music_folder` back to `~/Music` — path settings kept resetting. Fixes #515.

UI store moves to its own `ui.json` (with one-time migration of UI keys); `preferred_output_format` becomes backend-only; backend `save()` is now atomic.

Test plan: `pytest` (new atomic-save + single-source tests) and `playwright test` (new settings dialog output-format specs); full backend + e2e suites pass.