### PR TITLE
feat(library): tree counts reflect active filters (#399)

### DIFF
--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -236,16 +236,51 @@ def fetch_from_downloads(
 @router.get("/folders/tree", response_model=TreeNode)
 def get_folder_tree(
     root_folder: Annotated[Path, Depends(get_root_folder)],
+    search: str | None = Query(None),
+    genres: list[str] | None = Query(None),
+    keys: list[str] | None = Query(None),
+    bpm_min: int | None = Query(None, ge=0),
+    bpm_max: int | None = Query(None, ge=0),
+    has_soundcloud_id: bool | None = Query(None),
+    file_formats: list[str] | None = Query(None),
+    size_min: int | None = Query(None, ge=0),
+    size_max: int | None = Query(None, ge=0),
 ) -> TreeNode:
     """Return the folder tree built from indexed tracks.
 
     Only folders that contain at least one track (directly or in a
     descendant) are included — empty directories are omitted.
+
+    ``track_count`` is always the unfiltered recursive total, so the tree
+    structure is stable. When any filter argument is supplied, each node's
+    ``filtered_count`` carries the recursive count of tracks matching those
+    filters (``None`` otherwise).
     """
     root_str = str(root_folder.resolve())
     folder_counts = cache_db.get_folder_track_counts()
 
-    # Build nested dict from flat folder paths
+    has_filters = any(
+        v is not None
+        for v in (search, genres, keys, bpm_min, bpm_max, has_soundcloud_id, file_formats, size_min, size_max)
+    )
+    filtered_counts = (
+        cache_db.get_folder_track_counts(
+            search_query=search,
+            genres=genres,
+            keys=keys,
+            bpm_min=bpm_min,
+            bpm_max=bpm_max,
+            has_soundcloud_id=has_soundcloud_id,
+            file_formats=file_formats,
+            size_min=size_min,
+            size_max=size_max,
+        )
+        if has_filters
+        else None
+    )
+
+    # Build nested dict from flat folder paths (always the unfiltered set, so
+    # folders never disappear when a filter narrows the counts).
     tree: dict = {}
     for fp in folder_counts:
         # Make path relative to root; skip entries outside root
@@ -262,12 +297,18 @@ def get_folder_tree(
     def _build(name: str, abs_path: str, children_dict: dict) -> TreeNode:
         children = [_build(k, f"{abs_path}/{k}", v) for k, v in sorted(children_dict.items())]
         total = folder_counts.get(abs_path, 0) + sum(c.track_count for c in children)
-        return TreeNode(id=abs_path, name=name, children=children, track_count=total)
+        filtered = None
+        if filtered_counts is not None:
+            filtered = filtered_counts.get(abs_path, 0) + sum(c.filtered_count or 0 for c in children)
+        return TreeNode(id=abs_path, name=name, children=children, track_count=total, filtered_count=filtered)
 
     root_name = root_folder.name
     children = [_build(k, f"{root_str}/{k}", v) for k, v in sorted(tree.items())]
     total = folder_counts.get(root_str, 0) + sum(c.track_count for c in children)
-    return TreeNode(id=root_str, name=root_name, children=children, track_count=total)
+    filtered_root = None
+    if filtered_counts is not None:
+        filtered_root = filtered_counts.get(root_str, 0) + sum(c.filtered_count or 0 for c in children)
+    return TreeNode(id=root_str, name=root_name, children=children, track_count=total, filtered_count=filtered_root)
 
 
 @router.get("/folders/browse-path", response_model=Page[TrackBrowseResponse])

--- a/backend/core/services/cache_db.py
+++ b/backend/core/services/cache_db.py
@@ -234,10 +234,38 @@ def get_distinct_folders() -> list[str]:
     return [r[0] for r in rows]
 
 
-def get_folder_track_counts() -> dict[str, int]:
-    """Return direct track count per folder (non-recursive)."""
+def get_folder_track_counts(
+    *,
+    search_query: str | None = None,
+    genres: list[str] | None = None,
+    keys: list[str] | None = None,
+    bpm_min: int | None = None,
+    bpm_max: int | None = None,
+    has_soundcloud_id: bool | None = None,
+    file_formats: list[str] | None = None,
+    size_min: int | None = None,
+    size_max: int | None = None,
+) -> dict[str, int]:
+    """Return direct track count per folder (non-recursive).
+
+    When filter arguments are supplied, counts reflect only tracks matching
+    those filters — mirroring the browse endpoints so tree badges can track
+    the filtered result set.
+    """
+    stmt = _apply_filters(
+        select(Track.folder, func.count()),
+        search_query=search_query,
+        genres=genres,
+        keys=keys,
+        bpm_min=bpm_min,
+        bpm_max=bpm_max,
+        has_soundcloud_id=has_soundcloud_id,
+        file_formats=file_formats,
+        size_min=size_min,
+        size_max=size_max,
+    ).group_by(Track.folder)
     with get_engine().connect() as conn:
-        rows = conn.execute(select(Track.folder, func.count()).group_by(Track.folder)).all()
+        rows = conn.execute(stmt).all()
     return {r[0]: int(r[1]) for r in rows}
 
 

--- a/backend/schemas/tree.py
+++ b/backend/schemas/tree.py
@@ -15,3 +15,5 @@ class TreeNode(BaseModel):
     children: list[TreeNode] = []
     track_count: int = 0
     """Recursive count of tracks in this folder and all descendants."""
+    filtered_count: int | None = None
+    """Recursive count under the active filters; ``None`` when no filter is applied."""

--- a/frontend/e2e/library-tree-filtered-counts.spec.ts
+++ b/frontend/e2e/library-tree-filtered-counts.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "./fixtures";
+
+// #399 — tree count badges must reflect the active filters and revert when
+// filters clear. The backend returns `filtered_count` per node when a filter
+// query is present; the tree structure (and `track_count`) stays stable.
+
+type Node = {
+  id: string;
+  name: string;
+  children: Node[];
+  track_count: number;
+  filtered_count: number | null;
+};
+
+function treeBody(filtered: boolean): Node {
+  const mk = (id: string, name: string, total: number, filt: number): Node => ({
+    id,
+    name,
+    children: [],
+    track_count: total,
+    filtered_count: filtered ? filt : null,
+  });
+  return {
+    id: "/music",
+    name: "music",
+    children: [
+      mk("/music/prepare", "prepare", 12, 3),
+      mk("/music/collection", "collection", 30, 8),
+      mk("/music/cleaned", "cleaned", 5, 0),
+    ],
+    track_count: 47,
+    filtered_count: filtered ? 11 : null,
+  };
+}
+
+test.describe("Library tree — filtered counts (#399)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Override the fixture's tree route: reflect the filter query in the counts.
+    await page.route(/\/api\/metadata\/folders\/tree(\?|$)/, (route) => {
+      const url = new URL(route.request().url());
+      const filtered = url.searchParams.has("search");
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(treeBody(filtered)),
+      });
+    });
+  });
+
+  test("badges reflect the filter and revert when it clears", async ({
+    page,
+  }) => {
+    const tree = page.locator("div.border-r").first();
+    // Tree rows are full-width buttons; folder-shortcut buttons in the header
+    // are not, so `button.w-full` targets rows only.
+    const node = (name: string) =>
+      tree.locator("button.w-full", { hasText: name });
+
+    await page.goto("/library");
+
+    // Unfiltered: total counts.
+    await expect(node("music")).toContainText("47");
+
+    // Expand the root to reveal its children (chevron toggles expansion).
+    await node("music").locator("svg").first().click();
+    await expect(node("prepare")).toContainText("12");
+    await expect(node("collection")).toContainText("30");
+    await expect(node("cleaned")).toContainText("5");
+
+    // Apply a filter — counts drop to the filtered result.
+    await page.goto("/library?search=techno");
+    await expect(node("music")).toContainText("11");
+    await expect(node("prepare")).toContainText("3");
+    await expect(node("collection")).toContainText("8");
+    // A folder with zero matches shows no badge at all.
+    await expect(node("cleaned").locator("span.tabular-nums")).toHaveCount(0);
+
+    // Clearing the filter reverts to the total counts.
+    await page.goto("/library");
+    await expect(node("music")).toContainText("47");
+    await expect(node("prepare")).toContainText("12");
+    await expect(node("collection")).toContainText("30");
+  });
+});

--- a/frontend/src/app/library/filesystem-tree-panel.tsx
+++ b/frontend/src/app/library/filesystem-tree-panel.tsx
@@ -338,11 +338,18 @@ export function FilesystemTreePanel({
             </TooltipContent>
           </Tooltip>
         )}
-        {node.track_count > 0 && (
-          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-            {node.track_count}
-          </span>
-        )}
+        {(() => {
+          // filtered_count is set when a filter is active; fall back to the
+          // unfiltered total otherwise. Zero renders nothing.
+          const count = node.filtered_count ?? node.track_count;
+          return (
+            count > 0 && (
+              <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                {count}
+              </span>
+            )
+          );
+        })()}
       </>
     );
   };

--- a/frontend/src/app/library/filesystem-view.tsx
+++ b/frontend/src/app/library/filesystem-view.tsx
@@ -8,7 +8,12 @@ import {
   Wand2,
   XCircle,
 } from "lucide-react";
-import { useQueryState } from "nuqs";
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  useQueryState,
+} from "nuqs";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -80,21 +85,10 @@ export function FilesystemView() {
   // All rulesets (for context menu)
   const [allRulesets, setAllRulesets] = useState<Ruleset[]>([]);
 
-  // Load tree, folder config, root folder, and rulesets on mount
+  // Load folder config, root folder, and rulesets on mount. The tree itself is
+  // loaded by a filter-aware effect below so its counts reflect active filters.
   useEffect(() => {
     let cancelled = false;
-    api
-      .getFolderTree()
-      .then((t) => {
-        if (cancelled) return;
-        setTree(t);
-        setRootFolder(t.id);
-        // Default to root if no node selected
-        if (!selectedNodeId) {
-          setSelectedNodeId(t.id);
-        }
-      })
-      .catch(() => {});
 
     function loadFolders() {
       api
@@ -134,7 +128,6 @@ export function FilesystemView() {
       window.removeEventListener("folders-config-changed", loadFolders);
       unsubscribeRulesets();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Resolve active ruleset for the selected node, walking ancestors for recursive bindings
@@ -281,15 +274,74 @@ export function FilesystemView() {
   // Table refresh signal
   const [refreshToken, setRefreshToken] = useState(0);
 
-  // Reload the folder tree whenever something changes (save, apply rules, etc.)
-  // so folder track counts stay in sync.
+  // Active filter state, read from the same URL params the table uses. Drives
+  // filtered tree counts so badges reflect what's visible after filtering.
+  const [treeSearch] = useQueryState("search", parseAsString.withDefault(""));
+  const [treeGenres] = useQueryState(
+    "genre",
+    parseAsArrayOf(parseAsString).withDefault([]),
+  );
+  const [treeKeys] = useQueryState(
+    "key",
+    parseAsArrayOf(parseAsString).withDefault([]),
+  );
+  const [treeBpmMin] = useQueryState("bpmMin", parseAsInteger);
+  const [treeBpmMax] = useQueryState("bpmMax", parseAsInteger);
+  const [treeFormats] = useQueryState(
+    "file_format",
+    parseAsArrayOf(parseAsString).withDefault([]),
+  );
+  const [treeSizeMin] = useQueryState("file_sizeMin", parseAsInteger);
+  const [treeSizeMax] = useQueryState("file_sizeMax", parseAsInteger);
+  const [treeScLinkedRaw] = useQueryState("soundcloud_linked", parseAsString);
+  const treeScLinked =
+    treeScLinkedRaw === "true"
+      ? true
+      : treeScLinkedRaw === "false"
+        ? false
+        : undefined;
+
+  // Stable key over the filter values (nuqs arrays are fresh each render).
+  const treeFiltersKey = `${treeSearch}|${treeGenres.join(",")}|${treeKeys.join(
+    ",",
+  )}|${treeBpmMin}|${treeBpmMax}|${treeFormats.join(",")}|${treeSizeMin}|${treeSizeMax}|${treeScLinkedRaw ?? ""}`;
+
+  // Whether the default node has been selected once (avoids resetting the
+  // user's selection every time the filtered tree reloads).
+  const treeInitializedRef = useRef(false);
+
+  // (Re)load the folder tree with the active filters. Also re-runs on
+  // refreshToken (save, apply rules, etc.) so counts stay in sync.
   useEffect(() => {
-    if (refreshToken === 0) return; // initial mount already loads the tree
+    let cancelled = false;
     api
-      .getFolderTree()
-      .then(setTree)
+      .getFolderTree({
+        search: treeSearch || undefined,
+        genres: treeGenres.length ? treeGenres : undefined,
+        keys: treeKeys.length ? treeKeys : undefined,
+        bpmMin: treeBpmMin ?? undefined,
+        bpmMax: treeBpmMax ?? undefined,
+        fileFormats: treeFormats.length ? treeFormats : undefined,
+        sizeMin: treeSizeMin ?? undefined,
+        sizeMax: treeSizeMax ?? undefined,
+        hasSoundcloudId: treeScLinked,
+      })
+      .then((t) => {
+        if (cancelled) return;
+        setTree(t);
+        setRootFolder(t.id);
+        // Default to root once, if no node selected yet.
+        if (!treeInitializedRef.current) {
+          treeInitializedRef.current = true;
+          setSelectedNodeId((cur) => cur || t.id);
+        }
+      })
       .catch(() => {});
-  }, [refreshToken]);
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [treeFiltersKey, refreshToken]);
 
   useReloadHandler(() => setRefreshToken((t) => t + 1));
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -291,6 +291,8 @@ export interface TreeNode {
   name: string;
   children: TreeNode[];
   track_count: number;
+  // Recursive count under the active filters; null/undefined when unfiltered.
+  filtered_count?: number | null;
 }
 
 export interface FolderRulesetBinding {
@@ -672,8 +674,32 @@ export const api = {
 
   // ==================== Folder Tree ====================
 
-  async getFolderTree(): Promise<TreeNode> {
-    return fetchApi("/api/metadata/folders/tree");
+  async getFolderTree(params?: {
+    search?: string;
+    genres?: string[];
+    keys?: string[];
+    bpmMin?: number;
+    bpmMax?: number;
+    fileFormats?: string[];
+    sizeMin?: number;
+    sizeMax?: number;
+    hasSoundcloudId?: boolean;
+  }): Promise<TreeNode> {
+    const qs = new URLSearchParams();
+    if (params?.search) qs.set("search", params.search);
+    params?.genres?.forEach((g) => qs.append("genres", g));
+    params?.keys?.forEach((k) => qs.append("keys", k));
+    if (params?.bpmMin !== undefined) qs.set("bpm_min", String(params.bpmMin));
+    if (params?.bpmMax !== undefined) qs.set("bpm_max", String(params.bpmMax));
+    params?.fileFormats?.forEach((f) => qs.append("file_formats", f));
+    if (params?.sizeMin !== undefined)
+      qs.set("size_min", String(params.sizeMin));
+    if (params?.sizeMax !== undefined)
+      qs.set("size_max", String(params.sizeMax));
+    if (params?.hasSoundcloudId !== undefined)
+      qs.set("has_soundcloud_id", String(params.hasSoundcloudId));
+    const q = qs.toString();
+    return fetchApi(`/api/metadata/folders/tree${q ? `?${q}` : ""}`);
   },
 
   async browsePath(

--- a/tests/test_folder_tree_counts.py
+++ b/tests/test_folder_tree_counts.py
@@ -1,0 +1,71 @@
+"""Filtered per-folder counts backing the tree-view badges (#399).
+
+``get_folder_track_counts`` must return unfiltered direct counts by default and
+counts restricted to matching tracks when filter arguments are supplied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.db import engine as db_engine
+from backend.core.services import cache_db
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine():
+    yield
+    if db_engine._engine is not None:  # type: ignore[attr-defined]
+        db_engine._engine.dispose()  # type: ignore[attr-defined]
+    db_engine._engine = None  # type: ignore[attr-defined]
+    db_engine._engine_path = None  # type: ignore[attr-defined]
+
+
+def _add(folder: Path, name: str, *, genre: str, bpm: int) -> None:
+    cache_db.upsert_track(
+        file_path=folder / name,
+        folder=folder,
+        title=name,
+        artist_str="Artist",
+        genre=genre,
+        key=None,
+        bpm=bpm,
+        release_date=None,
+        has_artwork=False,
+        file_size=1,
+        file_format=".mp3",
+        duration=None,
+        is_complete=False,
+        missing_fields=[],
+        mtime=1.0,
+    )
+
+
+def test_folder_counts_unfiltered_and_filtered(tmp_path: Path) -> None:
+    cache_db.init_db(tmp_path / "cache.db")
+    house = tmp_path / "music" / "house"
+    techno = tmp_path / "music" / "techno"
+    house.mkdir(parents=True)
+    techno.mkdir(parents=True)
+
+    _add(house, "a.mp3", genre="House", bpm=124)
+    _add(house, "b.mp3", genre="Techno", bpm=130)
+    _add(techno, "c.mp3", genre="Techno", bpm=135)
+
+    # Unfiltered: direct count per folder.
+    assert cache_db.get_folder_track_counts() == {
+        str(house): 2,
+        str(techno): 1,
+    }
+
+    # Genre filter narrows counts and drops non-matching folders.
+    assert cache_db.get_folder_track_counts(genres=["Techno"]) == {
+        str(house): 1,
+        str(techno): 1,
+    }
+    assert cache_db.get_folder_track_counts(genres=["House"]) == {str(house): 1}
+
+    # BPM range filter.
+    assert cache_db.get_folder_track_counts(bpm_min=131) == {str(techno): 1}


### PR DESCRIPTION
Filesystem tree count badges now reflect the active filters instead of always showing totals. The `/folders/tree` endpoint accepts the same filter params as the table and returns a per-node `filtered_count`; the tree structure stays stable (folders never disappear). Badges revert to the total count when filters clear.

Closes #399.

**Test:** `tests/test_folder_tree_counts.py` (filtered folder counts) + `frontend/e2e/library-tree-filtered-counts.spec.ts` (badges update on filter and revert on clear).