### PR TITLE
feat(nav): browser-style back/forward arrows

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -22,4 +22,58 @@ test.describe("Navigation", () => {
     await homeLink.click();
     await expect(page).toHaveURL(/^http:\/\/localhost:\d+\/(\?.*)?$/);
   });
+
+  test.describe("back/forward arrows", () => {
+    test("arrows are disabled with no history in that direction", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      const topbar = page.locator("header");
+      await expect(
+        topbar.getByRole("button", { name: /go back/i }),
+      ).toBeDisabled();
+      await expect(
+        topbar.getByRole("button", { name: /go forward/i }),
+      ).toBeDisabled();
+    });
+
+    test("arrows reflect history and navigate", async ({ page }) => {
+      await page.goto("/");
+      const topbar = page.locator("header");
+      const back = topbar.getByRole("button", { name: /go back/i });
+      const forward = topbar.getByRole("button", { name: /go forward/i });
+
+      await page
+        .locator("aside")
+        .getByRole("link", { name: /Library/i })
+        .click();
+      await expect(page).toHaveURL(/\/library/);
+
+      // A visited entry now exists behind us; nothing ahead.
+      await expect(back).toBeEnabled();
+      await expect(forward).toBeDisabled();
+
+      await back.click();
+      await expect(page).toHaveURL(/^http:\/\/localhost:\d+\/(\?.*)?$/);
+      await expect(forward).toBeEnabled();
+
+      await forward.click();
+      await expect(page).toHaveURL(/\/library/);
+    });
+
+    test("keyboard shortcuts drive back and forward", async ({ page }) => {
+      await page.goto("/");
+      await page
+        .locator("aside")
+        .getByRole("link", { name: /Library/i })
+        .click();
+      await expect(page).toHaveURL(/\/library/);
+
+      await page.locator("body").press("Meta+[");
+      await expect(page).toHaveURL(/^http:\/\/localhost:\d+\/(\?.*)?$/);
+
+      await page.locator("body").press("Meta+]");
+      await expect(page).toHaveURL(/\/library/);
+    });
+  });
 });

--- a/frontend/src/components/layout/nav-arrows.tsx
+++ b/frontend/src/components/layout/nav-arrows.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useEffect } from "react";
+
+import { useNavHistory } from "@/lib/use-nav-history";
+import { cn } from "@/lib/utils";
+
+export function NavArrows() {
+  const { canGoBack, canGoForward, back, forward } = useNavHistory();
+
+  // Browser-style ⌘[ / ⌘] (Ctrl+[ / Ctrl+] on Windows/Linux). These aren't
+  // text-editing shortcuts, so it's safe to bind them globally.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key === "[") {
+        e.preventDefault();
+        back();
+      } else if (e.key === "]") {
+        e.preventDefault();
+        forward();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [back, forward]);
+
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      <button
+        type="button"
+        onClick={back}
+        disabled={!canGoBack}
+        aria-label="Go back"
+        title="Go back (⌘[)"
+        className={cn(
+          "hover:bg-accent text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded-md transition-colors",
+          canGoBack ? "cursor-pointer" : "cursor-not-allowed opacity-40",
+        )}
+      >
+        <ArrowLeft className="size-3.5" aria-hidden />
+      </button>
+      <button
+        type="button"
+        onClick={forward}
+        disabled={!canGoForward}
+        aria-label="Go forward"
+        title="Go forward (⌘])"
+        className={cn(
+          "hover:bg-accent text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded-md transition-colors",
+          canGoForward ? "cursor-pointer" : "cursor-not-allowed opacity-40",
+        )}
+      >
+        <ArrowRight className="size-3.5" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/top-bar.tsx
+++ b/frontend/src/components/layout/top-bar.tsx
@@ -9,6 +9,7 @@ import { CommandPaletteTrigger } from "@/components/command-palette";
 import { isTauri } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
+import { NavArrows } from "./nav-arrows";
 import { useReloadTrigger, useTopBarContent } from "./top-bar-context";
 
 function useIsFullscreen() {
@@ -84,6 +85,7 @@ export function TopBar() {
           }}
         />
       </Link>
+      <NavArrows />
       <div className="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium">
         {title ?? null}
       </div>

--- a/frontend/src/lib/use-nav-history.ts
+++ b/frontend/src/lib/use-nav-history.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Browser-style back/forward needs to know the current position within the
+// session history and whether entries exist on either side. Neither the DOM
+// History API nor the Next.js App Router exposes that, so we track it: we tag
+// every history entry with a monotonic index (merged into whatever state Next
+// already stores) and read it back on `popstate`.
+
+type NavState = { canGoBack: boolean; canGoForward: boolean };
+
+const INDEX_KEY = "__starlibNavIdx";
+
+let currentIndex = 0;
+let maxIndex = 0;
+let installed = false;
+
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+function readIndex(state: unknown): number | undefined {
+  if (state && typeof state === "object" && INDEX_KEY in state) {
+    const v = (state as Record<string, unknown>)[INDEX_KEY];
+    if (typeof v === "number") return v;
+  }
+  return undefined;
+}
+
+function install() {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  const { history } = window;
+  const origPush = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+
+  // Seed the current entry. A reload preserves history.state, so recover the
+  // index if we set one before; forward entries can't be recovered, so treat
+  // the current position as the end (forward disabled until we navigate again).
+  const seeded = readIndex(history.state);
+  currentIndex = seeded ?? 0;
+  maxIndex = currentIndex;
+  origReplace({ ...(history.state ?? {}), [INDEX_KEY]: currentIndex }, "");
+
+  history.pushState = function (state, unused, url) {
+    // A push truncates any forward history.
+    currentIndex += 1;
+    maxIndex = currentIndex;
+    origPush({ ...(state ?? {}), [INDEX_KEY]: currentIndex }, unused, url);
+    // Next.js drives pushState from an insertion effect, where scheduling a
+    // React update synchronously warns. Defer to a microtask.
+    queueMicrotask(notify);
+  };
+
+  history.replaceState = function (state, unused, url) {
+    // A replace keeps the index, so nav-arrow state is unchanged — no notify.
+    // (Next.js calls this during an insertion effect, where scheduling a React
+    // update would warn.)
+    origReplace({ ...(state ?? {}), [INDEX_KEY]: currentIndex }, unused, url);
+  };
+
+  window.addEventListener("popstate", (e) => {
+    const idx = readIndex(e.state) ?? 0;
+    currentIndex = idx;
+    if (idx > maxIndex) maxIndex = idx;
+    notify();
+  });
+}
+
+function snapshot(): NavState {
+  return {
+    canGoBack: currentIndex > 0,
+    canGoForward: currentIndex < maxIndex,
+  };
+}
+
+export function useNavHistory() {
+  const [state, setState] = useState<NavState>({
+    canGoBack: false,
+    canGoForward: false,
+  });
+
+  useEffect(() => {
+    install();
+    const update = () => setState(snapshot());
+    update();
+    listeners.add(update);
+    return () => {
+      listeners.delete(update);
+    };
+  }, []);
+
+  const back = () => {
+    if (state.canGoBack) window.history.back();
+  };
+  const forward = () => {
+    if (state.canGoForward) window.history.forward();
+  };
+
+  return { ...state, back, forward };
+}


### PR DESCRIPTION
Adds back/forward arrows to the top bar with per-direction disabled states and ⌘[ / ⌘] shortcuts. History position is tracked by tagging entries with a monotonic index, since Next's App Router exposes no `canGoBack`/`canGoForward`.

Closes #409.

**Test plan:** `npx playwright test navigation` — covers disabled states, arrow navigation, and keyboard shortcuts.