### PR TITLE
feat(library): show empty folders in tree view

### DIFF
--- a/backend/api/metadata/files.py
+++ b/backend/api/metadata/files.py
@@ -3,8 +3,10 @@
 import asyncio
 import base64
 import logging
+import os
 import shutil
 import time
+from collections.abc import Iterable
 from datetime import date
 from pathlib import Path
 from typing import Annotated
@@ -233,6 +235,43 @@ def fetch_from_downloads(
     return FetchFromDownloadsResponse(moved=moved, skipped=skipped, errors=errors)
 
 
+def _folder_tree_dict(root_str: str, track_folders: Iterable[str]) -> dict:
+    """Build a nested folder-name dict from track folders and on-disk dirs.
+
+    Args:
+        root_str: Resolved root folder path as a string.
+        track_folders: Absolute paths of folders containing indexed tracks.
+
+    Returns:
+        Nested dict mapping folder name to its children dict.
+    """
+    tree: dict = {}
+
+    def _insert(fp: str) -> None:
+        # Make path relative to root; skip entries outside root
+        if not fp.startswith(root_str):
+            return
+        rel = fp[len(root_str) :]
+        if rel.startswith("/"):
+            rel = rel[1:]
+        parts = rel.split("/") if rel else []
+        node = tree
+        for part in parts:
+            node = node.setdefault(part, {})
+
+    for fp in track_folders:
+        _insert(fp)
+
+    # Also walk the filesystem so directories without indexed tracks (empty
+    # folders) appear in the tree.
+    for dirpath, dirnames, _ in os.walk(root_str):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+        for d in dirnames:
+            _insert(f"{dirpath}/{d}")
+
+    return tree
+
+
 @router.get("/folders/tree", response_model=TreeNode)
 def get_folder_tree(
     root_folder: Annotated[Path, Depends(get_root_folder)],
@@ -246,10 +285,10 @@ def get_folder_tree(
     size_min: int | None = Query(None, ge=0),
     size_max: int | None = Query(None, ge=0),
 ) -> TreeNode:
-    """Return the folder tree built from indexed tracks.
+    """Return the folder tree built from indexed tracks and on-disk directories.
 
-    Only folders that contain at least one track (directly or in a
-    descendant) are included — empty directories are omitted.
+    Every directory under the root is included — empty folders too. Hidden
+    (dot-prefixed) directories are skipped, matching the indexer.
 
     ``track_count`` is always the unfiltered recursive total, so the tree
     structure is stable. When any filter argument is supplied, each node's
@@ -281,18 +320,7 @@ def get_folder_tree(
 
     # Build nested dict from flat folder paths (always the unfiltered set, so
     # folders never disappear when a filter narrows the counts).
-    tree: dict = {}
-    for fp in folder_counts:
-        # Make path relative to root; skip entries outside root
-        if not fp.startswith(root_str):
-            continue
-        rel = fp[len(root_str) :]
-        if rel.startswith("/"):
-            rel = rel[1:]
-        parts = rel.split("/") if rel else []
-        node = tree
-        for part in parts:
-            node = node.setdefault(part, {})
+    tree = _folder_tree_dict(root_str, folder_counts)
 
     def _build(name: str, abs_path: str, children_dict: dict) -> TreeNode:
         children = [_build(k, f"{abs_path}/{k}", v) for k, v in sorted(children_dict.items())]

--- a/frontend/e2e/library-tree-empty-folders.spec.ts
+++ b/frontend/e2e/library-tree-empty-folders.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "./fixtures";
+
+// The backend tree now includes directories without any indexed tracks. The
+// tree view must render such nodes — without a count badge (zero renders
+// nothing).
+
+test.describe("Library tree — empty folders", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\/metadata\/folders\/tree(\?|$)/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "/music",
+          name: "music",
+          children: [
+            {
+              id: "/music/collection",
+              name: "collection",
+              children: [],
+              track_count: 30,
+              filtered_count: null,
+            },
+            {
+              id: "/music/empty",
+              name: "empty",
+              children: [],
+              track_count: 0,
+              filtered_count: null,
+            },
+          ],
+          track_count: 30,
+          filtered_count: null,
+        }),
+      }),
+    );
+  });
+
+  test("empty folder renders without a count badge", async ({ page }) => {
+    const tree = page.locator("div.border-r").first();
+    const node = (name: string) =>
+      tree.locator("button.w-full", { hasText: name });
+
+    await page.goto("/library");
+
+    // Expand the root to reveal its children.
+    await node("music").locator("svg").first().click();
+
+    await expect(node("empty")).toBeVisible();
+    await expect(node("empty").locator("span.tabular-nums")).toHaveCount(0);
+    await expect(node("collection")).toContainText("30");
+  });
+});

--- a/tests/test_folder_tree_api.py
+++ b/tests/test_folder_tree_api.py
@@ -1,0 +1,72 @@
+"""Folder tree endpoint includes empty directories.
+
+``GET /api/metadata/folders/tree`` builds the tree from indexed tracks *and*
+on-disk directories, so folders without any tracks still appear (with a
+``track_count`` of 0). Hidden (dot-prefixed) directories are skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.db import engine as db_engine
+from backend.core.services import cache_db
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine():
+    yield
+    if db_engine._engine is not None:  # type: ignore[attr-defined]
+        db_engine._engine.dispose()  # type: ignore[attr-defined]
+    db_engine._engine = None  # type: ignore[attr-defined]
+    db_engine._engine_path = None  # type: ignore[attr-defined]
+
+
+def _add(folder: Path, name: str) -> None:
+    cache_db.upsert_track(
+        file_path=folder / name,
+        folder=folder,
+        title=name,
+        artist_str="Artist",
+        genre="House",
+        key=None,
+        bpm=124,
+        release_date=None,
+        has_artwork=False,
+        file_size=1,
+        file_format=".mp3",
+        duration=None,
+        is_complete=False,
+        missing_fields=[],
+        mtime=1.0,
+    )
+
+
+def test_tree_includes_empty_folders(client: TestClient, tmp_music_folder: Path) -> None:
+    root = tmp_music_folder.resolve()
+    cache_db.init_db(root / "cache.db")
+
+    # "collection" gets a track; "prepare" and "cleaned" stay empty, and an
+    # empty nested folder plus a hidden folder are created on disk only.
+    _add(root / "collection", "a.mp3")
+    (root / "prepare" / "nested").mkdir()
+    (root / ".hidden").mkdir()
+
+    resp = client.get("/api/metadata/folders/tree")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    children = {c["name"]: c for c in data["children"]}
+    assert set(children) == {"prepare", "collection", "cleaned"}
+
+    assert children["collection"]["track_count"] == 1
+    assert children["prepare"]["track_count"] == 0
+    assert children["cleaned"]["track_count"] == 0
+
+    # Empty folders nest too.
+    nested = {c["name"]: c for c in children["prepare"]["children"]}
+    assert set(nested) == {"nested"}
+    assert nested["nested"]["track_count"] == 0


### PR DESCRIPTION
## Summary

Empty folders were invisible in the library tree view because the tree was built solely from the folders of indexed tracks (`get_folder_track_counts()` — a `GROUP BY Track.folder` query that can't yield trackless directories).

`GET /api/metadata/folders/tree` now additionally walks the filesystem under the root and merges every on-disk directory into the tree, so empty folders appear with a `track_count` of 0. Hidden (dot-prefixed) directories are skipped, matching the indexer's file discovery. The tree-dict construction moved into a `_folder_tree_dict()` helper.

No frontend changes needed — the tree view already renders zero-count nodes (a count of 0 shows no badge).

## Tests

- `tests/test_folder_tree_api.py` — endpoint test: empty top-level and nested folders appear with `track_count` 0, hidden folders don't, counts for folders with tracks are unchanged.
- `frontend/e2e/library-tree-empty-folders.spec.ts` — an empty folder in the tree response renders in the tree view without a count badge. (The behavior change itself is backend-only; e2e runs against the mocked backend.)
