### PR TITLE
feat(player): rekordbox-style zoomable waveform with grid, sections, cues

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,6 +164,26 @@ Chart series colors do **not** use the accent. They come from a distinct 5-step 
 | `--chart-4` | Orchid           | `oklch(0.68 0.16 305)`      | `#a877c1` |
 | `--chart-5` | Olive            | `oklch(0.70 0.13 105)`      | `#9eaa49` |
 
+### 2.7.1 Phrase-band sections
+
+The player's phrase band colors song-structure sections. One distinct hue per
+kind (the backend normalizes to these eight), light enough to carry black
+labels, spread around the wheel and ordered roughly by energy so the band reads
+at a glance. Theme-independent — the band paints its own color under black text
+in either theme. Adjacent sections are separated by a `color-mix(… 55%, black)`
+same-hue inset border.
+
+| Token              | Kind     | Value                  |
+| ------------------ | -------- | ---------------------- |
+| `--section-intro`  | intro    | `oklch(0.78 0.10 195)` |
+| `--section-verse`  | verse    | `oklch(0.74 0.12 245)` |
+| `--section-up`     | up       | `oklch(0.82 0.13  80)` |
+| `--section-chorus` | chorus   | `oklch(0.72 0.15  15)` |
+| `--section-down`   | down     | `oklch(0.72 0.12 285)` |
+| `--section-bridge` | bridge   | `oklch(0.74 0.14 330)` |
+| `--section-outro`  | outro    | `oklch(0.77 0.12 150)` |
+| `--section-other`  | other    | `oklch(0.72 0.02 260)` |
+
 ---
 
 ## 3. Typography

--- a/backend/api/metadata/audio.py
+++ b/backend/api/metadata/audio.py
@@ -56,7 +56,12 @@ _peaks_semaphore = asyncio.Semaphore(4)
 async def get_file_peaks(
     file_path: str,
     root_folder: Annotated[Path, Depends(get_root_folder)],
-    num_peaks: int = Query(200, ge=50, le=2000, description="Number of amplitude peaks to return"),
+    num_peaks: int = Query(
+        200,
+        ge=50,
+        le=50000,
+        description="Number of amplitude peaks to return (up to ~150/s for zoom).",
+    ),
 ) -> PeaksResponse:
     """Get waveform amplitude peak data for a file.
 

--- a/backend/api/rekordbox.py
+++ b/backend/api/rekordbox.py
@@ -205,6 +205,7 @@ class CueModel(BaseModel):
     timeMs: int
     color: str | None = None
     comment: str | None = None
+    outMs: int | None = None  # loop end (ms) for loop cues, else null
 
 
 class TrackAnalysisResponse(BaseModel):
@@ -233,7 +234,14 @@ def get_track_analysis(track_id: str, device: str | None = DeviceParam) -> Track
             else None
         ),
         cues=[
-            CueModel(type=c.type, index=c.index, timeMs=c.time_ms, color=c.color, comment=c.comment)
+            CueModel(
+                type=c.type,
+                index=c.index,
+                timeMs=c.time_ms,
+                color=c.color,
+                comment=c.comment,
+                outMs=c.out_ms,
+            )
             for c in analysis.cues
         ],
     )

--- a/backend/api/rekordbox.py
+++ b/backend/api/rekordbox.py
@@ -151,26 +151,30 @@ def get_track_artwork(track_id: str, small: bool = True, device: str | None = De
     )
 
 
+_WAVEFORM_GETTERS = {
+    "color": "get_track_waveform_preview",
+    "blue": "get_track_waveform_blue",
+    "color_detail": "get_track_waveform_color_detail",
+    "blue_detail": "get_track_waveform_blue_detail",
+}
+
+
 @router.get("/tracks/{track_id}/waveform")
 def get_track_waveform(
     track_id: str,
     device: str | None = DeviceParam,
-    variant: str = Query("color", pattern="^(color|blue)$"),
+    variant: str = Query("color", pattern="^(color|blue|color_detail|blue_detail)$"),
 ) -> Response:
-    """Serve a track's raw ANLZ preview waveform bytes.
+    """Serve a track's raw ANLZ waveform bytes for the frontend canvas.
 
-    ``variant=color`` (default) returns the PWV4 colour preview (7200 bytes:
-    1200 x 6). ``variant=blue`` returns the PWAV monochrome preview (400 bytes:
-    400 x 1, 5-bit height + 3-bit whiteness). The frontend decodes the byte
-    stream onto a canvas to render the waveform.
+    Preview variants span the whole track: ``color`` = PWV4 (1200 x 6 bytes),
+    ``blue`` = PWAV (400 x 1). Detail variants carry ~150 columns/second for
+    zoomed playback: ``color_detail`` = PWV5 (2 bytes/column, ``.EXT``),
+    ``blue_detail`` = PWV3 (1 byte/column, ``.DAT``).
     """
     source = rb_service.get_source(device)
     try:
-        data = (
-            source.get_track_waveform_blue(track_id)
-            if variant == "blue"
-            else source.get_track_waveform_preview(track_id)
-        )
+        data = getattr(source, _WAVEFORM_GETTERS[variant])(track_id)
     except rb_service.RekordboxUnavailable as exc:
         raise _unavailable(str(exc)) from exc
     if data is None:
@@ -179,6 +183,59 @@ def get_track_waveform(
         content=data,
         media_type="application/octet-stream",
         headers={"Cache-Control": "private, max-age=3600"},
+    )
+
+
+class BeatModel(BaseModel):
+    beat: int
+    bpm: float
+    timeMs: int
+
+
+class SectionModel(BaseModel):
+    kind: str
+    label: str
+    startMs: int
+    endMs: int
+
+
+class CueModel(BaseModel):
+    type: str
+    index: int | None = None
+    timeMs: int
+    color: str | None = None
+    comment: str | None = None
+
+
+class TrackAnalysisResponse(BaseModel):
+    beatgrid: list[BeatModel]
+    sections: list[SectionModel] | None = None
+    cues: list[CueModel]
+
+
+@router.get("/tracks/{track_id}/analysis", response_model=TrackAnalysisResponse)
+def get_track_analysis(track_id: str, device: str | None = DeviceParam) -> TrackAnalysisResponse:
+    """Return a track's beatgrid, phrase sections and cues as JSON.
+
+    Drives the zoomed player overlay: beat ticks, the phrase band and cue
+    markers. ``sections`` is ``null`` when the track has no phrase analysis;
+    beatgrid/cues degrade to empty lists rather than 404 when analysis is absent.
+    """
+    try:
+        analysis = rb_service.get_source(device).get_track_analysis(track_id)
+    except rb_service.RekordboxUnavailable as exc:
+        raise _unavailable(str(exc)) from exc
+    return TrackAnalysisResponse(
+        beatgrid=[BeatModel(beat=b.beat, bpm=b.bpm, timeMs=b.time_ms) for b in analysis.beatgrid],
+        sections=(
+            [SectionModel(kind=s.kind, label=s.label, startMs=s.start_ms, endMs=s.end_ms) for s in analysis.sections]
+            if analysis.sections is not None
+            else None
+        ),
+        cues=[
+            CueModel(type=c.type, index=c.index, timeMs=c.time_ms, color=c.color, comment=c.comment)
+            for c in analysis.cues
+        ],
     )
 
 

--- a/backend/core/services/rekordbox/analysis.py
+++ b/backend/core/services/rekordbox/analysis.py
@@ -18,7 +18,7 @@ Rekordbox applies to exported/USB ``PSSI`` tags.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -44,6 +44,7 @@ class Cue:
     time_ms: int
     color: str | None  # "#RRGGBB" when the cue carries a colour, else None
     comment: str | None
+    out_ms: int | None = None  # loop end (ms) when the cue is a loop, else None
 
 
 @dataclass(frozen=True)
@@ -345,3 +346,38 @@ def read_analysis(dat_path: str | None, dat_mtime: int, ext_path: str | None, ex
         The parsed :class:`TrackAnalysis`.
     """
     return _read_analysis_cached(dat_path, dat_mtime, ext_path, ext_mtime)
+
+
+def cues_from_db_rows(rows: Iterable[object]) -> list[Cue]:
+    """Map Rekordbox ``djmdCue`` rows to :class:`Cue`.
+
+    Rekordbox 6 keeps cues in ``master.db`` (the ``djmdCue`` table), not in the
+    local ANLZ sidecars — whose ``PCOB``/``PCO2`` tags stay empty until a USB
+    export writes them. ``Kind`` is ``0`` for a memory cue and the 1-based
+    hot-cue slot (``1`` = A) otherwise; ``InMsec`` is the cue time. ``OutMsec``
+    (when greater than the in-point) marks a loop's end, carried through so the
+    player can re-arm the loop.
+    """
+    cues: list[Cue] = []
+    for r in rows:
+        in_ms = getattr(r, "InMsec", None)
+        if in_ms is None or int(in_ms) < 0:
+            continue
+        in_ms = int(in_ms)
+        kind = int(getattr(r, "Kind", 0) or 0)
+        is_hot = kind >= 1
+        out_raw = getattr(r, "OutMsec", None)
+        out_ms = int(out_raw) if out_raw is not None and int(out_raw) > in_ms else None
+        comment = getattr(r, "Comment", None) or None
+        cues.append(
+            Cue(
+                type="hot" if is_hot else "memory",
+                index=kind if is_hot else None,
+                time_ms=in_ms,
+                color=None,
+                comment=comment,
+                out_ms=out_ms,
+            )
+        )
+    cues.sort(key=lambda c: c.time_ms)
+    return cues

--- a/backend/core/services/rekordbox/analysis.py
+++ b/backend/core/services/rekordbox/analysis.py
@@ -1,0 +1,347 @@
+"""Rekordbox ANLZ analysis parsing: beatgrid, phrase sections, cues.
+
+The preview/detail *waveform* bytes are extracted by the lightweight scanners in
+:mod:`.base` and streamed to the frontend untouched. The structured analysis
+here — beat positions, phrase (song-structure) sections, and hot/memory cues — is
+parsed server-side into JSON so the player can draw a beatgrid, a phrase band and
+cue markers over the zoomed waveform.
+
+Beatgrid and cues live in the ``.DAT`` file; phrase sections and the extended
+nxs2 cues live in the ``.EXT``. We reuse :mod:`pyrekordbox`'s ``construct`` tag
+definitions (already a dependency) for the fiddly variable-length cue and
+song-structure records rather than hand-rolling them, but only feed them the
+small tags we care about — never the multi-hundred-KB detail waveform — so the
+parse stays fast. The one piece of logic we replicate is the XOR "garbage mask"
+Rekordbox applies to exported/USB ``PSSI`` tags.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Beat:
+    """A single beatgrid tick."""
+
+    beat: int  # position in the bar, 1-4 (1 = downbeat)
+    bpm: float
+    time_ms: int
+
+
+@dataclass(frozen=True)
+class Cue:
+    """A memory point or hot cue."""
+
+    type: str  # "hot" or "memory"
+    index: int | None  # hot-cue slot (1-based), None for memory cues
+    time_ms: int
+    color: str | None  # "#RRGGBB" when the cue carries a colour, else None
+    comment: str | None
+
+
+@dataclass(frozen=True)
+class Section:
+    """A phrase (song-structure) region, resolved to a time span."""
+
+    kind: str  # normalized: intro/up/down/verse/bridge/chorus/outro/other
+    label: str  # human label, e.g. "Verse 2"
+    start_ms: int
+    end_ms: int
+
+
+@dataclass(frozen=True)
+class TrackAnalysis:
+    """Structured ANLZ analysis for one track."""
+
+    beatgrid: list[Beat]
+    sections: list[Section] | None  # None when the track has no phrase analysis
+    cues: list[Cue]
+
+
+# Phrase labels by (mood, kind), per the deep-symmetry ANLZ analysis. Mood is
+# High=1, Mid=2, Low=3; kind indexes into a mood-specific vocabulary.
+_PHRASE_LABELS: dict[int, dict[int, str]] = {
+    1: {1: "Intro", 2: "Up", 3: "Down", 5: "Chorus", 6: "Outro"},
+    2: {
+        1: "Intro",
+        2: "Verse 1",
+        3: "Verse 2",
+        4: "Verse 3",
+        5: "Verse 4",
+        6: "Verse 5",
+        7: "Verse 6",
+        8: "Bridge",
+        9: "Chorus",
+        10: "Outro",
+    },
+    3: {
+        1: "Intro",
+        2: "Verse 1",
+        3: "Verse 1",
+        4: "Verse 2",
+        5: "Verse 2",
+        6: "Verse 3",
+        7: "Verse 3",
+        8: "Bridge",
+        9: "Chorus",
+        10: "Outro",
+    },
+}
+
+
+def _normalize_kind(label: str) -> str:
+    """Map a phrase label to a stable kind slug for colouring."""
+    lower = label.lower()
+    for kind in ("intro", "verse", "bridge", "chorus", "outro", "up", "down"):
+        if lower.startswith(kind):
+            return kind
+    return "other"
+
+
+def _walk_tags(data: bytes) -> Iterator[tuple[str, bytes]]:
+    """Yield ``(fourcc, tag_bytes)`` for each ANLZ section without parsing content.
+
+    ``tag_bytes`` spans the whole tag (its generic header + body), ready to hand
+    to a ``construct`` struct.
+    """
+    if len(data) < 8 or data[:4] != b"PMAI":
+        return
+    pos = int.from_bytes(data[4:8], "big")
+    while pos + 12 <= len(data):
+        fourcc = data[pos : pos + 4]
+        len_tag = int.from_bytes(data[pos + 8 : pos + 12], "big")
+        if len_tag <= 0 or pos + len_tag > len(data):
+            return
+        try:
+            name = fourcc.decode("ascii")
+        except UnicodeDecodeError:
+            return
+        yield name, data[pos : pos + len_tag]
+        pos += len_tag
+
+
+# -- Beatgrid (PQTZ) -------------------------------------------------------------
+
+
+def parse_beatgrid(dat: bytes | None) -> list[Beat]:
+    """Parse the PQTZ beatgrid tag from ``.DAT`` bytes."""
+    if not dat:
+        return []
+    for name, tag in _walk_tags(dat):
+        if name != "PQTZ":
+            continue
+        # Content after the 12-byte generic header: u1(4) + u2(4) + entry_count(4),
+        # then 8-byte ticks (beat u16, tempo u16 = BPM*100, time u32 ms).
+        count = int.from_bytes(tag[20:24], "big")
+        beats: list[Beat] = []
+        base = 24
+        for i in range(count):
+            off = base + i * 8
+            if off + 8 > len(tag):
+                break
+            beat = int.from_bytes(tag[off : off + 2], "big")
+            tempo = int.from_bytes(tag[off + 2 : off + 4], "big")
+            time_ms = int.from_bytes(tag[off + 4 : off + 8], "big")
+            beats.append(Beat(beat=beat, bpm=tempo / 100.0, time_ms=time_ms))
+        return beats
+    return []
+
+
+def _beat_to_ms(beat_number: int, beatgrid: list[Beat]) -> int:
+    """Convert a 1-based global beat number to a time in ms via the beatgrid."""
+    if not beatgrid:
+        return 0
+    idx = max(0, min(beat_number - 1, len(beatgrid) - 1))
+    return beatgrid[idx].time_ms
+
+
+# -- Cues (PCO2 preferred, PCOB fallback) ---------------------------------------
+
+
+def _parse_pco2(tag: bytes) -> list[Cue]:
+    """Parse an extended (nxs2) PCO2 cue tag via pyrekordbox's construct struct."""
+    from pyrekordbox.anlz import structs
+
+    parsed = structs.AnlzTag.parse(tag)
+    cues: list[Cue] = []
+    for e in parsed.content.entries:
+        hot = int(e.hot_cue)
+        color = None
+        if e.color_red or e.color_green or e.color_blue:
+            color = f"#{e.color_red:02x}{e.color_green:02x}{e.color_blue:02x}"
+        comment = str(e.comment) if e.comment else None
+        cues.append(
+            Cue(
+                type="hot" if hot else "memory",
+                index=hot or None,
+                time_ms=int(e.time),
+                color=color,
+                comment=comment,
+            )
+        )
+    return cues
+
+
+def _parse_pcob(tag: bytes) -> list[Cue]:
+    """Parse a legacy PCOB cue tag via pyrekordbox's construct struct."""
+    from pyrekordbox.anlz import structs
+
+    parsed = structs.AnlzTag.parse(tag)
+    cues: list[Cue] = []
+    for e in parsed.content.entries:
+        hot = int(e.hot_cue)
+        cues.append(
+            Cue(
+                type="hot" if hot else "memory",
+                index=hot or None,
+                time_ms=int(e.time),
+                color=None,
+                comment=None,
+            )
+        )
+    return cues
+
+
+def _collect_cues(fourcc: str, parse, *blobs: bytes | None) -> list[Cue]:
+    """Parse every ``fourcc`` cue tag across ``blobs`` with ``parse``, deduped."""
+    cues: list[Cue] = []
+    seen: set[tuple[str, int | None, int]] = set()
+    for blob in blobs:
+        if not blob:
+            continue
+        for name, tag in _walk_tags(blob):
+            if name != fourcc:
+                continue
+            try:
+                parsed = parse(tag)
+            except Exception:
+                logger.debug("Failed to parse %s cue tag", fourcc, exc_info=True)
+                continue
+            for cue in parsed:
+                key = (cue.type, cue.index, cue.time_ms)
+                if key not in seen:
+                    seen.add(key)
+                    cues.append(cue)
+    return cues
+
+
+def parse_cues(dat: bytes | None, ext: bytes | None) -> list[Cue]:
+    """Parse cues, preferring extended nxs2 (PCO2) over legacy (PCOB) tags.
+
+    PCO2 lives in the ``.EXT`` and carries colours/comments; when a track has it
+    we use it exclusively. Otherwise we fall back to PCOB (present in both files).
+    """
+    pco2 = _collect_cues("PCO2", _parse_pco2, ext, dat)
+    cues = pco2 if pco2 else _collect_cues("PCOB", _parse_pcob, dat, ext)
+    return sorted(cues, key=lambda c: c.time_ms)
+
+
+# -- Phrase sections (PSSI, with XOR unmask) ------------------------------------
+
+
+def _unmask_pssi(tag: bytes) -> bytes:
+    """Undo the XOR "garbage mask" Rekordbox applies to exported PSSI tags.
+
+    Exported/USB files scramble every byte past offset 18 with a fixed pattern
+    offset by ``len_entries``. A tag is scrambled when its raw mood byte falls
+    outside the valid 1-3 range. Logic mirrors :mod:`pyrekordbox.anlz.file`.
+    """
+    from pyrekordbox.anlz.file import XOR_MASK
+
+    if len(tag) < 20:
+        return tag
+    mood = int.from_bytes(tag[18:20], "big")
+    if 1 <= mood <= 3:
+        return tag  # not scrambled
+    len_entries = int.from_bytes(tag[16:18], "big")
+    out = bytearray(tag)
+    for x in range(len(out) - 18):
+        mask = (XOR_MASK[x % len(XOR_MASK)] + len_entries) & 0xFF
+        out[18 + x] ^= mask
+    return bytes(out)
+
+
+def parse_sections(ext: bytes | None, beatgrid: list[Beat]) -> list[Section] | None:
+    """Parse the PSSI phrase tag and resolve each phrase to a time span.
+
+    Returns ``None`` when no phrase analysis exists (common: not every track is
+    phrase-analysed, and older ``.EXT`` files omit PSSI).
+    """
+    if not ext or not beatgrid:
+        return None
+    from pyrekordbox.anlz import structs
+
+    for name, tag in _walk_tags(ext):
+        if name != "PSSI":
+            continue
+        try:
+            parsed = structs.AnlzTag.parse(_unmask_pssi(tag))
+        except Exception:
+            logger.debug("Failed to parse PSSI tag", exc_info=True)
+            return None
+        content = parsed.content
+        mood = int(content.mood)
+        labels = _PHRASE_LABELS.get(mood, {})
+        entries = sorted(content.entries, key=lambda e: int(e.beat))
+        sections: list[Section] = []
+        for i, e in enumerate(entries):
+            start_beat = int(e.beat)
+            end_beat = int(entries[i + 1].beat) if i + 1 < len(entries) else int(content.end_beat)
+            label = labels.get(int(e.kind), f"Phrase {int(e.kind)}")
+            sections.append(
+                Section(
+                    kind=_normalize_kind(label),
+                    label=label,
+                    start_ms=_beat_to_ms(start_beat, beatgrid),
+                    end_ms=_beat_to_ms(end_beat, beatgrid),
+                )
+            )
+        return sections or None
+    return None
+
+
+# -- Cached entry point ---------------------------------------------------------
+
+
+@lru_cache(maxsize=512)
+def _read_analysis_cached(dat_path: str | None, dat_mtime: int, ext_path: str | None, ext_mtime: int) -> TrackAnalysis:
+    dat = None
+    ext = None
+    try:
+        if dat_path:
+            dat = Path(dat_path).read_bytes()
+    except OSError:
+        dat = None
+    try:
+        if ext_path:
+            ext = Path(ext_path).read_bytes()
+    except OSError:
+        ext = None
+    beatgrid = parse_beatgrid(dat)
+    return TrackAnalysis(
+        beatgrid=beatgrid,
+        sections=parse_sections(ext, beatgrid),
+        cues=parse_cues(dat, ext),
+    )
+
+
+def read_analysis(dat_path: str | None, dat_mtime: int, ext_path: str | None, ext_mtime: int) -> TrackAnalysis:
+    """Read and parse a track's ANLZ analysis, cached on ``(path, mtime)`` pairs.
+
+    Args:
+        dat_path: Absolute ``.DAT`` path, or ``None``.
+        dat_mtime: ``.DAT`` mtime in ns (cache key; 0 when absent).
+        ext_path: Absolute ``.EXT`` path, or ``None``.
+        ext_mtime: ``.EXT`` mtime in ns (cache key; 0 when absent).
+
+    Returns:
+        The parsed :class:`TrackAnalysis`.
+    """
+    return _read_analysis_cached(dat_path, dat_mtime, ext_path, ext_mtime)

--- a/backend/core/services/rekordbox/base.py
+++ b/backend/core/services/rekordbox/base.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
+from .analysis import TrackAnalysis, read_analysis
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,6 +103,52 @@ class RekordboxSource(ABC):
     @abstractmethod
     def get_track_waveform_blue(self, track_id: str) -> bytes | None:
         """Return the raw PWAV monochrome-preview entry bytes, or ``None``."""
+
+    @abstractmethod
+    def get_analysis_paths(self, track_id: str) -> tuple[Path | None, Path | None]:
+        """Return the ``(.DAT, .EXT)`` ANLZ sidecar paths for a track.
+
+        Either element is ``None`` when the corresponding file is absent (a track
+        may have no analysis at all, or an older ``.DAT``-only analysis without
+        the ``.EXT`` colour/phrase data). Existence is checked here so callers can
+        assume a returned path is readable.
+        """
+
+    def get_track_waveform_color_detail(self, track_id: str) -> bytes | None:
+        """Return raw PWV5 colour-detail bytes (2 B/column, ~150/s), or ``None``.
+
+        This is the high-resolution waveform used for zoomed playback, decoded on
+        the frontend canvas. Lives in the ``.EXT`` sidecar.
+        """
+        _, ext = self.get_analysis_paths(track_id)
+        if ext is None:
+            return None
+        return read_pwv5(str(ext), ext.stat().st_mtime_ns)
+
+    def get_track_waveform_blue_detail(self, track_id: str) -> bytes | None:
+        """Return raw PWV3 monochrome-detail bytes (1 B/column, ~150/s), or ``None``.
+
+        Zoom fallback when no ``.EXT`` colour detail exists. Lives in the ``.DAT``.
+        """
+        dat, _ = self.get_analysis_paths(track_id)
+        if dat is None:
+            return None
+        return read_pwv3(str(dat), dat.stat().st_mtime_ns)
+
+    def get_track_analysis(self, track_id: str) -> TrackAnalysis:
+        """Return the beatgrid, phrase sections, and cues for a track.
+
+        Beatgrid and cues come from the ``.DAT``; phrase sections and extended
+        (nxs2) cues from the ``.EXT``. Missing files degrade to empty lists /
+        ``None`` sections rather than raising.
+        """
+        dat, ext = self.get_analysis_paths(track_id)
+        return read_analysis(
+            str(dat) if dat else None,
+            dat.stat().st_mtime_ns if dat else 0,
+            str(ext) if ext else None,
+            ext.stat().st_mtime_ns if ext else 0,
+        )
 
 
 def extract_soundcloud_id(comment: str | None) -> int | None:
@@ -239,5 +287,74 @@ def read_pwav(path: str, mtime_ns: int) -> bytes | None:
     """
     try:
         return extract_pwav(Path(path).read_bytes())
+    except OSError:
+        return None
+
+
+def _extract_detail_entries(data: bytes, fourcc: bytes, entry_bytes: int) -> bytes | None:
+    """Extract raw entry bytes of a fixed-width detail-waveform tag.
+
+    PWV5 (colour detail, ``.EXT``) and PWV3 (monochrome detail, ``.DAT``) share
+    the PWV4 tag layout: a 24-byte header (generic ``fourcc`` + len_header +
+    len_tag, then len_entry_bytes + len_entries + unknown) followed by
+    ``len_entries`` fixed-width columns. Both carry ~150 columns per second, so a
+    multi-minute track yields tens of thousands of columns — enough resolution to
+    zoom to a few bars. Walks the section list directly (see :func:`extract_pwv4`)
+    rather than construct-parsing the whole file.
+
+    Args:
+        data: Full contents of an ANLZ file.
+        fourcc: The tag identifier (``b"PWV5"`` or ``b"PWV3"``).
+        entry_bytes: Expected bytes per column (2 for PWV5, 1 for PWV3).
+
+    Returns:
+        The raw entry bytes, or ``None`` if the tag is absent or malformed.
+    """
+    if len(data) < 8 or data[:4] != b"PMAI":
+        return None
+    pos = int.from_bytes(data[4:8], "big")
+    while pos + 12 <= len(data):
+        tag = data[pos : pos + 4]
+        len_tag = int.from_bytes(data[pos + 8 : pos + 12], "big")
+        if len_tag <= 0:
+            return None
+        if tag == fourcc:
+            if pos + 24 > len(data):
+                return None
+            n_bytes = int.from_bytes(data[pos + 12 : pos + 16], "big")
+            n_entries = int.from_bytes(data[pos + 16 : pos + 20], "big")
+            start = pos + 24
+            end = start + n_bytes * n_entries
+            if n_bytes != entry_bytes or end > len(data):
+                return None
+            return data[start:end]
+        pos += len_tag
+    return None
+
+
+def extract_pwv5(data: bytes) -> bytes | None:
+    """Extract PWV5 colour-detail entry bytes (2 bytes/column) from a ``.EXT``."""
+    return _extract_detail_entries(data, b"PWV5", 2)
+
+
+def extract_pwv3(data: bytes) -> bytes | None:
+    """Extract PWV3 monochrome-detail entry bytes (1 byte/column) from a ``.DAT``."""
+    return _extract_detail_entries(data, b"PWV3", 1)
+
+
+@lru_cache(maxsize=256)
+def read_pwv5(path: str, mtime_ns: int) -> bytes | None:
+    """Read and extract PWV5 colour-detail bytes from an ANLZ ``.EXT``, cached."""
+    try:
+        return extract_pwv5(Path(path).read_bytes())
+    except OSError:
+        return None
+
+
+@lru_cache(maxsize=256)
+def read_pwv3(path: str, mtime_ns: int) -> bytes | None:
+    """Read and extract PWV3 monochrome-detail bytes from an ANLZ ``.DAT``, cached."""
+    try:
+        return extract_pwv3(Path(path).read_bytes())
     except OSError:
         return None

--- a/backend/core/services/rekordbox/local.py
+++ b/backend/core/services/rekordbox/local.py
@@ -235,6 +235,20 @@ class LocalMasterDbSource(RekordboxSource):
             return None
         return read_pwav(str(dat), mtime_ns)
 
+    def get_analysis_paths(self, track_id: str) -> tuple[Path | None, Path | None]:
+        """Return the ``(.DAT, .EXT)`` ANLZ sidecar paths for a track."""
+        db = self._open_db()
+        row = db.get_content(ID=track_id)
+        if row is None:
+            return None, None
+        rel = getattr(row, "AnalysisDataPath", None)
+        if not rel:
+            return None, None
+        base = self._resolve_relative(str(rel))
+        dat = base.with_suffix(".DAT")
+        ext = base.with_suffix(".EXT")
+        return (dat if dat.exists() else None, ext if ext.exists() else None)
+
     def list_all_tracks(self, limit: int | None = None) -> list[RekordboxTrack]:
         """Return all tracks in the collection."""
         db = self._open_db()

--- a/backend/core/services/rekordbox/local.py
+++ b/backend/core/services/rekordbox/local.py
@@ -14,6 +14,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
+from .analysis import Cue, TrackAnalysis, cues_from_db_rows
 from .base import (
     RekordboxPlaylist,
     RekordboxSource,
@@ -248,6 +249,31 @@ class LocalMasterDbSource(RekordboxSource):
         dat = base.with_suffix(".DAT")
         ext = base.with_suffix(".EXT")
         return (dat if dat.exists() else None, ext if ext.exists() else None)
+
+    def get_track_analysis(self, track_id: str) -> TrackAnalysis:
+        """Beatgrid + sections from the ANLZ sidecars, cues from ``master.db``.
+
+        Rekordbox 6 stores cues in the ``djmdCue`` table, leaving the local
+        ANLZ ``PCOB``/``PCO2`` tags empty, so the base ANLZ parse returns no
+        cues here. We overlay the database cues instead.
+        """
+        analysis = super().get_track_analysis(track_id)
+        cues = self._read_db_cues(track_id)
+        if not cues:
+            return analysis
+        from dataclasses import replace
+
+        return replace(analysis, cues=cues)
+
+    def _read_db_cues(self, track_id: str) -> list[Cue]:
+        """Read a track's cues from the ``djmdCue`` table (empty on any error)."""
+        try:
+            db = self._open_db()
+            rows = list(db.get_cue(ContentID=track_id))
+        except Exception:
+            logger.debug("Failed to read cues for %s", track_id, exc_info=True)
+            return []
+        return cues_from_db_rows(rows)
 
     def list_all_tracks(self, limit: int | None = None) -> list[RekordboxTrack]:
         """Return all tracks in the collection."""

--- a/backend/core/services/rekordbox/usb.py
+++ b/backend/core/services/rekordbox/usb.py
@@ -263,3 +263,16 @@ class UsbExportSource(RekordboxSource):
         except OSError:
             return None
         return read_pwav(str(dat), mtime_ns)
+
+    def get_analysis_paths(self, track_id: str) -> tuple[Path | None, Path | None]:
+        """Return the ``(.DAT, .EXT)`` ANLZ sidecar paths for a track."""
+        rows = self._query("SELECT analysisDataFilePath FROM content WHERE content_id = ?", (track_id,))
+        if not rows:
+            return None, None
+        rel = _clean(rows[0]["analysisDataFilePath"])
+        if not rel:
+            return None, None
+        base = self._resolve(rel)
+        dat = base.with_suffix(".DAT")
+        ext = base.with_suffix(".EXT")
+        return (dat if dat.exists() else None, ext if ext.exists() else None)

--- a/frontend/e2e/audio-output-disconnect.spec.ts
+++ b/frontend/e2e/audio-output-disconnect.spec.ts
@@ -7,7 +7,108 @@ import { expect, test } from "./fixtures";
  * "playing" with no sound. The fix listens for the audio element's `pause`
  * event and propagates it to the player context when it wasn't us who
  * initiated it.
+ *
+ * Local files now play through Web Audio (no <audio> element), so the
+ * element-`pause` path is exercised via a SoundCloud (HLS) track, which still
+ * uses an <audio> element. The device-count-drop path below covers both
+ * backends and is checked against a local track.
  */
+
+const SC_TRACK_ID = 42;
+
+/** ~3s silent WAV so the local Web Audio track keeps "playing" through the
+ * test instead of ending mid-way (which would confound the isPlaying state). */
+function makeSilentWav(): Buffer {
+  const numSamples = 24000;
+  const buf = Buffer.alloc(44 + numSamples);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + numSamples, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(8000, 24);
+  buf.writeUInt32LE(8000, 28);
+  buf.writeUInt16LE(1, 32);
+  buf.writeUInt16LE(8, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(numSamples, 40);
+  buf.fill(0x80, 44);
+  return buf;
+}
+
+/** Minimal SoundCloud setup: authed user + one likeable, streamable track. */
+async function setupSoundcloud(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: SC_TRACK_ID,
+            urn: `soundcloud:tracks:${SC_TRACK_ID}`,
+            title: "Disconnect me",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/disconnect-me",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  for (const url of [
+    "https://api.soundcloud.com/tracks*",
+    "https://api.soundcloud.com/me/playlists*",
+    "https://api.soundcloud.com/me/feed/tracks*",
+  ]) {
+    await page.route(url, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+  }
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+  await page.route("**/api/soundcloud/tracks/*/stream*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        url: "https://example.com/fake.m3u8",
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    }),
+  );
+}
 
 const MOCK_FILE = {
   file_path: "track.mp3",
@@ -39,57 +140,24 @@ test.describe("audio output disconnect", () => {
   test("OS-level pause on the <audio> element flips React state to paused", async ({
     page,
   }) => {
-    await page.route("**/api/metadata/folders/*/browse*", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          items: [MOCK_FILE],
-          total: 1,
-          page: 1,
-          size: 50,
-          pages: 1,
-        }),
-      }),
-    );
-    await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          items: [MOCK_FILE],
-          total: 1,
-          page: 1,
-          size: 50,
-          pages: 1,
-        }),
-      }),
-    );
-    await page.route("**/api/metadata/files/*/info", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_TRACK_INFO),
-      }),
-    );
-    await page.route("**/api/metadata/files/*/peaks*", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ peaks: Array(200).fill(0.3) }),
-      }),
-    );
+    await setupSoundcloud(page);
+    await page.goto("/library?source=soundcloud");
 
-    await page.goto("/library");
-    await page.waitForLoadState("networkidle");
-    await page.locator('[data-file-path="track.mp3"]').click();
+    const row = page.locator("[data-index]").first();
+    await expect(row).toContainText("Disconnect me");
+
+    // Start playback so the player has a current SC track (HLS → <audio>).
+    await row
+      .getByRole("button", { name: /play/i })
+      .first()
+      .click()
+      .catch(async () => {
+        await row.click();
+      });
 
     const player = page.getByTestId("waveform-player");
     await expect(player).toBeVisible();
 
-    // Click the toggle to start playback so isPlaying flips to true. (In
-    // headless tests the audio element may not actually emit sound, but the
-    // React state — which our pause handler reads via isPlayingRef — does.)
     const toggle = page.getByTestId("player-toggle");
     if ((await toggle.getAttribute("aria-label")) !== "Pause") {
       await toggle.click();
@@ -157,6 +225,13 @@ test.describe("audio output disconnect", () => {
         body: JSON.stringify({ peaks: Array(200).fill(0.3) }),
       }),
     );
+    await page.route("**/api/metadata/files/*/audio", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        body: makeSilentWav(),
+      }),
+    );
 
     // Stub enumerateDevices BEFORE navigation so the player effect's initial
     // count snapshot uses our two-output baseline. The listener pauses when a
@@ -197,8 +272,16 @@ test.describe("audio output disconnect", () => {
     }
     await expect(toggle).toHaveAttribute("aria-label", "Pause");
 
-    // Drop one output and fire devicechange — mirrors AirPods leaving the
-    // device list. The listener should observe the count decrease and pause.
+    // Fire an initial devicechange while the count is still 2 — this
+    // deterministically syncs the listener's baseline (its mount-time count is
+    // set asynchronously and can lag under parallel load).
+    await page.evaluate(() =>
+      navigator.mediaDevices.dispatchEvent(new Event("devicechange")),
+    );
+    await page.waitForTimeout(50);
+
+    // Now drop one output and fire again — mirrors AirPods leaving the device
+    // list. The listener observes the count decrease and pauses.
     await page.evaluate(() => {
       const w = window as unknown as { __outputCount: number };
       w.__outputCount = 1;

--- a/frontend/e2e/player-zoom.spec.ts
+++ b/frontend/e2e/player-zoom.spec.ts
@@ -74,7 +74,10 @@ const ANALYSIS = {
     { beat: 4, bpm: 124.5, timeMs: 1446 },
   ],
   sections: [{ kind: "intro", label: "Intro", startMs: 0, endMs: 1446 }],
-  cues: [{ type: "hot", index: 1, timeMs: 0, color: "#ff8800", comment: null }],
+  cues: [
+    { type: "hot", index: 1, timeMs: 0, color: "#ff8800", comment: null },
+    { type: "memory", index: null, timeMs: 50, color: null, comment: null },
+  ],
 };
 
 test.describe("Player zoom — Rekordbox track", () => {
@@ -142,6 +145,61 @@ test.describe("Player zoom — Rekordbox track", () => {
     await expect(player.getByText("1.1", { exact: true })).toBeVisible();
     // Phrase sections are marked on the whole-track overview, not the zoom strip.
     await expect(player.getByTestId("player-section").first()).toBeVisible();
+  });
+
+  test("overview shows numbered, clickable cue markers", async ({ page }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // Cues render as numbered colour squares (1, 2… in time order), each
+    // clickable to seek — the two mocked cues become "1" (hot) and "2" (memory).
+    const cues = player.getByTestId("player-cue");
+    await expect(cues).toHaveCount(2);
+    await expect(cues.filter({ hasText: "1" })).toHaveAttribute(
+      "data-cue-type",
+      "hot",
+    );
+    await expect(cues.filter({ hasText: "2" })).toHaveAttribute(
+      "data-cue-type",
+      "memory",
+    );
+    await cues.first().click();
+  });
+
+  test("CUE sets and recalls an in-memory cue point", async ({ page }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // No cue point yet.
+    await expect(page.getByTestId("player-cue-point")).toHaveCount(0);
+
+    // Pause (wait for it to register so CUE takes the "set" branch, not
+    // "recall"), then CUE sets a cue point marker on the overview.
+    await player.getByTestId("player-toggle").click();
+    await expect(player.getByRole("button", { name: "Play" })).toBeVisible();
+    await player.getByTestId("player-cue-btn").click();
+    await expect(page.getByTestId("player-cue-point")).toBeVisible();
+  });
+
+  test("LOOP controls appear when zoomed and toggle an active loop", async ({
+    page,
+  }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // Loop controls are hidden in the collapsed overview.
+    await expect(player.getByTestId("player-loop-btn")).toHaveCount(0);
+
+    // Zoom in → expanded → loop controls present but idle.
+    await player.getByRole("button", { name: "Zoom in" }).click();
+    const loopBtn = player.getByTestId("player-loop-btn");
+    await expect(loopBtn).toBeVisible();
+    await expect(page.getByTestId("player-loop-region")).toHaveCount(0);
+
+    // Toggle → active loop draws a region on the overview.
+    await loopBtn.click();
+    await expect(loopBtn).toHaveAttribute("data-active", "true");
+    await expect(page.getByTestId("player-loop-region")).toBeVisible();
   });
 
   test("zoom in reveals the scrolling detail strip, zoom out hides it", async ({

--- a/frontend/e2e/player-zoom.spec.ts
+++ b/frontend/e2e/player-zoom.spec.ts
@@ -2,9 +2,10 @@ import type { Page, Route } from "@playwright/test";
 
 import { expect, test } from "./fixtures";
 
-/** Minimal 100ms silent WAV (8kHz mono 8-bit PCM) so audio.duration resolves. */
+/** ~3s silent WAV (8kHz mono 8-bit PCM) so audio.duration resolves and the
+ * track doesn't end mid-test (which would race isPlaying-dependent flows). */
 function makeSilentWav(): Buffer {
-  const numSamples = 800;
+  const numSamples = 24000;
   const buf = Buffer.alloc(44 + numSamples);
   buf.write("RIFF", 0);
   buf.writeUInt32LE(36 + numSamples, 4);
@@ -75,7 +76,15 @@ const ANALYSIS = {
   ],
   sections: [{ kind: "intro", label: "Intro", startMs: 0, endMs: 1446 }],
   cues: [
-    { type: "hot", index: 1, timeMs: 0, color: "#ff8800", comment: null },
+    // Slot-A hot cue is a loop (has an out-point) → clicking re-arms the loop.
+    {
+      type: "hot",
+      index: 1,
+      timeMs: 0,
+      color: "#ff8800",
+      comment: null,
+      outMs: 2000,
+    },
     { type: "memory", index: null, timeMs: 50, color: null, comment: null },
   ],
 };
@@ -134,32 +143,52 @@ test.describe("Player zoom — Rekordbox track", () => {
     await expect(page.getByTestId("waveform-player")).toBeVisible();
   }
 
-  test("shows the analysed key and bar.beat readout in the player", async ({
-    page,
-  }) => {
+  test("shows the analysed key in the player", async ({ page }) => {
     await playFoo(page);
     const player = page.getByTestId("waveform-player");
     // Musical key from the Rekordbox analysis, shown next to the BPM.
     await expect(player.getByText("8A", { exact: true })).toBeVisible();
-    // bar.beat derived from the beatgrid (position 1.1 at the track start).
-    await expect(player.getByText("1.1", { exact: true })).toBeVisible();
     // Phrase sections are marked on the whole-track overview, not the zoom strip.
     await expect(player.getByTestId("player-section").first()).toBeVisible();
+  });
+
+  test("shows the pitched key, with the original + fractional shift below", async ({
+    page,
+  }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+    await expect(player.getByText("8A", { exact: true })).toBeVisible();
+
+    // Pitch 124.5 → 140 BPM: nearest whole semitone is +2 (8A → 10A), but the
+    // exact shift is fractional (+2.0 st).
+    await player.getByTestId("bpm-pitcher-trigger").click();
+    const input = page.getByTestId("bpm-pitcher-target-input");
+    await input.fill("140");
+    await input.press("Enter");
+    await page.getByTestId("bpm-pitcher-toggle").click();
+    await page.keyboard.press("Escape");
+
+    // Big label = pitched key, green.
+    const key = player.getByText("10A", { exact: true });
+    await expect(key).toBeVisible();
+    await expect(key).toHaveClass(/text-primary/);
+    // Below = original key + fractional semitone shift.
+    await expect(player.getByText("8A +2.0 st", { exact: true })).toBeVisible();
   });
 
   test("overview shows numbered, clickable cue markers", async ({ page }) => {
     await playFoo(page);
     const player = page.getByTestId("waveform-player");
 
-    // Cues render as numbered colour squares (1, 2… in time order), each
-    // clickable to seek — the two mocked cues become "1" (hot) and "2" (memory).
+    // Hot cues render colour-coded with their letter (slot 1 → "A"); memory
+    // cues are numbered from 1. Each is clickable to seek.
     const cues = player.getByTestId("player-cue");
     await expect(cues).toHaveCount(2);
-    await expect(cues.filter({ hasText: "1" })).toHaveAttribute(
+    await expect(cues.filter({ hasText: "A" })).toHaveAttribute(
       "data-cue-type",
       "hot",
     );
-    await expect(cues.filter({ hasText: "2" })).toHaveAttribute(
+    await expect(cues.filter({ hasText: "1" })).toHaveAttribute(
       "data-cue-type",
       "memory",
     );
@@ -181,17 +210,14 @@ test.describe("Player zoom — Rekordbox track", () => {
     await expect(page.getByTestId("player-cue-point")).toBeVisible();
   });
 
-  test("LOOP controls appear when zoomed and toggle an active loop", async ({
+  test("loop control lives in the top bar and toggles an active loop", async ({
     page,
   }) => {
     await playFoo(page);
     const player = page.getByTestId("waveform-player");
 
-    // Loop controls are hidden in the collapsed overview.
-    await expect(player.getByTestId("player-loop-btn")).toHaveCount(0);
-
-    // Zoom in → expanded → loop controls present but idle.
-    await player.getByRole("button", { name: "Zoom in" }).click();
+    // The merged loop control sits in the always-visible top utility bar — no
+    // need to zoom in first. Idle to start (no region drawn).
     const loopBtn = player.getByTestId("player-loop-btn");
     await expect(loopBtn).toBeVisible();
     await expect(page.getByTestId("player-loop-region")).toHaveCount(0);
@@ -202,31 +228,72 @@ test.describe("Player zoom — Rekordbox track", () => {
     await expect(page.getByTestId("player-loop-region")).toBeVisible();
   });
 
-  test("zoom in reveals the scrolling detail strip, zoom out hides it", async ({
+  test("top bar shows pressable hot cues", async ({ page }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // Both analysed cues (one hot, one memory) surface as pressable chips.
+    const hotcues = player.getByTestId("player-hotcue");
+    await expect(hotcues).toHaveCount(2);
+    await expect(hotcues.first()).toHaveAttribute("data-cue-type", "hot");
+    // Pressing one seeks — just assert it doesn't throw / stays mounted.
+    await hotcues.first().click();
+    await expect(player).toBeVisible();
+  });
+
+  test("loop hot cue re-arms its loop when clicked", async ({ page }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // No loop yet. The slot-A hot cue carries an out-point (it's a loop).
+    await expect(page.getByTestId("player-loop-region")).toHaveCount(0);
+    await player
+      .getByTestId("player-hotcue")
+      .filter({ hasText: "A" })
+      .first()
+      .click();
+    // Clicking it arms the loop region on the overview.
+    await expect(page.getByTestId("player-loop-region")).toBeVisible();
+  });
+
+  test("overview shows a play-position indicator", async ({ page }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+    await expect(player.getByTestId("player-overview-playhead")).toBeVisible();
+  });
+
+  test("detail toggle shows/hides the strip; +/- change the zoom level", async ({
     page,
   }) => {
     await playFoo(page);
     const player = page.getByTestId("waveform-player");
 
-    // Overview only to start — no detail strip.
+    // Overview only to start — no detail strip; the zoom stepper is hidden.
     await expect(page.getByTestId("player-detail-strip")).toHaveCount(0);
+    await expect(player.getByRole("button", { name: "Zoom in" })).toHaveCount(
+      0,
+    );
 
-    await player.getByRole("button", { name: "Zoom in" }).click();
+    // The dedicated toggle reveals the strip (and the zoom stepper) at the
+    // default zoom.
+    await player.getByTestId("player-detail-toggle").click();
     const strip = page.getByTestId("player-detail-strip");
     await expect(strip).toBeVisible();
-    await expect(strip).toHaveAttribute("data-zoom-bars", "128");
+    await expect(strip).toHaveAttribute("data-zoom-bars", "32");
     await expect(strip.locator("canvas")).toBeVisible();
 
-    // Zooming further in steps to a tighter window.
+    // +/- only change the zoom level — they never hide the strip.
     await player.getByRole("button", { name: "Zoom in" }).click();
-    await expect(strip).toHaveAttribute("data-zoom-bars", "64");
+    await expect(strip).toHaveAttribute("data-zoom-bars", "16");
+    await player.getByRole("button", { name: "Zoom out" }).click();
+    await expect(strip).toHaveAttribute("data-zoom-bars", "32");
 
-    // Collapse back to the overview (zoom out disables itself at the top level).
-    const zoomOut = player.getByRole("button", { name: "Zoom out" });
-    while (await zoomOut.isEnabled()) {
-      await zoomOut.click();
-    }
+    // The toggle hides both the strip and the stepper again.
+    await player.getByTestId("player-detail-toggle").click();
     await expect(page.getByTestId("player-detail-strip")).toHaveCount(0);
+    await expect(player.getByRole("button", { name: "Zoom in" })).toHaveCount(
+      0,
+    );
   });
 });
 
@@ -293,7 +360,7 @@ test.describe("Player zoom — local file", () => {
     const player = page.getByTestId("waveform-player");
     await expect(player).toBeVisible();
 
-    await player.getByRole("button", { name: "Zoom in" }).click();
+    await player.getByTestId("player-detail-toggle").click();
     await expect(page.getByTestId("player-detail-strip")).toBeVisible();
   });
 });

--- a/frontend/e2e/player-zoom.spec.ts
+++ b/frontend/e2e/player-zoom.spec.ts
@@ -1,0 +1,241 @@
+import type { Page, Route } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
+
+/** Minimal 100ms silent WAV (8kHz mono 8-bit PCM) so audio.duration resolves. */
+function makeSilentWav(): Buffer {
+  const numSamples = 800;
+  const buf = Buffer.alloc(44 + numSamples);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + numSamples, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(8000, 24);
+  buf.writeUInt32LE(8000, 28);
+  buf.writeUInt16LE(1, 32);
+  buf.writeUInt16LE(8, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(numSamples, 40);
+  buf.fill(0x80, 44);
+  return buf;
+}
+
+function jsonRoute(body: unknown) {
+  return (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+}
+
+const TINY_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==",
+  "base64",
+);
+
+const REK_TRACK = {
+  id: "t-1",
+  title: "Foo",
+  artist: "Bar",
+  album: null,
+  genre: "House",
+  bpm: 124.5,
+  key: "8A",
+  duration_seconds: 350,
+  file_path: "/music/foo.flac",
+  comment: null,
+  soundcloud_id: null,
+  date_added: "2024-01-15",
+  release_date: null,
+  has_artwork: true,
+  has_waveform: true,
+};
+
+const PLAYLISTS = [
+  {
+    id: "pl-1",
+    name: "Sunday Mix",
+    parent_id: null,
+    is_folder: false,
+    is_smart: false,
+    track_count: 1,
+  },
+];
+
+const ANALYSIS = {
+  beatgrid: [
+    { beat: 1, bpm: 124.5, timeMs: 0 },
+    { beat: 2, bpm: 124.5, timeMs: 482 },
+    { beat: 3, bpm: 124.5, timeMs: 964 },
+    { beat: 4, bpm: 124.5, timeMs: 1446 },
+  ],
+  sections: [{ kind: "intro", label: "Intro", startMs: 0, endMs: 1446 }],
+  cues: [{ type: "hot", index: 1, timeMs: 0, color: "#ff8800", comment: null }],
+};
+
+test.describe("Player zoom — Rekordbox track", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(
+      "**/api/rekordbox/status",
+      jsonRoute({ available: true, reason: null }),
+    );
+    await page.route(
+      "**/api/rekordbox/playlists",
+      jsonRoute({ playlists: PLAYLISTS }),
+    );
+    await page.route(
+      "**/api/rekordbox/playlists/pl-1/tracks",
+      jsonRoute({ tracks: [REK_TRACK] }),
+    );
+    await page.route("**/api/rekordbox/tracks/*/artwork*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/jpeg",
+        body: TINY_JPEG,
+      }),
+    );
+    // Preview + detail waveform bytes (any content; the canvas just paints).
+    await page.route("**/api/rekordbox/tracks/*/waveform*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/octet-stream",
+        body: Buffer.alloc(7200),
+      }),
+    );
+    await page.route(
+      "**/api/rekordbox/tracks/*/analysis*",
+      jsonRoute(ANALYSIS),
+    );
+    await page.route(
+      "**/api/metadata/files/*/peaks*",
+      jsonRoute({ peaks: Array(200).fill(0.3) }),
+    );
+    await page.route("**/api/metadata/files/*/audio", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        body: makeSilentWav(),
+      }),
+    );
+  });
+
+  async function playFoo(page: Page) {
+    await page.goto("/library?source=rekordbox");
+    await page.getByText("Sunday Mix").click();
+    const tracks = page.getByTestId("rekordbox-tracks");
+    await tracks.getByRole("button", { name: "Play Foo" }).click();
+    await expect(page.getByTestId("waveform-player")).toBeVisible();
+  }
+
+  test("shows the analysed key and bar.beat readout in the player", async ({
+    page,
+  }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+    // Musical key from the Rekordbox analysis, shown next to the BPM.
+    await expect(player.getByText("8A", { exact: true })).toBeVisible();
+    // bar.beat derived from the beatgrid (position 1.1 at the track start).
+    await expect(player.getByText("1.1", { exact: true })).toBeVisible();
+    // Phrase sections are marked on the whole-track overview, not the zoom strip.
+    await expect(player.getByTestId("player-section").first()).toBeVisible();
+  });
+
+  test("zoom in reveals the scrolling detail strip, zoom out hides it", async ({
+    page,
+  }) => {
+    await playFoo(page);
+    const player = page.getByTestId("waveform-player");
+
+    // Overview only to start — no detail strip.
+    await expect(page.getByTestId("player-detail-strip")).toHaveCount(0);
+
+    await player.getByRole("button", { name: "Zoom in" }).click();
+    const strip = page.getByTestId("player-detail-strip");
+    await expect(strip).toBeVisible();
+    await expect(strip).toHaveAttribute("data-zoom-bars", "128");
+    await expect(strip.locator("canvas")).toBeVisible();
+
+    // Zooming further in steps to a tighter window.
+    await player.getByRole("button", { name: "Zoom in" }).click();
+    await expect(strip).toHaveAttribute("data-zoom-bars", "64");
+
+    // Collapse back to the overview (zoom out disables itself at the top level).
+    const zoomOut = player.getByRole("button", { name: "Zoom out" });
+    while (await zoomOut.isEnabled()) {
+      await zoomOut.click();
+    }
+    await expect(page.getByTestId("player-detail-strip")).toHaveCount(0);
+  });
+});
+
+const MOCK_FILE = {
+  file_path: "track.mp3",
+  file_name: "track.mp3",
+  file_size: 5 * 1024 * 1024,
+  file_format: ".mp3",
+  has_artwork: false,
+};
+
+const MOCK_TRACK_INFO = {
+  file_path: "track.mp3",
+  file_name: "track.mp3",
+  title: "Test Track",
+  artist: "Test Artist",
+  bpm: null,
+  key: null,
+  genre: null,
+  comment: null,
+  release_date: null,
+  remixers: [],
+  has_artwork: false,
+  is_ready: false,
+  missing_fields: [],
+  issues: [],
+};
+
+test.describe("Player zoom — local file", () => {
+  test.beforeEach(async ({ page }) => {
+    const browse = jsonRoute({
+      items: [MOCK_FILE],
+      total: 1,
+      page: 1,
+      size: 50,
+      pages: 1,
+    });
+    await page.route("**/api/metadata/folders/*/browse*", browse);
+    await page.route(/\/api\/metadata\/folders\/browse-path\?/, browse);
+    await page.route(
+      "**/api/metadata/files/*/info",
+      jsonRoute(MOCK_TRACK_INFO),
+    );
+    await page.route(
+      "**/api/metadata/files/*/peaks*",
+      jsonRoute({ peaks: Array(200).fill(0.3) }),
+    );
+    await page.route("**/api/metadata/files/*/audio", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        headers: { "Accept-Ranges": "bytes" },
+        body: makeSilentWav(),
+      }),
+    );
+  });
+
+  test("local files are zoomable (no beatgrid, still expands)", async ({
+    page,
+  }) => {
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+    await page.locator('[data-file-path="track.mp3"]').click();
+    const player = page.getByTestId("waveform-player");
+    await expect(player).toBeVisible();
+
+    await player.getByRole("button", { name: "Zoom in" }).click();
+    await expect(page.getByTestId("player-detail-strip")).toBeVisible();
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -60,6 +60,20 @@
   --chart-4: oklch(0.68 0.16 305);
   --chart-5: oklch(0.7 0.13 105);
 
+  /* ── Phrase-band section palette ─────────────────────────────────────────────
+     One distinct hue per song-structure kind (intro/up/down/verse/bridge/
+     chorus/outro/other). Light enough to carry black labels; spread around the
+     wheel and ordered roughly by energy so the band reads at a glance. Theme-
+     independent — the band paints its own colour under black text either way. */
+  --section-intro: oklch(0.78 0.1 195); /* teal — calm start */
+  --section-verse: oklch(0.74 0.12 245); /* blue */
+  --section-up: oklch(0.82 0.13 80); /* amber — build-up */
+  --section-chorus: oklch(0.72 0.15 15); /* red-pink — drop / hook */
+  --section-down: oklch(0.72 0.12 285); /* indigo — breakdown */
+  --section-bridge: oklch(0.74 0.14 330); /* magenta */
+  --section-outro: oklch(0.77 0.12 150); /* green — wind-down */
+  --section-other: oklch(0.72 0.02 260); /* neutral grey */
+
   /* ── Radii (DESIGN.md §5) ────────────────────────────────────────────────── */
   --radius: 0.5rem;
 

--- a/frontend/src/app/library/rekordbox-view.tsx
+++ b/frontend/src/app/library/rekordbox-view.tsx
@@ -170,6 +170,7 @@ function toPlayerTrack(t: RekordboxTrack, device: string): PlayerTrack | null {
       : undefined,
     rekordboxId: t.has_waveform ? t.id : undefined,
     rekordboxDevice: usb ? device : undefined,
+    musicalKey: t.key ?? undefined,
     // USB tracks live on the device, not under the local root — stream them
     // through the device-scoped audio endpoint instead of the local file path.
     streamUrl: usb ? api.getRekordboxUsbAudioUrl(t.id, device) : undefined,

--- a/frontend/src/components/bpm-pitcher.tsx
+++ b/frontend/src/components/bpm-pitcher.tsx
@@ -239,27 +239,39 @@ export function BpmPitcher() {
           <button
             type="button"
             data-testid="bpm-pitcher-trigger"
-            className={cn(
-              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex h-10 cursor-pointer flex-col items-center justify-center rounded-md px-2 leading-none tabular-nums transition-colors",
-              pitchEnabled && "text-primary hover:text-primary",
-            )}
+            className="text-muted-foreground hover:bg-surface-3 flex h-10 cursor-pointer flex-col items-center justify-center rounded-md px-2 leading-none tabular-nums transition-colors"
             title="Target BPM"
             aria-label="Target BPM pitcher"
           >
             <span className="flex items-baseline gap-1">
-              <span className="text-xs font-medium">{bpmLabel}</span>
-              <span className="text-2xs opacity-70">BPM</span>
+              <span
+                className={cn(
+                  "text-xs font-semibold",
+                  pitchEnabled ? "text-primary" : "text-foreground",
+                )}
+              >
+                {bpmLabel}
+              </span>
+              {/* Label is never tinted — the value carries the pitch colour. */}
+              <span className="text-muted-foreground text-[8px] tracking-wider uppercase">
+                BPM
+              </span>
             </span>
             {pitchEnabled && currentBpm != null && (
               <span
                 data-testid="bpm-pitcher-rate-badge"
-                className={cn(
-                  "text-2xs mt-0.5 tabular-nums",
-                  ratePercent === 0 ? "opacity-60" : "text-primary",
-                )}
+                className="text-2xs mt-0.5 tabular-nums"
               >
-                {ratePercent > 0 ? "+" : ""}
-                {ratePercent.toFixed(1)}%
+                {/* Original BPM in gray; the delta carries the pitch colour. */}
+                <span className="text-muted-foreground">{currentBpm}</span>{" "}
+                <span
+                  className={
+                    ratePercent === 0 ? "text-muted-foreground" : "text-primary"
+                  }
+                >
+                  {ratePercent > 0 ? "+" : ""}
+                  {ratePercent.toFixed(1)}%
+                </span>
               </span>
             )}
           </button>

--- a/frontend/src/components/layout-shell.tsx
+++ b/frontend/src/components/layout-shell.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { usePlayer } from "@/lib/player-context";
-import { cn } from "@/lib/utils";
 
 export function LayoutShell({ children }: { children: React.ReactNode }) {
   const { currentTrack } = usePlayer();
   return (
     <main
-      className={cn(
-        "mt-11 ml-14 flex min-w-0 flex-1 flex-col overflow-hidden transition-[padding] duration-200 ease-out",
-        currentTrack && "pb-16",
-      )}
+      className="mt-11 ml-14 flex min-w-0 flex-1 flex-col overflow-hidden transition-[padding] duration-200 ease-out"
+      // Reserve exactly the player's height (published as --player-height); 0
+      // when nothing is playing.
+      style={{ paddingBottom: currentTrack ? "var(--player-height, 4rem)" : 0 }}
     >
       {children}
     </main>

--- a/frontend/src/components/player-detail-waveform.tsx
+++ b/frontend/src/components/player-detail-waveform.tsx
@@ -18,8 +18,27 @@ import {
   decodePwv3,
   decodePwv5,
   rgbCss,
+  textOn,
   type DetailWave,
 } from "@/lib/waveform-detail";
+
+/** Trace a rounded rectangle (no fill/stroke). */
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
 
 interface PlayerDetailWaveformProps {
   track: PlayerTrack;
@@ -31,6 +50,10 @@ interface PlayerDetailWaveformProps {
   bpm: number | null;
   /** Selected waveform style; picks colour vs blue detail for rekordbox tracks. */
   waveformStyle: WaveformStyle;
+  /** Active loop region (seconds), or `null` when no loop is set. */
+  loop?: { startSec: number; endSec: number } | null;
+  /** In-memory cue point (seconds), or `null`. */
+  cueSec?: number | null;
   className?: string;
 }
 
@@ -48,6 +71,8 @@ export function PlayerDetailWaveform({
   durationSec,
   bpm,
   waveformStyle,
+  loop,
+  cueSec,
   className,
 }: PlayerDetailWaveformProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -182,54 +207,118 @@ export function PlayerDetailWaveform({
         }
       }
 
-      // --- beat grid (rekordbox only); downbeats are emphasised + numbered ---
+      // --- loop region ---
+      if (loop) {
+        const x0 = timeToX(loop.startSec);
+        const x1 = timeToX(loop.endSec);
+        const green = isDark ? "#d0fd5a" : "#a8cd49";
+        ctx.fillStyle = isDark
+          ? "rgba(208,253,90,0.12)"
+          : "rgba(168,205,73,0.15)";
+        ctx.fillRect(x0, waveTop, x1 - x0, waveH);
+        ctx.strokeStyle = green;
+        ctx.lineWidth = 1;
+        ctx.strokeRect(x0 + 0.5, waveTop + 0.5, x1 - x0 - 1, waveH - 1);
+      }
+
+      // --- beat grid (rekordbox only) ---
+      // Bars (downbeats, every 4 beats) get a rekordbox-style marker: a subtly
+      // brighter line plus small red tips top & bottom. The three in-between
+      // beats are faint and only drawn when zoomed in enough to space them out,
+      // so a zoomed-out strip isn't a wall of lines.
       if (analysis?.beatgrid.length) {
+        const barPx = cssW / zoomBars; // px between bar starts (bpm cancels out)
+        const showBeats = barPx / 4 >= 10;
+        const showBarNums = barPx >= 26;
+        const red = isDark ? "#ff4a3d" : "#e0261c";
+        const tipW = 3; // half-width of the red bar tip
+        const tipH = 4;
         ctx.font = "8px ui-sans-serif, system-ui, sans-serif";
         ctx.textBaseline = "top";
         for (let i = 0; i < analysis.beatgrid.length; i++) {
           const b = analysis.beatgrid[i];
           const x = timeToX(b.timeMs / 1000);
-          if (x < 0 || x > cssW) continue;
+          if (x < -tipW || x > cssW + tipW) continue;
           const down = b.beat === 1;
-          ctx.strokeStyle = down
-            ? isDark
-              ? "rgba(255,255,255,0.45)"
-              : "rgba(0,0,0,0.4)"
-            : isDark
-              ? "rgba(255,255,255,0.16)"
-              : "rgba(0,0,0,0.14)";
-          ctx.lineWidth = 1;
-          ctx.beginPath();
-          ctx.moveTo(x + 0.5, waveTop);
-          ctx.lineTo(x + 0.5, cssH);
-          ctx.stroke();
           if (down) {
-            ctx.fillStyle = isDark
-              ? "rgba(255,255,255,0.5)"
-              : "rgba(0,0,0,0.45)";
-            ctx.fillText(String(downbeatPrefix[i]), x + 2, cssH - 10);
+            ctx.strokeStyle = isDark
+              ? "rgba(255,255,255,0.3)"
+              : "rgba(0,0,0,0.22)";
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(x + 0.5, waveTop);
+            ctx.lineTo(x + 0.5, cssH);
+            ctx.stroke();
+            ctx.fillStyle = red;
+            ctx.beginPath(); // top tip
+            ctx.moveTo(x - tipW, waveTop);
+            ctx.lineTo(x + tipW, waveTop);
+            ctx.lineTo(x, waveTop + tipH);
+            ctx.closePath();
+            ctx.fill();
+            ctx.beginPath(); // bottom tip
+            ctx.moveTo(x - tipW, cssH);
+            ctx.lineTo(x + tipW, cssH);
+            ctx.lineTo(x, cssH - tipH);
+            ctx.closePath();
+            ctx.fill();
+            if (showBarNums) {
+              ctx.fillStyle = isDark
+                ? "rgba(255,255,255,0.5)"
+                : "rgba(0,0,0,0.45)";
+              ctx.fillText(String(downbeatPrefix[i]), x + 3, cssH - 10);
+            }
+          } else if (showBeats) {
+            ctx.strokeStyle = isDark
+              ? "rgba(255,255,255,0.12)"
+              : "rgba(0,0,0,0.1)";
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(x + 0.5, waveTop);
+            ctx.lineTo(x + 0.5, cssH);
+            ctx.stroke();
           }
         }
       }
 
-      // --- cue markers ---
+      // --- cue markers (numbered colour squares, matching the overview) ---
       if (analysis?.cues.length) {
-        for (const c of analysis.cues) {
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.font = "bold 9px ui-sans-serif, system-ui, sans-serif";
+        for (let i = 0; i < analysis.cues.length; i++) {
+          const c = analysis.cues[i];
           const x = timeToX(c.timeMs / 1000);
-          if (x < -6 || x > cssW + 6) continue;
-          ctx.fillStyle = c.color ?? (c.type === "hot" ? "#f97316" : "#f43f5e");
+          if (x < -12 || x > cssW + 12) continue;
+          const color = c.color ?? (c.type === "hot" ? "#f97316" : "#ff4d6d");
+          ctx.globalAlpha = 0.55; // guide line
+          ctx.fillStyle = color;
+          ctx.fillRect(x - 0.5, waveTop, 1, waveH);
+          ctx.globalAlpha = 1;
+          const s = 12;
+          roundRectPath(ctx, x, waveTop, s, s, 2);
+          ctx.fillStyle = color;
+          ctx.fill();
+          ctx.fillStyle = textOn(color);
+          ctx.fillText(String(i + 1), x + s / 2, waveTop + s / 2 + 0.5);
+        }
+        ctx.textAlign = "left";
+        ctx.textBaseline = "top";
+      }
+
+      // --- in-memory cue point (amber flag) ---
+      if (cueSec != null) {
+        const x = timeToX(cueSec);
+        if (x >= -6 && x <= cssW + 6) {
+          const amber = "#f59e0b";
+          ctx.fillStyle = amber;
+          ctx.fillRect(x - 0.5, waveTop, 1, waveH);
           ctx.beginPath();
-          ctx.moveTo(x, waveTop);
-          ctx.lineTo(x - 4, waveTop);
-          ctx.lineTo(x, waveTop + 5);
+          ctx.moveTo(x - 5, waveTop);
+          ctx.lineTo(x + 5, waveTop);
+          ctx.lineTo(x, waveTop + 7);
           ctx.closePath();
           ctx.fill();
-          ctx.fillRect(x - 0.5, waveTop, 1, waveH);
-          if (c.type === "hot" && c.index != null) {
-            ctx.font = "8px ui-sans-serif, system-ui, sans-serif";
-            ctx.textBaseline = "top";
-            ctx.fillText(String(c.index), x + 2, waveTop + 1);
-          }
         }
       }
 
@@ -241,7 +330,17 @@ export function PlayerDetailWaveform({
       ctx.lineTo(cssW / 2, cssH);
       ctx.stroke();
     },
-    [size, durationSec, zoomBars, bpm, wave, analysis, downbeatPrefix],
+    [
+      size,
+      durationSec,
+      zoomBars,
+      bpm,
+      wave,
+      analysis,
+      downbeatPrefix,
+      loop,
+      cueSec,
+    ],
   );
 
   // Redraw on data/size change and subscribe to live progress.
@@ -253,28 +352,16 @@ export function PlayerDetailWaveform({
     });
   }, [draw, subscribeProgress]);
 
-  // Seek by grabbing the waveform: initial press jumps to the time under the
-  // cursor, then dragging scrubs relative to pointer movement.
-  const seekToClientX = useCallback(
-    (clientX: number, rect: DOMRect) => {
-      const span = barSpanSeconds(zoomBars, bpm);
-      const pps = rect.width / span;
-      const dx = clientX - rect.left - rect.width / 2;
-      const time = progressRef.current * durationSec + dx / pps;
-      if (durationSec > 0) seek(Math.max(0, Math.min(1, time / durationSec)));
-    },
-    [zoomBars, bpm, durationSec, seek],
-  );
-
+  // Grab-and-drag scrubbing: the press anchors the current position (no jump to
+  // the cursor); dragging then scrubs relative to pointer movement.
   const lastXRef = useRef(0);
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
       e.currentTarget.setPointerCapture(e.pointerId);
       draggingRef.current = true;
       lastXRef.current = e.clientX;
-      seekToClientX(e.clientX, e.currentTarget.getBoundingClientRect());
     },
-    [seekToClientX],
+    [],
   );
 
   const onPointerMove = useCallback(

--- a/frontend/src/components/player-detail-waveform.tsx
+++ b/frontend/src/components/player-detail-waveform.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import {
   barSpanSeconds,
   buildDownbeatPrefix,
+  computeCueDisplays,
   decodeFloatPeaks,
   decodePwv3,
   decodePwv5,
@@ -179,10 +180,15 @@ export function PlayerDetailWaveform({
       ctx.clearRect(0, 0, cssW, cssH);
       const isDark = document.documentElement.classList.contains("dark");
 
+      // Pad only the *waveform* amplitude 5% top and bottom (markers still span
+      // the full height) so the ends of the beat tips / cue markers read clearly
+      // against the quieter waveform.
+      const padY = cssH * 0.05;
       const waveTop = 0;
       const waveH = cssH;
-      const mid = waveH / 2;
-      const halfH = waveH / 2;
+      const waveBottom = cssH;
+      const mid = cssH / 2;
+      const halfH = cssH / 2 - padY;
 
       const span = barSpanSeconds(zoomBars, bpm); // seconds across the strip
       const t = progress * durationSec; // playhead time (s)
@@ -247,7 +253,7 @@ export function PlayerDetailWaveform({
             ctx.lineWidth = 1;
             ctx.beginPath();
             ctx.moveTo(x + 0.5, waveTop);
-            ctx.lineTo(x + 0.5, cssH);
+            ctx.lineTo(x + 0.5, waveBottom);
             ctx.stroke();
             ctx.fillStyle = red;
             ctx.beginPath(); // top tip
@@ -257,16 +263,16 @@ export function PlayerDetailWaveform({
             ctx.closePath();
             ctx.fill();
             ctx.beginPath(); // bottom tip
-            ctx.moveTo(x - tipW, cssH);
-            ctx.lineTo(x + tipW, cssH);
-            ctx.lineTo(x, cssH - tipH);
+            ctx.moveTo(x - tipW, waveBottom);
+            ctx.lineTo(x + tipW, waveBottom);
+            ctx.lineTo(x, waveBottom - tipH);
             ctx.closePath();
             ctx.fill();
             if (showBarNums) {
               ctx.fillStyle = isDark
                 ? "rgba(255,255,255,0.5)"
                 : "rgba(0,0,0,0.45)";
-              ctx.fillText(String(downbeatPrefix[i]), x + 3, cssH - 10);
+              ctx.fillText(String(downbeatPrefix[i]), x + 3, waveBottom - 10);
             }
           } else if (showBeats) {
             ctx.strokeStyle = isDark
@@ -275,14 +281,15 @@ export function PlayerDetailWaveform({
             ctx.lineWidth = 1;
             ctx.beginPath();
             ctx.moveTo(x + 0.5, waveTop);
-            ctx.lineTo(x + 0.5, cssH);
+            ctx.lineTo(x + 0.5, waveBottom);
             ctx.stroke();
           }
         }
       }
 
-      // --- cue markers (numbered colour squares, matching the overview) ---
+      // --- cue markers (hot cues colour-coded w/ letter, memory numbered) ---
       if (analysis?.cues.length) {
+        const displays = computeCueDisplays(analysis.cues);
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.font = "bold 9px ui-sans-serif, system-ui, sans-serif";
@@ -290,7 +297,7 @@ export function PlayerDetailWaveform({
           const c = analysis.cues[i];
           const x = timeToX(c.timeMs / 1000);
           if (x < -12 || x > cssW + 12) continue;
-          const color = c.color ?? (c.type === "hot" ? "#f97316" : "#ff4d6d");
+          const { color, label } = displays[i];
           ctx.globalAlpha = 0.55; // guide line
           ctx.fillStyle = color;
           ctx.fillRect(x - 0.5, waveTop, 1, waveH);
@@ -300,7 +307,7 @@ export function PlayerDetailWaveform({
           ctx.fillStyle = color;
           ctx.fill();
           ctx.fillStyle = textOn(color);
-          ctx.fillText(String(i + 1), x + s / 2, waveTop + s / 2 + 0.5);
+          ctx.fillText(label, x + s / 2, waveTop + s / 2 + 0.5);
         }
         ctx.textAlign = "left";
         ctx.textBaseline = "top";

--- a/frontend/src/components/player-detail-waveform.tsx
+++ b/frontend/src/components/player-detail-waveform.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { loadWaveform } from "@/components/rekordbox-waveform";
+import { api } from "@/lib/api";
+import { usePlayer, type PlayerTrack } from "@/lib/player-context";
+import {
+  getCachedRekordboxAnalysis,
+  type TrackAnalysis,
+} from "@/lib/rekordbox-analysis";
+import type { WaveformStyle } from "@/lib/settings";
+import { cn } from "@/lib/utils";
+import {
+  barSpanSeconds,
+  buildDownbeatPrefix,
+  decodeFloatPeaks,
+  decodePwv3,
+  decodePwv5,
+  rgbCss,
+  type DetailWave,
+} from "@/lib/waveform-detail";
+
+interface PlayerDetailWaveformProps {
+  track: PlayerTrack;
+  /** Bars visible across the strip (rekordbox playhead-centred zoom). */
+  zoomBars: number;
+  /** Track length in seconds. */
+  durationSec: number;
+  /** Detected BPM, for the bars→seconds mapping. */
+  bpm: number | null;
+  /** Selected waveform style; picks colour vs blue detail for rekordbox tracks. */
+  waveformStyle: WaveformStyle;
+  className?: string;
+}
+
+/**
+ * The zoomed, scrolling waveform strip. The playhead is fixed at the horizontal
+ * centre and the waveform scrolls beneath it, rekordbox-style. Draws the
+ * high-resolution detail waveform plus, for rekordbox tracks, the beatgrid and
+ * cue markers. Phrase sections are shown on the full-track overview instead.
+ * WaveSurfer (in the parent) stays the audio/progress driver; this component
+ * only reads progress and paints.
+ */
+export function PlayerDetailWaveform({
+  track,
+  zoomBars,
+  durationSec,
+  bpm,
+  waveformStyle,
+  className,
+}: PlayerDetailWaveformProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [wave, setWave] = useState<DetailWave | null>(null);
+  const [analysis, setAnalysis] = useState<TrackAnalysis | null>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  const { subscribeProgress, seek } = usePlayer();
+  const progressRef = useRef(0);
+  const draggingRef = useRef(false);
+
+  const isRek = !!track.rekordboxId;
+  const detailVariant =
+    waveformStyle === "rekordbox_blue" ? "blue_detail" : "color_detail";
+
+  // Load the detail waveform for this track (rekordbox PWV5/PWV3 bytes, or the
+  // backend's high-resolution ffmpeg peaks for a local file).
+  useEffect(() => {
+    let cancelled = false;
+    if (isRek && track.rekordboxId) {
+      loadWaveform(
+        track.rekordboxId,
+        track.rekordboxDevice,
+        detailVariant,
+      ).then((bytes) => {
+        if (cancelled) return;
+        setWave(
+          !bytes
+            ? null
+            : detailVariant === "blue_detail"
+              ? decodePwv3(bytes)
+              : decodePwv5(bytes),
+        );
+      });
+    } else if (durationSec > 0) {
+      const numPeaks = Math.max(
+        50,
+        Math.min(50000, Math.round(durationSec * 150)),
+      );
+      api
+        .getFilePeaks(track.filePath, numPeaks)
+        .then((peaks) => {
+          if (!cancelled) setWave(decodeFloatPeaks(peaks, durationSec));
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isRek,
+    track.rekordboxId,
+    track.rekordboxDevice,
+    track.filePath,
+    detailVariant,
+    durationSec,
+  ]);
+
+  // Load beatgrid / sections / cues (rekordbox only). Non-rekordbox tracks
+  // resolve to `null` so a previous track's grid never bleeds through.
+  useEffect(() => {
+    let cancelled = false;
+    const p =
+      isRek && track.rekordboxId
+        ? getCachedRekordboxAnalysis(track.rekordboxId, track.rekordboxDevice)
+        : Promise.resolve(null);
+    p.then((a) => {
+      if (!cancelled) setAnalysis(a);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isRek, track.rekordboxId, track.rekordboxDevice]);
+
+  const downbeatPrefix = useMemo(
+    () => buildDownbeatPrefix(analysis?.beatgrid ?? []),
+    [analysis],
+  );
+
+  // Track the wrapper's pixel box so the canvas fills the fluid player width.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (r) setSize({ w: Math.round(r.width), h: Math.round(r.height) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const draw = useCallback(
+    (progress: number) => {
+      const canvas = canvasRef.current;
+      const { w: cssW, h: cssH } = size;
+      if (!canvas || cssW === 0 || cssH === 0 || durationSec <= 0) return;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, cssW, cssH);
+      const isDark = document.documentElement.classList.contains("dark");
+
+      const waveTop = 0;
+      const waveH = cssH;
+      const mid = waveH / 2;
+      const halfH = waveH / 2;
+
+      const span = barSpanSeconds(zoomBars, bpm); // seconds across the strip
+      const t = progress * durationSec; // playhead time (s)
+      const pps = cssW / span; // pixels per second
+      const timeToX = (sec: number) => cssW / 2 + (sec - t) * pps;
+
+      // --- waveform columns ---
+      if (wave) {
+        const cps = wave.columnsPerSecond;
+        const first = Math.max(0, Math.floor((t - span / 2) * cps));
+        const last = Math.min(
+          wave.heights.length - 1,
+          Math.ceil((t + span / 2) * cps),
+        );
+        const colW = Math.max(1, pps / cps);
+        const themed = isDark ? "#8888aa" : "#909091";
+        for (let i = first; i <= last; i++) {
+          const x = timeToX(i / cps);
+          const barH = Math.max(1, wave.heights[i] * halfH);
+          ctx.fillStyle = wave.colors ? rgbCss(wave.colors[i]) : themed;
+          ctx.fillRect(x, mid - barH, colW, barH * 2);
+        }
+      }
+
+      // --- beat grid (rekordbox only); downbeats are emphasised + numbered ---
+      if (analysis?.beatgrid.length) {
+        ctx.font = "8px ui-sans-serif, system-ui, sans-serif";
+        ctx.textBaseline = "top";
+        for (let i = 0; i < analysis.beatgrid.length; i++) {
+          const b = analysis.beatgrid[i];
+          const x = timeToX(b.timeMs / 1000);
+          if (x < 0 || x > cssW) continue;
+          const down = b.beat === 1;
+          ctx.strokeStyle = down
+            ? isDark
+              ? "rgba(255,255,255,0.45)"
+              : "rgba(0,0,0,0.4)"
+            : isDark
+              ? "rgba(255,255,255,0.16)"
+              : "rgba(0,0,0,0.14)";
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(x + 0.5, waveTop);
+          ctx.lineTo(x + 0.5, cssH);
+          ctx.stroke();
+          if (down) {
+            ctx.fillStyle = isDark
+              ? "rgba(255,255,255,0.5)"
+              : "rgba(0,0,0,0.45)";
+            ctx.fillText(String(downbeatPrefix[i]), x + 2, cssH - 10);
+          }
+        }
+      }
+
+      // --- cue markers ---
+      if (analysis?.cues.length) {
+        for (const c of analysis.cues) {
+          const x = timeToX(c.timeMs / 1000);
+          if (x < -6 || x > cssW + 6) continue;
+          ctx.fillStyle = c.color ?? (c.type === "hot" ? "#f97316" : "#f43f5e");
+          ctx.beginPath();
+          ctx.moveTo(x, waveTop);
+          ctx.lineTo(x - 4, waveTop);
+          ctx.lineTo(x, waveTop + 5);
+          ctx.closePath();
+          ctx.fill();
+          ctx.fillRect(x - 0.5, waveTop, 1, waveH);
+          if (c.type === "hot" && c.index != null) {
+            ctx.font = "8px ui-sans-serif, system-ui, sans-serif";
+            ctx.textBaseline = "top";
+            ctx.fillText(String(c.index), x + 2, waveTop + 1);
+          }
+        }
+      }
+
+      // --- centre playhead ---
+      ctx.strokeStyle = isDark ? "#d0fd5a" : "#a8cd49";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(cssW / 2, 0);
+      ctx.lineTo(cssW / 2, cssH);
+      ctx.stroke();
+    },
+    [size, durationSec, zoomBars, bpm, wave, analysis, downbeatPrefix],
+  );
+
+  // Redraw on data/size change and subscribe to live progress.
+  useEffect(() => {
+    draw(progressRef.current);
+    return subscribeProgress((p) => {
+      progressRef.current = p;
+      draw(p);
+    });
+  }, [draw, subscribeProgress]);
+
+  // Seek by grabbing the waveform: initial press jumps to the time under the
+  // cursor, then dragging scrubs relative to pointer movement.
+  const seekToClientX = useCallback(
+    (clientX: number, rect: DOMRect) => {
+      const span = barSpanSeconds(zoomBars, bpm);
+      const pps = rect.width / span;
+      const dx = clientX - rect.left - rect.width / 2;
+      const time = progressRef.current * durationSec + dx / pps;
+      if (durationSec > 0) seek(Math.max(0, Math.min(1, time / durationSec)));
+    },
+    [zoomBars, bpm, durationSec, seek],
+  );
+
+  const lastXRef = useRef(0);
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      e.currentTarget.setPointerCapture(e.pointerId);
+      draggingRef.current = true;
+      lastXRef.current = e.clientX;
+      seekToClientX(e.clientX, e.currentTarget.getBoundingClientRect());
+    },
+    [seekToClientX],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!draggingRef.current || durationSec <= 0) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const span = barSpanSeconds(zoomBars, bpm);
+      const pps = rect.width / span;
+      const dx = e.clientX - lastXRef.current;
+      lastXRef.current = e.clientX;
+      const time = progressRef.current * durationSec - dx / pps;
+      seek(Math.max(0, Math.min(1, time / durationSec)));
+    },
+    [zoomBars, bpm, durationSec, seek],
+  );
+
+  const onPointerUp = useCallback(() => {
+    draggingRef.current = false;
+  }, []);
+
+  return (
+    <div ref={wrapRef} className={cn("size-full", className)}>
+      <canvas
+        ref={canvasRef}
+        className="block size-full cursor-ew-resize touch-none"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        aria-hidden
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/player-rekordbox-waveform.tsx
+++ b/frontend/src/components/player-rekordbox-waveform.tsx
@@ -131,12 +131,13 @@ export function PlayerRekordboxWaveform({
         }
       }
 
-      // Played overlay up to the current position.
+      // Played overlay up to the current position — darkens the already-played
+      // region so the upcoming part stays the brighter, more legible one.
       if (progress > 0) {
         const playedX = Math.round(progress * cssW);
         ctx.save();
         ctx.globalCompositeOperation = "source-atop";
-        ctx.fillStyle = "rgba(255, 255, 255, 0.4)";
+        ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
         ctx.fillRect(0, 0, playedX, cssH);
         ctx.restore();
       }

--- a/frontend/src/components/rekordbox-waveform.tsx
+++ b/frontend/src/components/rekordbox-waveform.tsx
@@ -36,8 +36,9 @@ const SOURCE_COLS = 1200;
 const cache = new Map<string, Uint8Array | null>();
 const inflight = new Map<string, Promise<Uint8Array | null>>();
 
-/** Waveform byte variant: PWV4 colour preview or PWAV monochrome preview. */
-export type WaveformVariant = "color" | "blue";
+/** Waveform byte variant: whole-track preview (`color`/`blue`) or
+ * ~150-column/second detail for zoom (`color_detail`/`blue_detail`). */
+export type WaveformVariant = "color" | "blue" | "color_detail" | "blue_detail";
 
 function cacheKey(
   trackId: string,

--- a/frontend/src/components/rekordbox-waveform.tsx
+++ b/frontend/src/components/rekordbox-waveform.tsx
@@ -178,14 +178,14 @@ export function RekordboxWaveform({
         }
       }
 
-      // Played overlay: tints columns up to current progress when the track is
-      // playing. Keeps the colour signature visible but desaturates the rest.
+      // Played overlay: darkens columns up to current progress when the track
+      // is playing, so the upcoming part reads as the brighter one.
       const active = isActiveRef.current;
       if (active && progress > 0) {
         const playedX = Math.round(progress * cssW);
         ctx.save();
         ctx.globalCompositeOperation = "source-atop";
-        ctx.fillStyle = "rgba(255, 255, 255, 0.35)";
+        ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
         ctx.fillRect(0, 0, playedX, cssH);
         ctx.restore();
       }

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
 import Hls from "hls.js";
 import {
+  ChevronLeft,
+  ChevronRight,
   Pause,
   Play,
   SkipBack,
@@ -31,18 +32,22 @@ import {
   getCachedSoundcloudStreamUrl,
   invalidateSoundcloudStreamUrl,
 } from "@/lib/soundcloud-cache";
-import { useResizableWidth } from "@/lib/use-resizable";
 import { useWaveformStyle } from "@/lib/use-waveform-style";
 import { cn } from "@/lib/utils";
 import {
   barBeatLabel,
   barSpanSeconds,
   buildDownbeatPrefix,
+  hotCueLetter,
+  textOn,
 } from "@/lib/waveform-detail";
 
 /** Zoom steps: `null` = whole-track overview only, then bars visible. */
 const ZOOM_LEVELS: (number | null)[] = [null, 128, 64, 32, 16, 8, 4];
 const ZOOM_KEY = "player.zoomBars";
+
+/** Selectable loop lengths, in beats. */
+const LOOP_BEAT_STEPS = [1, 2, 4, 8, 16, 32] as const;
 
 /** Phrase-kind → chart token (defined in globals.css). Colours the phrase band
  * drawn over the whole-track overview. */
@@ -121,11 +126,13 @@ export function WaveformPlayer() {
     reportProgress,
     registerSeek,
     reportDuration,
+    seek,
     currentBpm,
     targetBpm,
     pitchEnabled,
   } = usePlayer();
   const containerRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WaveSurferType | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const isPlayingRef = useRef(isPlaying);
@@ -135,11 +142,18 @@ export function WaveformPlayer() {
   const [currentTime, setCurrentTime] = useState(0);
   const [ready, setReady] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState(false);
   const [zoomBars, setZoomBars] = useState<number | null>(null);
   const [analysis, setAnalysis] = useState<TrackAnalysis | null>(null);
 
-  const treeWidth = useResizableWidth("tree-panel-width", 240);
+  // Cue + loop (in-memory only; reset on track change). The temp cue point is a
+  // single settable/recallable marker; the loop is N beats from a start anchor,
+  // enforced in the audio driver below.
+  const [cueSec, setCueSec] = useState<number | null>(null);
+  const [loopActive, setLoopActive] = useState(false);
+  const [loopStartSec, setLoopStartSec] = useState(0);
+  const [loopBeats, setLoopBeats] = useState(8);
+  const loopRef = useRef<{ start: number; end: number } | null>(null);
+
   const waveformStyle = useWaveformStyle();
 
   // Hydrate the persisted zoom level once on mount.
@@ -179,6 +193,109 @@ export function WaveformPlayer() {
     () => buildDownbeatPrefix(analysis?.beatgrid ?? []),
     [analysis],
   );
+
+  // --- cue + loop ---
+  const loopEndSec = useMemo(() => {
+    if (!currentBpm || currentBpm <= 0) return null;
+    return loopStartSec + (loopBeats * 60) / currentBpm;
+  }, [currentBpm, loopStartSec, loopBeats]);
+
+  // Mirror the active loop into a ref the audioprocess handler reads, so it
+  // stays live without re-subscribing the WaveSurfer listener on every change.
+  useEffect(() => {
+    loopRef.current =
+      loopActive && loopEndSec != null
+        ? { start: loopStartSec, end: loopEndSec }
+        : null;
+  }, [loopActive, loopStartSec, loopEndSec]);
+
+  // Clear cue + loop when the track changes.
+  const trackKey = currentTrack?.rekordboxId ?? currentTrack?.filePath;
+  useEffect(() => {
+    setCueSec(null);
+    setLoopActive(false);
+  }, [trackKey]);
+
+  // Snap a time to the nearest beat when a beatgrid is available.
+  const snapToBeat = (sec: number): number => {
+    const grid = analysis?.beatgrid;
+    if (!grid || grid.length === 0) return sec;
+    let best = sec;
+    let bestDist = Infinity;
+    for (const b of grid) {
+      const bt = b.timeMs / 1000;
+      const d = Math.abs(bt - sec);
+      if (d < bestDist) {
+        bestDist = d;
+        best = bt;
+      }
+      if (bt > sec + 1) break; // grid is sorted ascending
+    }
+    return best;
+  };
+
+  // Rekordbox-style CUE: playing → tap jumps back to the cue and pauses.
+  // Paused → press sets the cue at the playhead and previews (plays while held);
+  // release stops and returns to the cue point. A quick tap therefore just sets
+  // the cue and leaves playback stopped there.
+  const cuePreviewRef = useRef<number | null>(null);
+  const handleCueDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    if (duration <= 0) return;
+    if (isPlaying) {
+      pause();
+      seek((cueSec ?? 0) / duration);
+    } else {
+      const cp = currentTime;
+      setCueSec(cp);
+      cuePreviewRef.current = cp;
+      toggle(); // resume → preview from the cue while held
+    }
+  };
+  const handleCueUp = () => {
+    if (cuePreviewRef.current != null && duration > 0) {
+      const cp = cuePreviewRef.current;
+      cuePreviewRef.current = null;
+      pause();
+      seek(cp / duration);
+    }
+  };
+
+  const toggleLoop = () => {
+    if (!currentBpm || currentBpm <= 0) return;
+    setLoopActive((active) => {
+      if (!active) setLoopStartSec(snapToBeat(currentTime));
+      return !active;
+    });
+  };
+
+  const changeLoopBeats = (dir: 1 | -1) => {
+    setLoopBeats((prev) => {
+      const i = LOOP_BEAT_STEPS.indexOf(
+        prev as (typeof LOOP_BEAT_STEPS)[number],
+      );
+      return LOOP_BEAT_STEPS[
+        Math.max(0, Math.min(LOOP_BEAT_STEPS.length - 1, i + dir))
+      ];
+    });
+  };
+
+  // Publish the player's actual height so the layout shell can reserve exactly
+  // that much bottom padding (the height varies with collapsed/expanded state).
+  useEffect(() => {
+    const el = rootRef.current;
+    const root = document.documentElement;
+    if (!el) {
+      root.style.setProperty("--player-height", "0px");
+      return;
+    }
+    const set = () =>
+      root.style.setProperty("--player-height", `${el.offsetHeight}px`);
+    set();
+    const ro = new ResizeObserver(set);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [currentTrack]);
 
   useEffect(() => {
     isPlayingRef.current = isPlaying;
@@ -603,7 +720,12 @@ export function WaveformPlayer() {
       });
 
       ws.on("audioprocess", () => {
-        const t = ws!.getCurrentTime();
+        let t = ws!.getCurrentTime();
+        const lp = loopRef.current;
+        if (lp && t >= lp.end) {
+          ws!.setTime(lp.start);
+          t = lp.start;
+        }
         setCurrentTime(t);
         reportProgress(t / knownDuration);
       });
@@ -719,10 +841,6 @@ export function WaveformPlayer() {
 
   const artworkUrl =
     currentTrack.artworkUrl ?? api.getArtworkUrl(currentTrack.filePath);
-  // SoundCloud serves artwork at multiple sizes via suffix (`-large` is ~100px,
-  // `-t500x500` is 500px). Upgrade for the expanded preview so it doesn't look
-  // pixelated at tree-panel width. Non-SC URLs pass through unchanged.
-  const largeArtworkUrl = artworkUrl.replace("-large", "-t500x500");
   const titleText = currentTrack.title ?? currentTrack.fileName;
   const artistText = currentTrack.artist ?? "";
   const loadingProgress = duration > 0 ? currentTime / duration : 0;
@@ -756,461 +874,504 @@ export function WaveformPlayer() {
         })()
       : null;
 
-  const morphTransition = {
-    type: "spring" as const,
-    stiffness: 380,
-    damping: 34,
-  };
+  const remaining = Math.max(0, duration - currentTime);
 
   return (
-    <>
-      {/* Background panel — fades in/out behind the morphing artwork + title. */}
-      <AnimatePresence>
-        {expanded && (
-          <motion.div
-            key="artwork-panel-bg"
-            className="border-border fixed bottom-0 left-14 z-50 border-t bg-[var(--surface-2)]"
-            style={{
-              // Leave the rightmost pixel uncovered so the tree view's own
-              // border-r (which the panel would otherwise paint over) stays
-              // visible, giving a continuous vertical separator line.
-              width: `${treeWidth - 1}px`,
-              height: `${treeWidth + 64}px`,
-            }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
-            onClick={() => setExpanded(false)}
-          />
-        )}
-      </AnimatePresence>
-
-      {/* Big artwork — mounted only when expanded; shares layoutId with the
-          small artwork so framer-motion animates the transform between them. */}
-      {expanded && (
-        <motion.button
-          layoutId="player-artwork"
-          layoutDependency={expanded}
-          type="button"
-          data-testid="player-artwork"
-          onClick={() => setExpanded(false)}
-          className="bg-muted fixed left-14 z-50 cursor-pointer overflow-hidden"
-          style={{
-            bottom: "4rem",
-            width: `${treeWidth - 1}px`,
-            height: `${treeWidth - 1}px`,
-          }}
-          title="Collapse artwork"
-          aria-label="Collapse artwork"
-          transition={morphTransition}
-        >
-          <img
-            src={largeArtworkUrl}
-            alt=""
-            className="size-full object-cover"
-            onError={(e) => {
-              // Fall back to the small artwork URL if the hi-res variant 404s
-              // (e.g., non-SC sources where `-large` isn't in the URL).
-              const img = e.currentTarget as HTMLImageElement;
-              if (img.src !== artworkUrl) {
-                img.src = artworkUrl;
-              } else {
-                img.style.display = "none";
-              }
-            }}
-          />
-        </motion.button>
-      )}
-
-      {/* Big title row — same layoutId dance as the artwork. */}
-      {expanded && (
-        <motion.div
-          layoutId="player-title"
-          layoutDependency={expanded}
-          className="fixed bottom-0 left-14 z-50 flex h-16 min-w-0 flex-col justify-center gap-0.5 px-3"
-          style={{ width: `${treeWidth - 1}px` }}
-          onClick={() => setExpanded(false)}
-          transition={morphTransition}
-        >
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-xs" title={titleText}>
-              {titleText}
-            </span>
-            {currentTrack.permalinkUrl && (
-              <a
-                href={currentTrack.permalinkUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
-                title="Open on SoundCloud"
-                aria-label="Open on SoundCloud"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <img
-                  src="/icons/soundcloud.svg"
-                  alt=""
-                  className="size-3 dark:invert"
-                />
-              </a>
-            )}
-          </div>
-          {artistText && (
-            <span
-              className="text-muted-foreground truncate text-xs"
-              title={artistText}
-            >
-              {artistText}
-            </span>
-          )}
-        </motion.div>
-      )}
-
-      <div
-        data-testid="waveform-player"
-        className="border-border fixed right-0 bottom-0 left-14 z-40 flex flex-col border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
-      >
-        {/* Zoomed detail strip — scrolls with playback, playhead centred.
-            Stacks above the transport row (which stays anchored at the bottom). */}
-        {zoomActive && (
+    <div
+      ref={rootRef}
+      data-testid="waveform-player"
+      className="border-border fixed right-0 bottom-0 left-14 z-40 flex border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
+    >
+      {/* ===== Side rail — all controls live here; the right side is waveforms
+          only. Rows drop from four (expanded) to two (collapsed). ===== */}
+      <div className="border-border flex w-[360px] shrink-0 flex-col justify-center gap-1 border-r px-3 py-1.5">
+        {/* Artwork + title / artist */}
+        <div className="flex min-w-0 items-center gap-2.5">
           <div
-            data-testid="player-detail-strip"
-            data-zoom-bars={zoomBars ?? undefined}
-            className="border-border h-16 border-b px-3 py-1"
-            onWheel={(e) => {
-              e.preventDefault();
-              changeZoom(e.deltaY < 0 ? 1 : -1);
-            }}
+            data-testid="player-artwork"
+            className="bg-muted size-9 shrink-0 overflow-hidden rounded-md"
           >
-            <PlayerDetailWaveform
-              track={currentTrack}
-              zoomBars={zoomBars!}
-              durationSec={duration}
-              bpm={currentBpm}
-              waveformStyle={waveformStyle}
+            <img
+              src={artworkUrl}
+              alt=""
+              className="size-full object-cover"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = "none";
+              }}
             />
           </div>
-        )}
-        <div className="flex h-16 items-stretch">
-          {/* Mini block — fixed width matching the tree panel above */}
-          <div
-            className="border-border flex shrink-0 items-center gap-2 border-r pr-3 pl-2"
-            style={{ width: `${treeWidth}px` }}
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span
+                className="text-primary truncate text-sm font-semibold"
+                title={titleText}
+              >
+                {titleText}
+              </span>
+              {currentTrack.permalinkUrl && (
+                <a
+                  href={currentTrack.permalinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
+                  title="Open on SoundCloud"
+                  aria-label="Open on SoundCloud"
+                >
+                  <img
+                    src="/icons/soundcloud.svg"
+                    alt=""
+                    className="size-3 dark:invert"
+                  />
+                </a>
+              )}
+            </div>
+            {artistText && (
+              <span
+                className="text-muted-foreground truncate text-xs"
+                title={artistText}
+              >
+                {artistText}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Transport + time */}
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={(e) => {
+              previous();
+              e.currentTarget.blur();
+            }}
+            disabled={!hasPrevious && currentTime <= 3}
+            className={cn(
+              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
+              !hasPrevious &&
+                currentTime <= 3 &&
+                "cursor-not-allowed opacity-40 hover:bg-transparent",
+            )}
+            title="Previous (←)"
+            aria-label="Previous track"
           >
-            {/* Artwork — click expands. When expanded, this unmounts and the
-            big artwork (same layoutId) takes over; framer-motion animates
-            the transform between the two positions. */}
-            {!expanded && (
-              <motion.button
-                layoutId="player-artwork"
-                layoutDependency={expanded}
-                type="button"
-                data-testid="player-artwork"
-                className="bg-muted relative flex size-10 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md"
-                onClick={() => setExpanded(true)}
-                title="Expand artwork"
-                aria-label="Expand artwork"
-                aria-expanded={false}
-                transition={morphTransition}
-              >
-                <img
-                  src={artworkUrl}
-                  alt=""
-                  className="size-full object-cover"
-                  onError={(e) => {
-                    (e.currentTarget as HTMLImageElement).style.display =
-                      "none";
-                  }}
-                />
-              </motion.button>
+            <SkipBack className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            data-testid="player-toggle"
+            onClick={(e) => {
+              toggle();
+              // Drop focus so a subsequent Space keypress isn't captured by
+              // the button's default activation behavior (which would
+              // re-toggle on top of the window-level keyboard handler).
+              e.currentTarget.blur();
+            }}
+            className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
+            title={isPlaying ? "Pause (Space)" : "Play (Space)"}
+            aria-label={isPlaying ? "Pause" : "Play"}
+          >
+            {isPlaying ? (
+              <Pause className="size-3.5" />
+            ) : (
+              <Play className="size-3.5 translate-x-px" />
             )}
-
-            {/* Title + artist — morphs into the expanded panel's title row. */}
-            {!expanded && (
-              <motion.div
-                layoutId="player-title"
-                layoutDependency={expanded}
-                className="flex min-w-0 flex-1 flex-col gap-0.5"
-                transition={morphTransition}
-              >
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate text-xs" title={titleText}>
-                    {titleText}
-                  </span>
-                  {currentTrack.permalinkUrl && (
-                    <a
-                      href={currentTrack.permalinkUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
-                      title="Open on SoundCloud"
-                      aria-label="Open on SoundCloud"
-                    >
-                      <img
-                        src="/icons/soundcloud.svg"
-                        alt=""
-                        className="size-3 dark:invert"
-                      />
-                    </a>
-                  )}
-                </div>
-                {artistText && (
-                  <div
-                    className="text-muted-foreground truncate text-xs"
-                    title={artistText}
-                  >
-                    {artistText}
-                  </div>
-                )}
-              </motion.div>
+          </button>
+          {/* CUE — round CDJ-style button: tap sets/recalls, hold previews. */}
+          <button
+            type="button"
+            data-testid="player-cue-btn"
+            onPointerDown={handleCueDown}
+            onPointerUp={handleCueUp}
+            onPointerCancel={handleCueUp}
+            className={cn(
+              "flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-full border text-[10px] font-semibold transition-colors select-none",
+              cueSec != null
+                ? "border-amber-500 text-amber-500 hover:bg-amber-500/10"
+                : "border-border text-muted-foreground hover:text-foreground hover:bg-surface-3",
             )}
-          </div>
+            title="Cue — tap to set/recall, hold to preview"
+            aria-label="Cue"
+          >
+            CUE
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              next();
+              e.currentTarget.blur();
+            }}
+            disabled={!hasNext}
+            className={cn(
+              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
+              !hasNext && "cursor-not-allowed opacity-40 hover:bg-transparent",
+            )}
+            title="Next (→)"
+            aria-label="Next track"
+          >
+            <SkipForward className="size-3.5" />
+          </button>
 
-          {/* Transport cluster — lifted out of the tree-width column so the
-          title block has room to breathe. */}
-          <div className="flex shrink-0 items-center gap-0.5 px-3">
-            <button
-              type="button"
-              onClick={(e) => {
-                previous();
-                e.currentTarget.blur();
-              }}
-              disabled={!hasPrevious && currentTime <= 3}
-              className={cn(
-                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-                !hasPrevious &&
-                  currentTime <= 3 &&
-                  "cursor-not-allowed opacity-40 hover:bg-transparent",
-              )}
-              title="Previous (←)"
-              aria-label="Previous track"
-            >
-              <SkipBack className="size-4" />
-            </button>
-            <button
-              type="button"
-              data-testid="player-toggle"
-              onClick={(e) => {
-                toggle();
-                // Drop focus so a subsequent Space keypress isn't captured by
-                // the button's default activation behavior (which would
-                // re-toggle on top of the window-level keyboard handler).
-                e.currentTarget.blur();
-              }}
-              className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-9 cursor-pointer items-center justify-center rounded-full transition-colors"
-              title={isPlaying ? "Pause (Space)" : "Play (Space)"}
-              aria-label={isPlaying ? "Pause" : "Play"}
-            >
-              {isPlaying ? (
-                <Pause className="size-4" />
+          {/* Right of transport: time + remaining (expanded) or the pitcher +
+              key · bar.beat inline (collapsed, so the rail stays two rows). */}
+          <div className="ml-auto flex items-center gap-2">
+            {!zoomActive && <BpmPitcher />}
+            <div className="flex flex-col items-end leading-tight tabular-nums">
+              <span className="text-sm font-medium">
+                <span className="text-foreground">
+                  {formatTime(currentTime)}
+                </span>
+                <span className="text-muted-foreground">
+                  {" "}
+                  / {formatTime(duration)}
+                </span>
+              </span>
+              {zoomActive ? (
+                <span className="text-muted-foreground text-xs">
+                  −{formatTime(remaining)} LEFT
+                </span>
               ) : (
-                <Play className="size-4 translate-x-px" />
+                <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                  <span title="Key">{currentTrack.musicalKey ?? "—"}</span>
+                  {barBeat && (
+                    <>
+                      <span>·</span>
+                      <span title="Bar.beat">{barBeat}</span>
+                    </>
+                  )}
+                </span>
               )}
-            </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                next();
-                e.currentTarget.blur();
-              }}
-              disabled={!hasNext}
-              className={cn(
-                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-                !hasNext &&
-                  "cursor-not-allowed opacity-40 hover:bg-transparent",
-              )}
-              title="Next (→)"
-              aria-label="Next track"
-            >
-              <SkipForward className="size-4" />
-            </button>
+            </div>
           </div>
+        </div>
 
-          {/* Target-BPM pitcher — displays current BPM and allows pitching
-          playback. Sits between transport and waveform. */}
-          <BpmPitcher />
-
-          {/* Musical key (Rekordbox analysis), when known. */}
-          {currentTrack.musicalKey && (
-            <div
-              className="text-muted-foreground flex shrink-0 items-center pr-1 text-xs font-medium tabular-nums"
-              title="Key"
-            >
-              {currentTrack.musicalKey}
-            </div>
-          )}
-
-          {errorMsg ? (
-            <div
-              role="alert"
-              className="text-destructive flex shrink-0 items-center px-3 text-xs"
-            >
-              {errorMsg}
-            </div>
-          ) : (
-            <>
-              {/* Current time (+ bar.beat when a beatgrid is available) */}
-              <div className="text-muted-foreground flex shrink-0 flex-col items-start justify-center pl-2 text-xs leading-tight tabular-nums">
-                <span>{formatTime(currentTime)}</span>
-                {barBeat && (
-                  <span className="text-[10px] opacity-70" title="Bar.beat">
-                    {barBeat}
-                  </span>
+        {/* Expanded only: loop row + BPM/KEY boxes. */}
+        {zoomActive && (
+          <>
+            <div className="flex items-center gap-0.5">
+              <button
+                type="button"
+                onClick={(e) => {
+                  changeLoopBeats(-1);
+                  e.currentTarget.blur();
+                }}
+                disabled={loopBeats === LOOP_BEAT_STEPS[0]}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 border-border flex size-7 cursor-pointer items-center justify-center rounded-md border transition-colors",
+                  loopBeats === LOOP_BEAT_STEPS[0] &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
                 )}
-              </div>
-
-              {/* Waveform (fills remaining width) */}
-              <div
-                className="relative flex min-w-0 flex-1 items-center px-3"
-                onWheel={
-                  zoomable
-                    ? (e) => {
-                        e.preventDefault();
-                        changeZoom(e.deltaY < 0 ? 1 : -1);
-                      }
-                    : undefined
-                }
+                title="Halve loop length"
+                aria-label="Halve loop length"
               >
-                <div
-                  ref={containerRef}
-                  className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
-                  style={{ cursor: "pointer" }}
+                <ChevronLeft className="size-4" />
+              </button>
+              <span
+                className="text-foreground border-border w-9 rounded-md border py-1 text-center text-sm font-medium tabular-nums"
+                title="Loop length (beats)"
+              >
+                {loopBeats}
+              </span>
+              <button
+                type="button"
+                onClick={(e) => {
+                  changeLoopBeats(1);
+                  e.currentTarget.blur();
+                }}
+                disabled={
+                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1]
+                }
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 border-border flex size-7 cursor-pointer items-center justify-center rounded-md border transition-colors",
+                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1] &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
+                )}
+                title="Double loop length"
+                aria-label="Double loop length"
+              >
+                <ChevronRight className="size-4" />
+              </button>
+              <button
+                type="button"
+                data-testid="player-loop-btn"
+                data-active={loopActive || undefined}
+                onClick={(e) => {
+                  toggleLoop();
+                  e.currentTarget.blur();
+                }}
+                disabled={!currentBpm}
+                className={cn(
+                  "ml-auto flex h-7 cursor-pointer items-center rounded-md border px-4 text-xs font-semibold transition-colors",
+                  loopActive
+                    ? "border-primary text-primary hover:bg-primary/10"
+                    : "border-border text-muted-foreground hover:text-foreground hover:bg-surface-3",
+                  !currentBpm && "cursor-not-allowed opacity-40",
+                )}
+                title={currentBpm ? "Toggle loop" : "Loop needs a known BPM"}
+                aria-label="Toggle loop"
+              >
+                LOOP
+              </button>
+            </div>
+            <div className="flex items-stretch gap-2">
+              <div className="border-border flex flex-1 items-center rounded-md border px-1">
+                <BpmPitcher />
+              </div>
+              <div className="border-border flex flex-1 items-center gap-1.5 rounded-md border px-3">
+                <span className="text-foreground text-sm font-semibold tabular-nums">
+                  {currentTrack.musicalKey ?? "—"}
+                </span>
+                <span className="text-2xs text-muted-foreground tracking-wider uppercase">
+                  Key
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ===== Waveform area — right side, waveforms only ===== */}
+      {errorMsg ? (
+        <div
+          role="alert"
+          className="text-destructive flex flex-1 items-center px-4 text-xs"
+        >
+          {errorMsg}
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-1">
+          <div className="relative flex min-w-0 flex-1 flex-col justify-center gap-1 py-2 pl-2">
+            {/* Zoom detail strip (expanded only) */}
+            {zoomActive && (
+              <div
+                data-testid="player-detail-strip"
+                data-zoom-bars={zoomBars ?? undefined}
+                className="h-20 px-1"
+                onWheel={(e) => {
+                  e.preventDefault();
+                  changeZoom(e.deltaY < 0 ? 1 : -1);
+                }}
+              >
+                <PlayerDetailWaveform
+                  track={currentTrack}
+                  zoomBars={zoomBars!}
+                  durationSec={duration}
+                  bpm={currentBpm}
+                  waveformStyle={waveformStyle}
+                  loop={
+                    loopActive && loopEndSec != null
+                      ? { startSec: loopStartSec, endSec: loopEndSec }
+                      : null
+                  }
+                  cueSec={cueSec}
                 />
-                {/* Phrase sections + cue markers + zoom-window indicator over
-                    the whole-track overview (rekordbox tracks with analysis). */}
-                {(viewport ||
-                  (duration > 0 &&
-                    (analysis?.cues.length || analysis?.sections?.length))) && (
-                  <div className="pointer-events-none absolute inset-y-2 right-3 left-3">
-                    {/* Phrase-section band along the top edge. */}
-                    {duration > 0 &&
-                      analysis?.sections?.map((s, i) => (
+              </div>
+            )}
+
+            {/* Overview waveform */}
+            <div
+              className="relative flex h-12 items-center px-1"
+              onWheel={
+                zoomable
+                  ? (e) => {
+                      e.preventDefault();
+                      changeZoom(e.deltaY < 0 ? 1 : -1);
+                    }
+                  : undefined
+              }
+            >
+              <div
+                ref={containerRef}
+                className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
+                style={{ cursor: "pointer" }}
+              />
+              {/* Cue markers + loop region + zoom-window indicator over the
+                    whole-track overview. Phrase sections are a separate row. */}
+              {(viewport ||
+                (duration > 0 &&
+                  (analysis?.cues.length || loopActive || cueSec != null))) && (
+                <div className="pointer-events-none absolute inset-x-1 inset-y-0 z-10">
+                  {/* Loop region (drawn under the cue markers). */}
+                  {loopActive && loopEndSec != null && duration > 0 && (
+                    <div
+                      data-testid="player-loop-region"
+                      className="border-primary bg-primary/15 absolute inset-y-0 rounded-sm border"
+                      style={{
+                        left: `${(loopStartSec / duration) * 100}%`,
+                        width: `${((loopEndSec - loopStartSec) / duration) * 100}%`,
+                      }}
+                    />
+                  )}
+                  {/* Cue markers — numbered colour squares (rekordbox-style),
+                        click to seek. */}
+                  {duration > 0 &&
+                    analysis?.cues.map((c, i) => {
+                      const color =
+                        c.color ?? (c.type === "hot" ? "#f97316" : "#f43f5e");
+                      return (
                         <div
                           key={i}
-                          data-testid="player-section"
-                          className="absolute top-0 flex h-2.5 items-center overflow-hidden rounded-[1px] px-0.5"
-                          style={{
-                            left: `${(s.startMs / 1000 / duration) * 100}%`,
-                            width: `${((s.endMs - s.startMs) / 1000 / duration) * 100}%`,
-                            backgroundColor:
-                              SECTION_COLOR_VAR[s.kind] ??
-                              SECTION_COLOR_VAR.other,
-                          }}
-                        >
-                          <span className="truncate text-[8px] leading-none font-medium text-black/70">
-                            {s.label}
-                          </span>
-                        </div>
-                      ))}
-                    {duration > 0 &&
-                      analysis?.cues.map((c, i) => (
-                        <div
-                          key={i}
-                          className="absolute inset-y-0 w-px"
+                          className="absolute inset-y-0"
                           style={{
                             left: `${(c.timeMs / 1000 / duration) * 100}%`,
-                            backgroundColor:
-                              c.color ??
-                              (c.type === "hot" ? "#f97316" : "#f43f5e"),
                           }}
-                        />
-                      ))}
-                    {viewport && (
-                      <div
-                        className="border-primary/70 bg-primary/15 absolute inset-y-0 rounded-sm border"
-                        style={{
-                          left: `${viewport.left * 100}%`,
-                          width: `${viewport.width * 100}%`,
-                        }}
+                        >
+                          <div
+                            className="absolute inset-y-0 w-px -translate-x-1/2"
+                            style={{ backgroundColor: color }}
+                          />
+                          <button
+                            type="button"
+                            data-testid="player-cue"
+                            data-cue-type={c.type}
+                            onClick={() => seek(c.timeMs / 1000 / duration)}
+                            title={
+                              c.type === "hot"
+                                ? `Hot cue ${hotCueLetter(c.index)}`
+                                : "Memory cue"
+                            }
+                            className="pointer-events-auto absolute top-0 flex size-3 -translate-x-1/2 cursor-pointer items-center justify-center rounded-[2px] text-[8px] leading-none font-bold transition-transform hover:scale-110"
+                            style={{
+                              backgroundColor: color,
+                              color: textOn(color),
+                            }}
+                          >
+                            {i + 1}
+                          </button>
+                        </div>
+                      );
+                    })}
+                  {/* In-memory cue point (amber flag), click to recall. */}
+                  {cueSec != null && duration > 0 && (
+                    <div
+                      className="absolute inset-y-0"
+                      style={{ left: `${(cueSec / duration) * 100}%` }}
+                    >
+                      <div className="absolute inset-y-0 w-px -translate-x-1/2 bg-amber-500" />
+                      <button
+                        type="button"
+                        data-testid="player-cue-point"
+                        onClick={() => seek(cueSec / duration)}
+                        title="Cue point"
+                        aria-label="Cue point"
+                        className="pointer-events-auto absolute top-0 block size-0 -translate-x-1/2 cursor-pointer border-t-[7px] border-r-[5px] border-l-[5px] border-t-amber-500 border-r-transparent border-l-transparent"
                       />
-                    )}
-                  </div>
-                )}
-                {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
-                  to keep driving audio + progress; this canvas paints the
-                  coloured waveform and owns seek/hover. */}
-                {rekColored && currentTrack.rekordboxId && (
-                  <div
-                    data-testid="player-rekordbox-waveform"
-                    data-variant={rekVariant}
-                    className="absolute inset-y-0 right-3 left-3 flex items-center"
-                  >
-                    <PlayerRekordboxWaveform
-                      trackId={currentTrack.rekordboxId}
-                      device={currentTrack.rekordboxDevice}
-                      variant={rekVariant}
-                      durationSec={duration}
-                      className="h-8"
-                    />
-                  </div>
-                )}
-                {/* Loading-state fallback progress — fades out once waveform is ready. */}
-                <div
-                  className={cn(
-                    "bg-surface-3 pointer-events-none absolute right-3 bottom-2 left-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
-                    ready ? "opacity-0" : "opacity-100",
+                    </div>
                   )}
-                >
-                  <div
-                    className="bg-primary h-full"
-                    style={{
-                      width: `${Math.min(100, loadingProgress * 100)}%`,
-                    }}
-                  />
-                </div>
-              </div>
-
-              {/* Zoom controls — hidden for SoundCloud streams. */}
-              {zoomable && (
-                <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 pl-1">
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      changeZoom(1);
-                      e.currentTarget.blur();
-                    }}
-                    disabled={zoomBars === 4}
-                    className={cn(
-                      "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
-                      zoomBars === 4 &&
-                        "cursor-not-allowed opacity-40 hover:bg-transparent",
-                    )}
-                    title="Zoom in"
-                    aria-label="Zoom in"
-                  >
-                    <ZoomIn className="size-3.5" />
-                  </button>
-                  <span className="text-muted-foreground text-[9px] tabular-nums">
-                    {zoomBars == null ? "—" : zoomBars}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      changeZoom(-1);
-                      e.currentTarget.blur();
-                    }}
-                    disabled={zoomBars == null}
-                    className={cn(
-                      "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
-                      zoomBars == null &&
-                        "cursor-not-allowed opacity-40 hover:bg-transparent",
-                    )}
-                    title="Zoom out"
-                    aria-label="Zoom out"
-                  >
-                    <ZoomOut className="size-3.5" />
-                  </button>
+                  {viewport && (
+                    <div
+                      className="border-primary/70 bg-primary/15 absolute inset-y-0 rounded-sm border"
+                      style={{
+                        left: `${viewport.left * 100}%`,
+                        width: `${viewport.width * 100}%`,
+                      }}
+                    />
+                  )}
                 </div>
               )}
-
-              {/* Total duration — right of waveform */}
-              <div className="text-muted-foreground flex shrink-0 items-center pr-4 text-xs tabular-nums">
-                {formatTime(duration)}
+              {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
+                  to keep driving audio + progress; this canvas paints the
+                  coloured waveform and owns seek/hover. */}
+              {rekColored && currentTrack.rekordboxId && (
+                <div
+                  data-testid="player-rekordbox-waveform"
+                  data-variant={rekVariant}
+                  className="absolute inset-x-1 inset-y-0 flex items-center"
+                >
+                  <PlayerRekordboxWaveform
+                    trackId={currentTrack.rekordboxId}
+                    device={currentTrack.rekordboxDevice}
+                    variant={rekVariant}
+                    durationSec={duration}
+                    className="h-8"
+                  />
+                </div>
+              )}
+              {/* Loading-state fallback progress — fades out once waveform is ready. */}
+              <div
+                className={cn(
+                  "bg-surface-3 pointer-events-none absolute inset-x-1 bottom-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
+                  ready ? "opacity-0" : "opacity-100",
+                )}
+              >
+                <div
+                  className="bg-primary h-full"
+                  style={{
+                    width: `${Math.min(100, loadingProgress * 100)}%`,
+                  }}
+                />
               </div>
-            </>
+            </div>
+
+            {/* Phrase band — labelled song-structure sections. */}
+            {duration > 0 && analysis?.sections?.length ? (
+              <div className="relative h-3.5 px-1">
+                <div className="absolute inset-x-1 inset-y-0">
+                  {analysis.sections.map((s, i) => (
+                    <div
+                      key={i}
+                      data-testid="player-section"
+                      className="absolute inset-y-0 flex items-center overflow-hidden rounded-[1px] px-1"
+                      style={{
+                        left: `${(s.startMs / 1000 / duration) * 100}%`,
+                        width: `${((s.endMs - s.startMs) / 1000 / duration) * 100}%`,
+                        backgroundColor:
+                          SECTION_COLOR_VAR[s.kind] ?? SECTION_COLOR_VAR.other,
+                      }}
+                    >
+                      <span className="truncate text-[8px] leading-none font-semibold tracking-wide text-black/70 uppercase">
+                        {s.label}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {/* Zoom controls — hidden for SoundCloud streams. */}
+          {zoomable && (
+            <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 px-2">
+              <button
+                type="button"
+                onClick={(e) => {
+                  changeZoom(1);
+                  e.currentTarget.blur();
+                }}
+                disabled={zoomBars === 4}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-6 cursor-pointer items-center justify-center rounded transition-colors",
+                  zoomBars === 4 &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
+                )}
+                title="Zoom in"
+                aria-label="Zoom in"
+              >
+                <ZoomIn className="size-4" />
+              </button>
+              <span className="text-muted-foreground text-[9px] tabular-nums">
+                {zoomBars == null ? "—" : zoomBars}
+              </span>
+              <button
+                type="button"
+                onClick={(e) => {
+                  changeZoom(-1);
+                  e.currentTarget.blur();
+                }}
+                disabled={zoomBars == null}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-6 cursor-pointer items-center justify-center rounded transition-colors",
+                  zoomBars == null &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
+                )}
+                title="Zoom out"
+                aria-label="Zoom out"
+              >
+                <ZoomOut className="size-4" />
+              </button>
+            </div>
           )}
         </div>
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -2,17 +2,30 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import Hls from "hls.js";
-import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import {
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type WaveSurferType from "wavesurfer.js";
 
 import { BpmPitcher, computePlaybackRate } from "@/components/bpm-pitcher";
+import { PlayerDetailWaveform } from "@/components/player-detail-waveform";
 import { PlayerRekordboxWaveform } from "@/components/player-rekordbox-waveform";
 import { loadWaveform, pwv4ToPeaks } from "@/components/rekordbox-waveform";
 import { api } from "@/lib/api";
 import { usePlayer } from "@/lib/player-context";
 import { selectPeaksSource } from "@/lib/player-peaks";
+import {
+  getCachedRekordboxAnalysis,
+  type TrackAnalysis,
+} from "@/lib/rekordbox-analysis";
 import { markScUnplayable } from "@/lib/sc-unplayable";
+import { getRaw, setRaw } from "@/lib/settings";
 import {
   getCachedSoundcloudPeaks,
   getCachedSoundcloudStreamUrl,
@@ -21,6 +34,35 @@ import {
 import { useResizableWidth } from "@/lib/use-resizable";
 import { useWaveformStyle } from "@/lib/use-waveform-style";
 import { cn } from "@/lib/utils";
+import {
+  barBeatLabel,
+  barSpanSeconds,
+  buildDownbeatPrefix,
+} from "@/lib/waveform-detail";
+
+/** Zoom steps: `null` = whole-track overview only, then bars visible. */
+const ZOOM_LEVELS: (number | null)[] = [null, 128, 64, 32, 16, 8, 4];
+const ZOOM_KEY = "player.zoomBars";
+
+/** Phrase-kind → chart token (defined in globals.css). Colours the phrase band
+ * drawn over the whole-track overview. */
+const SECTION_COLOR_VAR: Record<string, string> = {
+  intro: "var(--chart-1)",
+  down: "var(--chart-1)",
+  verse: "var(--chart-2)",
+  chorus: "var(--chart-3)",
+  up: "var(--chart-3)",
+  bridge: "var(--chart-4)",
+  outro: "var(--chart-5)",
+  other: "var(--border-strong)",
+};
+
+/** Step one level toward zoomed-in (`dir=1`) or zoomed-out (`dir=-1`). */
+function stepZoom(current: number | null, dir: 1 | -1): number | null {
+  const i = ZOOM_LEVELS.indexOf(current);
+  const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, i + dir));
+  return ZOOM_LEVELS[next];
+}
 
 /** Heuristic: URL is an HLS playlist (by extension). */
 function isHlsUrl(url: string): boolean {
@@ -94,9 +136,49 @@ export function WaveformPlayer() {
   const [ready, setReady] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
+  const [zoomBars, setZoomBars] = useState<number | null>(null);
+  const [analysis, setAnalysis] = useState<TrackAnalysis | null>(null);
 
   const treeWidth = useResizableWidth("tree-panel-width", 240);
   const waveformStyle = useWaveformStyle();
+
+  // Hydrate the persisted zoom level once on mount.
+  useEffect(() => {
+    getRaw<number | null>(ZOOM_KEY, null)
+      .then((v) => {
+        if (ZOOM_LEVELS.includes(v)) setZoomBars(v);
+      })
+      .catch(() => {});
+  }, []);
+
+  const changeZoom = (dir: 1 | -1) => {
+    setZoomBars((prev) => {
+      const next = stepZoom(prev, dir);
+      setRaw(ZOOM_KEY, next).catch(() => {});
+      return next;
+    });
+  };
+
+  // Fetch beatgrid/sections/cues for rekordbox tracks (cached; the detail strip
+  // shares this fetch). Drives the bar.beat readout.
+  const rekId = currentTrack?.rekordboxId;
+  const rekDevice = currentTrack?.rekordboxDevice;
+  useEffect(() => {
+    setAnalysis(null);
+    if (!rekId) return;
+    let cancelled = false;
+    getCachedRekordboxAnalysis(rekId, rekDevice).then((a) => {
+      if (!cancelled) setAnalysis(a);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [rekId, rekDevice]);
+
+  const downbeatPrefix = useMemo(
+    () => buildDownbeatPrefix(analysis?.beatgrid ?? []),
+    [analysis],
+  );
 
   useEffect(() => {
     isPlayingRef.current = isPlaying;
@@ -653,6 +735,27 @@ export function WaveformPlayer() {
     (waveformStyle === "rekordbox_rgb" || waveformStyle === "rekordbox_blue");
   const rekVariant = waveformStyle === "rekordbox_blue" ? "blue" : "color";
 
+  // Zoom is available for everything except SoundCloud streams (whose ~1800
+  // pre-baked samples can't resolve a few bars).
+  const zoomable = selectPeaksSource(currentTrack).kind !== "soundcloud";
+  const zoomActive = zoomable && zoomBars != null;
+  const barBeat = analysis?.beatgrid.length
+    ? barBeatLabel(currentTime, analysis.beatgrid, downbeatPrefix)
+    : null;
+  // Fraction of the track visible in the detail strip — drawn as an indicator
+  // rectangle over the whole-track overview.
+  const viewport =
+    zoomActive && duration > 0
+      ? (() => {
+          const half = barSpanSeconds(zoomBars!, currentBpm) / 2 / duration;
+          const center = currentTime / duration;
+          return {
+            left: Math.max(0, center - half),
+            width: Math.min(1, center + half) - Math.max(0, center - half),
+          };
+        })()
+      : null;
+
   const morphTransition = {
     type: "spring" as const,
     stiffness: 380,
@@ -765,203 +868,348 @@ export function WaveformPlayer() {
 
       <div
         data-testid="waveform-player"
-        className="border-border fixed right-0 bottom-0 left-14 z-40 flex h-16 items-stretch border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
+        className="border-border fixed right-0 bottom-0 left-14 z-40 flex flex-col border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
       >
-        {/* Mini block — fixed width matching the tree panel above */}
-        <div
-          className="border-border flex shrink-0 items-center gap-2 border-r pr-3 pl-2"
-          style={{ width: `${treeWidth}px` }}
-        >
-          {/* Artwork — click expands. When expanded, this unmounts and the
+        {/* Zoomed detail strip — scrolls with playback, playhead centred.
+            Stacks above the transport row (which stays anchored at the bottom). */}
+        {zoomActive && (
+          <div
+            data-testid="player-detail-strip"
+            data-zoom-bars={zoomBars ?? undefined}
+            className="border-border h-16 border-b px-3 py-1"
+            onWheel={(e) => {
+              e.preventDefault();
+              changeZoom(e.deltaY < 0 ? 1 : -1);
+            }}
+          >
+            <PlayerDetailWaveform
+              track={currentTrack}
+              zoomBars={zoomBars!}
+              durationSec={duration}
+              bpm={currentBpm}
+              waveformStyle={waveformStyle}
+            />
+          </div>
+        )}
+        <div className="flex h-16 items-stretch">
+          {/* Mini block — fixed width matching the tree panel above */}
+          <div
+            className="border-border flex shrink-0 items-center gap-2 border-r pr-3 pl-2"
+            style={{ width: `${treeWidth}px` }}
+          >
+            {/* Artwork — click expands. When expanded, this unmounts and the
             big artwork (same layoutId) takes over; framer-motion animates
             the transform between the two positions. */}
-          {!expanded && (
-            <motion.button
-              layoutId="player-artwork"
-              layoutDependency={expanded}
+            {!expanded && (
+              <motion.button
+                layoutId="player-artwork"
+                layoutDependency={expanded}
+                type="button"
+                data-testid="player-artwork"
+                className="bg-muted relative flex size-10 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md"
+                onClick={() => setExpanded(true)}
+                title="Expand artwork"
+                aria-label="Expand artwork"
+                aria-expanded={false}
+                transition={morphTransition}
+              >
+                <img
+                  src={artworkUrl}
+                  alt=""
+                  className="size-full object-cover"
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.display =
+                      "none";
+                  }}
+                />
+              </motion.button>
+            )}
+
+            {/* Title + artist — morphs into the expanded panel's title row. */}
+            {!expanded && (
+              <motion.div
+                layoutId="player-title"
+                layoutDependency={expanded}
+                className="flex min-w-0 flex-1 flex-col gap-0.5"
+                transition={morphTransition}
+              >
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate text-xs" title={titleText}>
+                    {titleText}
+                  </span>
+                  {currentTrack.permalinkUrl && (
+                    <a
+                      href={currentTrack.permalinkUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
+                      title="Open on SoundCloud"
+                      aria-label="Open on SoundCloud"
+                    >
+                      <img
+                        src="/icons/soundcloud.svg"
+                        alt=""
+                        className="size-3 dark:invert"
+                      />
+                    </a>
+                  )}
+                </div>
+                {artistText && (
+                  <div
+                    className="text-muted-foreground truncate text-xs"
+                    title={artistText}
+                  >
+                    {artistText}
+                  </div>
+                )}
+              </motion.div>
+            )}
+          </div>
+
+          {/* Transport cluster — lifted out of the tree-width column so the
+          title block has room to breathe. */}
+          <div className="flex shrink-0 items-center gap-0.5 px-3">
+            <button
               type="button"
-              data-testid="player-artwork"
-              className="bg-muted relative flex size-10 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md"
-              onClick={() => setExpanded(true)}
-              title="Expand artwork"
-              aria-label="Expand artwork"
-              aria-expanded={false}
-              transition={morphTransition}
+              onClick={(e) => {
+                previous();
+                e.currentTarget.blur();
+              }}
+              disabled={!hasPrevious && currentTime <= 3}
+              className={cn(
+                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                !hasPrevious &&
+                  currentTime <= 3 &&
+                  "cursor-not-allowed opacity-40 hover:bg-transparent",
+              )}
+              title="Previous (←)"
+              aria-label="Previous track"
             >
-              <img
-                src={artworkUrl}
-                alt=""
-                className="size-full object-cover"
-                onError={(e) => {
-                  (e.currentTarget as HTMLImageElement).style.display = "none";
-                }}
-              />
-            </motion.button>
+              <SkipBack className="size-4" />
+            </button>
+            <button
+              type="button"
+              data-testid="player-toggle"
+              onClick={(e) => {
+                toggle();
+                // Drop focus so a subsequent Space keypress isn't captured by
+                // the button's default activation behavior (which would
+                // re-toggle on top of the window-level keyboard handler).
+                e.currentTarget.blur();
+              }}
+              className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-9 cursor-pointer items-center justify-center rounded-full transition-colors"
+              title={isPlaying ? "Pause (Space)" : "Play (Space)"}
+              aria-label={isPlaying ? "Pause" : "Play"}
+            >
+              {isPlaying ? (
+                <Pause className="size-4" />
+              ) : (
+                <Play className="size-4 translate-x-px" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                next();
+                e.currentTarget.blur();
+              }}
+              disabled={!hasNext}
+              className={cn(
+                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                !hasNext &&
+                  "cursor-not-allowed opacity-40 hover:bg-transparent",
+              )}
+              title="Next (→)"
+              aria-label="Next track"
+            >
+              <SkipForward className="size-4" />
+            </button>
+          </div>
+
+          {/* Target-BPM pitcher — displays current BPM and allows pitching
+          playback. Sits between transport and waveform. */}
+          <BpmPitcher />
+
+          {/* Musical key (Rekordbox analysis), when known. */}
+          {currentTrack.musicalKey && (
+            <div
+              className="text-muted-foreground flex shrink-0 items-center pr-1 text-xs font-medium tabular-nums"
+              title="Key"
+            >
+              {currentTrack.musicalKey}
+            </div>
           )}
 
-          {/* Title + artist — morphs into the expanded panel's title row. */}
-          {!expanded && (
-            <motion.div
-              layoutId="player-title"
-              layoutDependency={expanded}
-              className="flex min-w-0 flex-1 flex-col gap-0.5"
-              transition={morphTransition}
+          {errorMsg ? (
+            <div
+              role="alert"
+              className="text-destructive flex shrink-0 items-center px-3 text-xs"
             >
-              <div className="flex min-w-0 items-center gap-1.5">
-                <span className="truncate text-xs" title={titleText}>
-                  {titleText}
-                </span>
-                {currentTrack.permalinkUrl && (
-                  <a
-                    href={currentTrack.permalinkUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
-                    title="Open on SoundCloud"
-                    aria-label="Open on SoundCloud"
-                  >
-                    <img
-                      src="/icons/soundcloud.svg"
-                      alt=""
-                      className="size-3 dark:invert"
-                    />
-                  </a>
+              {errorMsg}
+            </div>
+          ) : (
+            <>
+              {/* Current time (+ bar.beat when a beatgrid is available) */}
+              <div className="text-muted-foreground flex shrink-0 flex-col items-start justify-center pl-2 text-xs leading-tight tabular-nums">
+                <span>{formatTime(currentTime)}</span>
+                {barBeat && (
+                  <span className="text-[10px] opacity-70" title="Bar.beat">
+                    {barBeat}
+                  </span>
                 )}
               </div>
-              {artistText && (
-                <div
-                  className="text-muted-foreground truncate text-xs"
-                  title={artistText}
-                >
-                  {artistText}
-                </div>
-              )}
-            </motion.div>
-          )}
-        </div>
 
-        {/* Transport cluster — lifted out of the tree-width column so the
-          title block has room to breathe. */}
-        <div className="flex shrink-0 items-center gap-0.5 px-3">
-          <button
-            type="button"
-            onClick={(e) => {
-              previous();
-              e.currentTarget.blur();
-            }}
-            disabled={!hasPrevious && currentTime <= 3}
-            className={cn(
-              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-              !hasPrevious &&
-                currentTime <= 3 &&
-                "cursor-not-allowed opacity-40 hover:bg-transparent",
-            )}
-            title="Previous (←)"
-            aria-label="Previous track"
-          >
-            <SkipBack className="size-4" />
-          </button>
-          <button
-            type="button"
-            data-testid="player-toggle"
-            onClick={(e) => {
-              toggle();
-              // Drop focus so a subsequent Space keypress isn't captured by
-              // the button's default activation behavior (which would
-              // re-toggle on top of the window-level keyboard handler).
-              e.currentTarget.blur();
-            }}
-            className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-9 cursor-pointer items-center justify-center rounded-full transition-colors"
-            title={isPlaying ? "Pause (Space)" : "Play (Space)"}
-            aria-label={isPlaying ? "Pause" : "Play"}
-          >
-            {isPlaying ? (
-              <Pause className="size-4" />
-            ) : (
-              <Play className="size-4 translate-x-px" />
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              next();
-              e.currentTarget.blur();
-            }}
-            disabled={!hasNext}
-            className={cn(
-              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-              !hasNext && "cursor-not-allowed opacity-40 hover:bg-transparent",
-            )}
-            title="Next (→)"
-            aria-label="Next track"
-          >
-            <SkipForward className="size-4" />
-          </button>
-        </div>
-
-        {/* Target-BPM pitcher — displays current BPM and allows pitching
-          playback. Sits between transport and waveform. */}
-        <BpmPitcher />
-
-        {errorMsg ? (
-          <div
-            role="alert"
-            className="text-destructive flex shrink-0 items-center px-3 text-xs"
-          >
-            {errorMsg}
-          </div>
-        ) : (
-          <>
-            {/* Current time — left of waveform */}
-            <div className="text-muted-foreground flex shrink-0 items-center pl-2 text-xs tabular-nums">
-              {formatTime(currentTime)}
-            </div>
-
-            {/* Waveform (fills remaining width) */}
-            <div className="relative flex min-w-0 flex-1 items-center px-3">
+              {/* Waveform (fills remaining width) */}
               <div
-                ref={containerRef}
-                className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
-                style={{ cursor: "pointer" }}
-              />
-              {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
-                  to keep driving audio + progress; this canvas paints the
-                  coloured waveform and owns seek/hover. */}
-              {rekColored && currentTrack.rekordboxId && (
-                <div
-                  data-testid="player-rekordbox-waveform"
-                  data-variant={rekVariant}
-                  className="absolute inset-y-0 right-3 left-3 flex items-center"
-                >
-                  <PlayerRekordboxWaveform
-                    trackId={currentTrack.rekordboxId}
-                    device={currentTrack.rekordboxDevice}
-                    variant={rekVariant}
-                    durationSec={duration}
-                    className="h-8"
-                  />
-                </div>
-              )}
-              {/* Loading-state fallback progress — fades out once waveform is ready. */}
-              <div
-                className={cn(
-                  "bg-surface-3 pointer-events-none absolute right-3 bottom-2 left-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
-                  ready ? "opacity-0" : "opacity-100",
-                )}
+                className="relative flex min-w-0 flex-1 items-center px-3"
+                onWheel={
+                  zoomable
+                    ? (e) => {
+                        e.preventDefault();
+                        changeZoom(e.deltaY < 0 ? 1 : -1);
+                      }
+                    : undefined
+                }
               >
                 <div
-                  className="bg-primary h-full"
-                  style={{ width: `${Math.min(100, loadingProgress * 100)}%` }}
+                  ref={containerRef}
+                  className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
+                  style={{ cursor: "pointer" }}
                 />
+                {/* Phrase sections + cue markers + zoom-window indicator over
+                    the whole-track overview (rekordbox tracks with analysis). */}
+                {(viewport ||
+                  (duration > 0 &&
+                    (analysis?.cues.length || analysis?.sections?.length))) && (
+                  <div className="pointer-events-none absolute inset-y-2 right-3 left-3">
+                    {/* Phrase-section band along the top edge. */}
+                    {duration > 0 &&
+                      analysis?.sections?.map((s, i) => (
+                        <div
+                          key={i}
+                          data-testid="player-section"
+                          className="absolute top-0 flex h-2.5 items-center overflow-hidden rounded-[1px] px-0.5"
+                          style={{
+                            left: `${(s.startMs / 1000 / duration) * 100}%`,
+                            width: `${((s.endMs - s.startMs) / 1000 / duration) * 100}%`,
+                            backgroundColor:
+                              SECTION_COLOR_VAR[s.kind] ??
+                              SECTION_COLOR_VAR.other,
+                          }}
+                        >
+                          <span className="truncate text-[8px] leading-none font-medium text-black/70">
+                            {s.label}
+                          </span>
+                        </div>
+                      ))}
+                    {duration > 0 &&
+                      analysis?.cues.map((c, i) => (
+                        <div
+                          key={i}
+                          className="absolute inset-y-0 w-px"
+                          style={{
+                            left: `${(c.timeMs / 1000 / duration) * 100}%`,
+                            backgroundColor:
+                              c.color ??
+                              (c.type === "hot" ? "#f97316" : "#f43f5e"),
+                          }}
+                        />
+                      ))}
+                    {viewport && (
+                      <div
+                        className="border-primary/70 bg-primary/15 absolute inset-y-0 rounded-sm border"
+                        style={{
+                          left: `${viewport.left * 100}%`,
+                          width: `${viewport.width * 100}%`,
+                        }}
+                      />
+                    )}
+                  </div>
+                )}
+                {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
+                  to keep driving audio + progress; this canvas paints the
+                  coloured waveform and owns seek/hover. */}
+                {rekColored && currentTrack.rekordboxId && (
+                  <div
+                    data-testid="player-rekordbox-waveform"
+                    data-variant={rekVariant}
+                    className="absolute inset-y-0 right-3 left-3 flex items-center"
+                  >
+                    <PlayerRekordboxWaveform
+                      trackId={currentTrack.rekordboxId}
+                      device={currentTrack.rekordboxDevice}
+                      variant={rekVariant}
+                      durationSec={duration}
+                      className="h-8"
+                    />
+                  </div>
+                )}
+                {/* Loading-state fallback progress — fades out once waveform is ready. */}
+                <div
+                  className={cn(
+                    "bg-surface-3 pointer-events-none absolute right-3 bottom-2 left-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
+                    ready ? "opacity-0" : "opacity-100",
+                  )}
+                >
+                  <div
+                    className="bg-primary h-full"
+                    style={{
+                      width: `${Math.min(100, loadingProgress * 100)}%`,
+                    }}
+                  />
+                </div>
               </div>
-            </div>
 
-            {/* Total duration — right of waveform */}
-            <div className="text-muted-foreground flex shrink-0 items-center pr-4 text-xs tabular-nums">
-              {formatTime(duration)}
-            </div>
-          </>
-        )}
+              {/* Zoom controls — hidden for SoundCloud streams. */}
+              {zoomable && (
+                <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 pl-1">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      changeZoom(1);
+                      e.currentTarget.blur();
+                    }}
+                    disabled={zoomBars === 4}
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+                      zoomBars === 4 &&
+                        "cursor-not-allowed opacity-40 hover:bg-transparent",
+                    )}
+                    title="Zoom in"
+                    aria-label="Zoom in"
+                  >
+                    <ZoomIn className="size-3.5" />
+                  </button>
+                  <span className="text-muted-foreground text-[9px] tabular-nums">
+                    {zoomBars == null ? "—" : zoomBars}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      changeZoom(-1);
+                      e.currentTarget.blur();
+                    }}
+                    disabled={zoomBars == null}
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+                      zoomBars == null &&
+                        "cursor-not-allowed opacity-40 hover:bg-transparent",
+                    )}
+                    title="Zoom out"
+                    aria-label="Zoom out"
+                  >
+                    <ZoomOut className="size-3.5" />
+                  </button>
+                </div>
+              )}
+
+              {/* Total duration — right of waveform */}
+              <div className="text-muted-foreground flex shrink-0 items-center pr-4 text-xs tabular-nums">
+                {formatTime(duration)}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -2,10 +2,12 @@
 
 import Hls from "hls.js";
 import {
+  AudioWaveform,
   ChevronLeft,
   ChevronRight,
   Pause,
   Play,
+  Repeat,
   SkipBack,
   SkipForward,
   ZoomIn,
@@ -19,6 +21,7 @@ import { PlayerDetailWaveform } from "@/components/player-detail-waveform";
 import { PlayerRekordboxWaveform } from "@/components/player-rekordbox-waveform";
 import { loadWaveform, pwv4ToPeaks } from "@/components/rekordbox-waveform";
 import { api } from "@/lib/api";
+import { LoopingWebAudioPlayer } from "@/lib/looping-web-audio-player";
 import { usePlayer } from "@/lib/player-context";
 import { selectPeaksSource } from "@/lib/player-peaks";
 import {
@@ -35,16 +38,20 @@ import {
 import { useWaveformStyle } from "@/lib/use-waveform-style";
 import { cn } from "@/lib/utils";
 import {
-  barBeatLabel,
   barSpanSeconds,
-  buildDownbeatPrefix,
-  hotCueLetter,
+  computeCueDisplays,
+  keySemitonesForRate,
+  semitonesFloatForRate,
   textOn,
+  transposeKey,
 } from "@/lib/waveform-detail";
 
-/** Zoom steps: `null` = whole-track overview only, then bars visible. */
-const ZOOM_LEVELS: (number | null)[] = [null, 128, 64, 32, 16, 8, 4];
+/** Zoom steps (bars visible in the detail strip), widest → tightest. */
+const ZOOM_LEVELS = [128, 64, 32, 16, 8, 4] as const;
+const DEFAULT_ZOOM = 32;
 const ZOOM_KEY = "player.zoomBars";
+/** Whether the zoomed detail strip is shown (toggled independently of zoom). */
+const DETAIL_KEY = "player.detailOpen";
 
 /** Selectable loop lengths, in beats. */
 const LOOP_BEAT_STEPS = [1, 2, 4, 8, 16, 32] as const;
@@ -52,20 +59,21 @@ const LOOP_BEAT_STEPS = [1, 2, 4, 8, 16, 32] as const;
 /** Phrase-kind → chart token (defined in globals.css). Colours the phrase band
  * drawn over the whole-track overview. */
 const SECTION_COLOR_VAR: Record<string, string> = {
-  intro: "var(--chart-1)",
-  down: "var(--chart-1)",
-  verse: "var(--chart-2)",
-  chorus: "var(--chart-3)",
-  up: "var(--chart-3)",
-  bridge: "var(--chart-4)",
-  outro: "var(--chart-5)",
-  other: "var(--border-strong)",
+  intro: "var(--section-intro)",
+  verse: "var(--section-verse)",
+  up: "var(--section-up)",
+  chorus: "var(--section-chorus)",
+  down: "var(--section-down)",
+  bridge: "var(--section-bridge)",
+  outro: "var(--section-outro)",
+  other: "var(--section-other)",
 };
 
 /** Step one level toward zoomed-in (`dir=1`) or zoomed-out (`dir=-1`). */
-function stepZoom(current: number | null, dir: 1 | -1): number | null {
-  const i = ZOOM_LEVELS.indexOf(current);
-  const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, i + dir));
+function stepZoom(current: number, dir: 1 | -1): number {
+  const i = ZOOM_LEVELS.indexOf(current as (typeof ZOOM_LEVELS)[number]);
+  const base = i < 0 ? ZOOM_LEVELS.indexOf(DEFAULT_ZOOM) : i;
+  const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, base + dir));
   return ZOOM_LEVELS[next];
 }
 
@@ -135,6 +143,9 @@ export function WaveformPlayer() {
   const rootRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WaveSurferType | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Local tracks play through Web Audio (gapless loop + instant cue); SoundCloud
+  // streams stay on the HTMLAudioElement above. Exactly one is live at a time.
+  const webAudioRef = useRef<LoopingWebAudioPlayer | null>(null);
   const isPlayingRef = useRef(isPlaying);
   const nextRef = useRef(next);
   const hasNextRef = useRef(hasNext);
@@ -142,7 +153,8 @@ export function WaveformPlayer() {
   const [currentTime, setCurrentTime] = useState(0);
   const [ready, setReady] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [zoomBars, setZoomBars] = useState<number | null>(null);
+  const [zoomBars, setZoomBars] = useState<number>(DEFAULT_ZOOM);
+  const [detailOpen, setDetailOpen] = useState(false);
   const [analysis, setAnalysis] = useState<TrackAnalysis | null>(null);
 
   // Cue + loop (in-memory only; reset on track change). The temp cue point is a
@@ -152,16 +164,24 @@ export function WaveformPlayer() {
   const [loopActive, setLoopActive] = useState(false);
   const [loopStartSec, setLoopStartSec] = useState(0);
   const [loopBeats, setLoopBeats] = useState(8);
+  // Explicit loop end (seconds) when a loop is armed from a rekordbox loop cue;
+  // null falls back to the beat-length calc. Cleared by the beat controls.
+  const [loopEndOverride, setLoopEndOverride] = useState<number | null>(null);
   const loopRef = useRef<{ start: number; end: number } | null>(null);
 
   const waveformStyle = useWaveformStyle();
 
-  // Hydrate the persisted zoom level once on mount.
+  // Hydrate the persisted zoom level + detail-strip visibility once on mount.
   useEffect(() => {
-    getRaw<number | null>(ZOOM_KEY, null)
+    getRaw<number>(ZOOM_KEY, DEFAULT_ZOOM)
       .then((v) => {
-        if (ZOOM_LEVELS.includes(v)) setZoomBars(v);
+        if (ZOOM_LEVELS.includes(v as (typeof ZOOM_LEVELS)[number])) {
+          setZoomBars(v);
+        }
       })
+      .catch(() => {});
+    getRaw<boolean>(DETAIL_KEY, false)
+      .then((v) => setDetailOpen(!!v))
       .catch(() => {});
   }, []);
 
@@ -169,6 +189,14 @@ export function WaveformPlayer() {
     setZoomBars((prev) => {
       const next = stepZoom(prev, dir);
       setRaw(ZOOM_KEY, next).catch(() => {});
+      return next;
+    });
+  };
+
+  const toggleDetail = () => {
+    setDetailOpen((prev) => {
+      const next = !prev;
+      setRaw(DETAIL_KEY, next).catch(() => {});
       return next;
     });
   };
@@ -189,24 +217,23 @@ export function WaveformPlayer() {
     };
   }, [rekId, rekDevice]);
 
-  const downbeatPrefix = useMemo(
-    () => buildDownbeatPrefix(analysis?.beatgrid ?? []),
-    [analysis],
-  );
-
   // --- cue + loop ---
   const loopEndSec = useMemo(() => {
+    if (loopEndOverride != null) return loopEndOverride;
     if (!currentBpm || currentBpm <= 0) return null;
     return loopStartSec + (loopBeats * 60) / currentBpm;
-  }, [currentBpm, loopStartSec, loopBeats]);
+  }, [loopEndOverride, currentBpm, loopStartSec, loopBeats]);
 
-  // Mirror the active loop into a ref the audioprocess handler reads, so it
-  // stays live without re-subscribing the WaveSurfer listener on every change.
+  // Drive the loop region. Local tracks loop natively on the Web Audio buffer
+  // (sample-accurate, gapless); the ref is the fallback the audioprocess handler
+  // reads for the SoundCloud (HTMLAudioElement) path.
   useEffect(() => {
-    loopRef.current =
+    const region =
       loopActive && loopEndSec != null
         ? { start: loopStartSec, end: loopEndSec }
         : null;
+    loopRef.current = region;
+    webAudioRef.current?.setLoop(region);
   }, [loopActive, loopStartSec, loopEndSec]);
 
   // Clear cue + loop when the track changes.
@@ -214,6 +241,7 @@ export function WaveformPlayer() {
   useEffect(() => {
     setCueSec(null);
     setLoopActive(false);
+    setLoopEndOverride(null);
   }, [trackKey]);
 
   // Snap a time to the nearest beat when a beatgrid is available.
@@ -263,6 +291,7 @@ export function WaveformPlayer() {
 
   const toggleLoop = () => {
     if (!currentBpm || currentBpm <= 0) return;
+    setLoopEndOverride(null); // beat-length loop from here
     setLoopActive((active) => {
       if (!active) setLoopStartSec(snapToBeat(currentTime));
       return !active;
@@ -270,6 +299,7 @@ export function WaveformPlayer() {
   };
 
   const changeLoopBeats = (dir: 1 | -1) => {
+    setLoopEndOverride(null); // switch back to a beat-length loop
     setLoopBeats((prev) => {
       const i = LOOP_BEAT_STEPS.indexOf(
         prev as (typeof LOOP_BEAT_STEPS)[number],
@@ -278,6 +308,18 @@ export function WaveformPlayer() {
         Math.max(0, Math.min(LOOP_BEAT_STEPS.length - 1, i + dir))
       ];
     });
+  };
+
+  // Arm the loop from a rekordbox loop cue (explicit in/out points) and jump to
+  // its start. A quick seek for a plain cue; an active loop for a loop cue.
+  const jumpToCue = (timeSec: number, outSec: number | null) => {
+    if (duration <= 0) return;
+    if (outSec != null && outSec > timeSec) {
+      setLoopStartSec(timeSec);
+      setLoopEndOverride(outSec);
+      setLoopActive(true);
+    }
+    seek(timeSec / duration);
   };
 
   // Publish the player's actual height so the layout shell can reserve exactly
@@ -475,133 +517,188 @@ export function WaveformPlayer() {
             )
           : Promise.resolve(undefined);
 
-      const audio = new Audio();
-      audio.preload = "auto";
-      // Attach to DOM so platform pause events (headphones unplugged, etc.)
-      // dispatch reliably and so tests can reach the element.
-      audio.hidden = true;
-      document.body.appendChild(audio);
-      audioRef.current = audio;
+      // Both playback paths converge on the shared WaveSurfer setup below via
+      // these: the resolved peaks, the WaveSurfer + hover modules, the decoded
+      // duration, and the playback `media` (a Web Audio buffer player for local
+      // tracks, an HTMLAudioElement for SoundCloud streams).
+      let media: HTMLAudioElement | LoopingWebAudioPlayer;
+      let knownDuration: number;
+      let peaks: number[];
+      let wsMod: typeof import("wavesurfer.js");
+      let hoverMod: typeof import("wavesurfer.js/dist/plugins/hover.esm.js");
+      const isLocal = peaksSource.kind !== "soundcloud";
 
-      // Sync React state when the OS pauses our audio behind our back —
-      // e.g. headphones unplugged or Bluetooth device disconnects. Without
-      // this, isPlaying stays true and the UI shows "playing" with no sound.
-      // We ignore self-initiated pauses two ways: ws.pause() fires this
-      // event, but by then isPlayingRef is already false (the [isPlaying]
-      // effect updated it). Track-change cleanup also fires pause(), but by
-      // then audioRef has been swapped to the new track's element, so the
-      // ref-equality check skips it.
-      audio.addEventListener("pause", () => {
-        if (audioRef.current !== audio) return;
-        if (isPlayingRef.current && audio.paused) pause();
-      });
-
-      // Start playback as soon as the browser has enough buffered data.
-      // This fires well before WaveSurfer's `ready` (which waits for peaks
-      // + a finite duration), cutting the "click-to-first-note" latency.
-      const resolvedStreamUrl = await streamUrlPromise;
-      if (cancelled) return;
-      // For SC tracks the resolve can fail — bail before attaching a bad src.
-      // Flag the track unplayable so the queue's auto-skip effect advances
-      // past it. Don't set errorMsg here: the JSX swaps the container div
-      // out for the error text, and the next track's init() runs synchronously
-      // before React re-renders to clear the error — so containerRef.current
-      // is null and that init bails too, leaving the waveform unrendered.
-      if (
-        currentTrack!.streamRefreshKey !== undefined &&
-        currentTrack!.streamRefreshKey !== null &&
-        !resolvedStreamUrl
-      ) {
-        const sid =
-          typeof currentTrack!.streamRefreshKey === "number"
-            ? currentTrack!.streamRefreshKey
-            : Number(currentTrack!.streamRefreshKey);
-        if (Number.isFinite(sid) && sid > 0) markScUnplayable(sid);
-        return;
-      }
-      const sourceUrl =
-        resolvedStreamUrl ?? api.getAudioUrl(currentTrack!.filePath);
-
-      const onStreamExpired = async () => {
-        if (retriedStreamRefresh || !currentTrack!.streamRefreshKey) return;
-        retriedStreamRefresh = true;
-        // Evict the frontend cache AND force the backend to bypass its own
-        // cache — without force_refresh the server would hand us the same
-        // stale URL that just 403'd.
-        invalidateSoundcloudStreamUrl(currentTrack!.streamRefreshKey);
+      if (isLocal) {
+        // Local file → Web Audio: fetch + decode the whole buffer, then play it
+        // through a source node. Seeks reschedule the node (no HTMLMediaElement
+        // seek stall), so cue points are instant and loops wrap gaplessly.
+        const player = new LoopingWebAudioPlayer();
+        webAudioRef.current = player;
+        media = player;
+        // Mirror the HTMLAudioElement's OS-pause sync (headphones unplugged).
+        player.addEventListener("pause", () => {
+          if (webAudioRef.current !== player) return;
+          if (isPlayingRef.current && player.paused) pause();
+        });
+        // USB Rekordbox exports route audio through the device endpoint
+        // (`streamUrl`); plain local files fall back to the file-path endpoint.
+        const resolvedStreamUrl = await streamUrlPromise;
+        if (cancelled) return;
+        const sourceUrl =
+          resolvedStreamUrl ?? api.getAudioUrl(currentTrack!.filePath);
         try {
-          const url = await getCachedSoundcloudStreamUrl(
-            currentTrack!.streamRefreshKey,
-            { forceRefresh: true },
-          );
+          const [p, ws1, hover1] = await Promise.all([
+            peaksPromise,
+            wsImportPromise,
+            hoverImportPromise,
+            player.loadBuffer(sourceUrl),
+          ]);
+          peaks = p;
+          wsMod = ws1;
+          hoverMod = hover1;
+        } catch (err) {
           if (cancelled) return;
-          // Confirm the refreshed URL is actually live before swapping it in
-          // — otherwise we silently replace a broken source with another
-          // broken one and the user just sees a dead player. Range-byte HEAD
-          // equivalent works against HLS playlist CDNs that reject bare HEAD.
+          console.error("[player] failed to load local audio:", err);
+          setErrorMsg("Couldn't load the audio file.");
+          return;
+        }
+        if (cancelled || !containerRef.current) return;
+        if (!isFinite(player.duration) || player.duration <= 0) return;
+        knownDuration = player.duration;
+        registerSeek((ratio) => {
+          player.currentTime =
+            Math.max(0, Math.min(1, ratio)) * player.duration;
+        });
+      } else {
+        const audio = new Audio();
+        audio.preload = "auto";
+        // Attach to DOM so platform pause events (headphones unplugged, etc.)
+        // dispatch reliably and so tests can reach the element.
+        audio.hidden = true;
+        document.body.appendChild(audio);
+        audioRef.current = audio;
+
+        // Sync React state when the OS pauses our audio behind our back —
+        // e.g. headphones unplugged or Bluetooth device disconnects. Without
+        // this, isPlaying stays true and the UI shows "playing" with no sound.
+        // We ignore self-initiated pauses two ways: ws.pause() fires this
+        // event, but by then isPlayingRef is already false (the [isPlaying]
+        // effect updated it). Track-change cleanup also fires pause(), but by
+        // then audioRef has been swapped to the new track's element, so the
+        // ref-equality check skips it.
+        audio.addEventListener("pause", () => {
+          if (audioRef.current !== audio) return;
+          if (isPlayingRef.current && audio.paused) pause();
+        });
+
+        // Start playback as soon as the browser has enough buffered data.
+        // This fires well before WaveSurfer's `ready` (which waits for peaks
+        // + a finite duration), cutting the "click-to-first-note" latency.
+        const resolvedStreamUrl = await streamUrlPromise;
+        if (cancelled) return;
+        // For SC tracks the resolve can fail — bail before attaching a bad src.
+        // Flag the track unplayable so the queue's auto-skip effect advances
+        // past it. Don't set errorMsg here: the JSX swaps the container div
+        // out for the error text, and the next track's init() runs synchronously
+        // before React re-renders to clear the error — so containerRef.current
+        // is null and that init bails too, leaving the waveform unrendered.
+        if (
+          currentTrack!.streamRefreshKey !== undefined &&
+          currentTrack!.streamRefreshKey !== null &&
+          !resolvedStreamUrl
+        ) {
+          const sid =
+            typeof currentTrack!.streamRefreshKey === "number"
+              ? currentTrack!.streamRefreshKey
+              : Number(currentTrack!.streamRefreshKey);
+          if (Number.isFinite(sid) && sid > 0) markScUnplayable(sid);
+          return;
+        }
+        const sourceUrl =
+          resolvedStreamUrl ?? api.getAudioUrl(currentTrack!.filePath);
+
+        const onStreamExpired = async () => {
+          if (retriedStreamRefresh || !currentTrack!.streamRefreshKey) return;
+          retriedStreamRefresh = true;
+          // Evict the frontend cache AND force the backend to bypass its own
+          // cache — without force_refresh the server would hand us the same
+          // stale URL that just 403'd.
+          invalidateSoundcloudStreamUrl(currentTrack!.streamRefreshKey);
           try {
-            const probe = await fetch(url, {
-              method: "GET",
-              headers: { Range: "bytes=0-0" },
-            });
-            if (!probe.ok) {
+            const url = await getCachedSoundcloudStreamUrl(
+              currentTrack!.streamRefreshKey,
+              { forceRefresh: true },
+            );
+            if (cancelled) return;
+            // Confirm the refreshed URL is actually live before swapping it in
+            // — otherwise we silently replace a broken source with another
+            // broken one and the user just sees a dead player. Range-byte HEAD
+            // equivalent works against HLS playlist CDNs that reject bare HEAD.
+            try {
+              const probe = await fetch(url, {
+                method: "GET",
+                headers: { Range: "bytes=0-0" },
+              });
+              if (!probe.ok) {
+                setErrorMsg(
+                  `Refreshed stream URL returned ${probe.status}. Playback stopped.`,
+                );
+                return;
+              }
+            } catch (probeErr) {
+              console.error("Refreshed HLS URL probe failed:", probeErr);
               setErrorMsg(
-                `Refreshed stream URL returned ${probe.status}. Playback stopped.`,
+                "Couldn't reach the refreshed stream URL. Playback stopped.",
               );
               return;
             }
-          } catch (probeErr) {
-            console.error("Refreshed HLS URL probe failed:", probeErr);
-            setErrorMsg(
-              "Couldn't reach the refreshed stream URL. Playback stopped.",
-            );
-            return;
+            if (cancelled) return;
+            hls?.destroy();
+            hls = attachAudioSource(audio, url, {
+              onExpired: () => {
+                // Fresh URL also 403'd — this isn't expiry, it's SoundCloud
+                // refusing to stream the track to our app entirely (label
+                // upload, geo-restriction, owner-disabled streaming).
+                console.warn(
+                  "[player] refreshed HLS URL also returned 403; track restricted",
+                );
+                const sid =
+                  typeof currentTrack!.streamRefreshKey === "number"
+                    ? currentTrack!.streamRefreshKey
+                    : Number(currentTrack!.streamRefreshKey);
+                if (Number.isFinite(sid) && sid > 0) markScUnplayable(sid);
+                // No setErrorMsg: the unplayable flag triggers auto-skip,
+                // and showing the error swaps out containerRef before the
+                // next track's init() can use it (see initial-bail comment).
+              },
+            });
+          } catch (err) {
+            console.warn("[player] failed to refresh HLS stream URL:", err);
+            setErrorMsg("Couldn't refresh the stream URL.");
           }
-          if (cancelled) return;
-          hls?.destroy();
-          hls = attachAudioSource(audio, url, {
-            onExpired: () => {
-              // Fresh URL also 403'd — this isn't expiry, it's SoundCloud
-              // refusing to stream the track to our app entirely (label
-              // upload, geo-restriction, owner-disabled streaming).
-              console.warn(
-                "[player] refreshed HLS URL also returned 403; track restricted",
-              );
-              const sid =
-                typeof currentTrack!.streamRefreshKey === "number"
-                  ? currentTrack!.streamRefreshKey
-                  : Number(currentTrack!.streamRefreshKey);
-              if (Number.isFinite(sid) && sid > 0) markScUnplayable(sid);
-              // No setErrorMsg: the unplayable flag triggers auto-skip,
-              // and showing the error swaps out containerRef before the
-              // next track's init() can use it (see initial-bail comment).
-            },
-          });
-        } catch (err) {
-          console.warn("[player] failed to refresh HLS stream URL:", err);
-          setErrorMsg("Couldn't refresh the stream URL.");
-        }
-      };
+        };
 
-      hls = attachAudioSource(audio, sourceUrl, { onExpired: onStreamExpired });
-
-      // Seeks only need the media element + a finite duration — register as
-      // soon as metadata lands instead of waiting for `ws.ready` (which
-      // blocks on the peaks fetch). Pending seeks (play-from-position via a
-      // row waveform click) apply the moment this registers.
-      const registerAudioSeek = () => {
-        if (cancelled) return;
-        registerSeek((ratio) => {
-          audio.currentTime = Math.max(0, Math.min(1, ratio)) * audio.duration;
+        hls = attachAudioSource(audio, sourceUrl, {
+          onExpired: onStreamExpired,
         });
-      };
 
-      // Now await the remaining work in parallel: peaks, waveform module
-      // imports, and a finite audio.duration. Audio playback has already
-      // been kicked off via the `canplay` listener, so this path only
-      // affects when the waveform appears — not when sound starts.
-      const [peaks, { default: WaveSurfer }, { default: HoverPlugin }] =
-        await Promise.all([
+        // Seeks only need the media element + a finite duration — register as
+        // soon as metadata lands instead of waiting for `ws.ready` (which
+        // blocks on the peaks fetch). Pending seeks (play-from-position via a
+        // row waveform click) apply the moment this registers.
+        const registerAudioSeek = () => {
+          if (cancelled) return;
+          registerSeek((ratio) => {
+            audio.currentTime =
+              Math.max(0, Math.min(1, ratio)) * audio.duration;
+          });
+        };
+
+        // Now await the remaining work in parallel: peaks, waveform module
+        // imports, and a finite audio.duration. Audio playback has already
+        // been kicked off via the `canplay` listener, so this path only
+        // affects when the waveform appears — not when sound starts.
+        const [scPeaks, scWsMod, scHoverMod] = await Promise.all([
           peaksPromise,
           wsImportPromise,
           hoverImportPromise,
@@ -639,9 +736,17 @@ export function WaveformPlayer() {
             audio.addEventListener("error", onError, { once: true });
           }),
         ]);
-      if (cancelled || !containerRef.current) return;
-      if (!isFinite(audio.duration) || audio.duration <= 0) return;
-      const knownDuration = audio.duration;
+        if (cancelled || !containerRef.current) return;
+        if (!isFinite(audio.duration) || audio.duration <= 0) return;
+        peaks = scPeaks;
+        wsMod = scWsMod;
+        hoverMod = scHoverMod;
+        knownDuration = audio.duration;
+        media = audio;
+      }
+
+      const WaveSurfer = wsMod.default;
+      const HoverPlugin = hoverMod.default;
 
       const isDark = document.documentElement.classList.contains("dark");
 
@@ -688,7 +793,9 @@ export function WaveformPlayer() {
         interact: true,
         peaks: [peaks],
         duration: knownDuration,
-        media: audio,
+        // WaveSurfer types `media` as HTMLMediaElement; it also accepts its own
+        // WebAudioPlayer (which LoopingWebAudioPlayer extends) as documented.
+        media: media as HTMLMediaElement,
         plugins: [
           HoverPlugin.create({
             lineColor: isDark ? "rgba(255,255,255,0.35)" : "rgba(0,0,0,0.25)",
@@ -708,20 +815,28 @@ export function WaveformPlayer() {
 
       wsRef.current = ws;
 
+      // Apply any loop that was toggled on before this player was wired up.
+      if (isLocal) webAudioRef.current?.setLoop(loopRef.current);
+
       ws.on("ready", () => {
         if (cancelled) return;
         setDuration(knownDuration);
         reportDuration(knownDuration);
         setReady(true);
         registerSeek((ratio) => {
-          audio.currentTime = Math.max(0, Math.min(1, ratio)) * audio.duration;
+          media.currentTime = Math.max(0, Math.min(1, ratio)) * media.duration;
         });
-        if (isPlayingRef.current) ws!.play();
+        // Web Audio play() resumes the AudioContext, which can reject if the
+        // track was torn down between ready and this call — swallow it.
+        if (isPlayingRef.current) ws!.play().catch(() => {});
       });
 
       ws.on("audioprocess", () => {
         let t = ws!.getCurrentTime();
-        const lp = loopRef.current;
+        // Local tracks loop natively on the buffer node (already wrapped in
+        // `t`). The SoundCloud element path has no loop, but keep the seek-wrap
+        // as a guarded fallback.
+        const lp = webAudioRef.current ? null : loopRef.current;
         if (lp && t >= lp.end) {
           ws!.setTime(lp.start);
           t = lp.start;
@@ -734,7 +849,7 @@ export function WaveformPlayer() {
         if (hasNextRef.current) {
           nextRef.current();
         } else {
-          audio.currentTime = 0;
+          media.currentTime = 0;
           setCurrentTime(0);
           reportProgress(0);
         }
@@ -768,6 +883,11 @@ export function WaveformPlayer() {
         audioRef.current.remove();
         audioRef.current = null;
       }
+      if (webAudioRef.current) {
+        // Stops the source node and closes the AudioContext (idempotent).
+        webAudioRef.current.destroy();
+        webAudioRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTrack?.filePath, reportProgress, registerSeek, reportDuration]);
@@ -776,7 +896,7 @@ export function WaveformPlayer() {
     const ws = wsRef.current;
     if (!ws || !ready) return;
     if (isPlaying) {
-      ws.play();
+      ws.play().catch(() => {});
     } else {
       ws.pause();
     }
@@ -786,13 +906,14 @@ export function WaveformPlayer() {
   // audio element's `src` changes, so this effect re-fires after every track
   // load via the `ready` dependency.
   useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    // Couple pitch to rate (vinyl-style) — browsers default preservesPitch to
-    // true, which keeps the original pitch while changing tempo. For a DJ
-    // pitcher we want both to shift together.
-    audio.preservesPitch = false;
-    audio.playbackRate = computePlaybackRate(
+    const media = webAudioRef.current ?? audioRef.current;
+    if (!media) return;
+    // Couple pitch to rate (vinyl-style). The HTMLAudioElement defaults
+    // preservesPitch to true, keeping the original pitch while changing tempo;
+    // for a DJ pitcher we want both to shift together. The Web Audio buffer
+    // source already couples them, so this only applies to the element path.
+    if (media instanceof HTMLAudioElement) media.preservesPitch = false;
+    media.playbackRate = computePlaybackRate(
       pitchEnabled,
       currentBpm,
       targetBpm,
@@ -839,6 +960,18 @@ export function WaveformPlayer() {
 
   if (!currentTrack) return null;
 
+  // Hot cues get a colour + letter; memory cues a running number. Computed once
+  // so the top bar, overview markers and detail strip stay consistent.
+  const cueDisplays = analysis ? computeCueDisplays(analysis.cues) : [];
+  const cueItems = analysis
+    ? analysis.cues.map((cue, i) => ({ cue, display: cueDisplays[i] }))
+    : [];
+  // Top bar splits hot cues (left, in slot order) from memory cues (right).
+  const hotCueItems = cueItems
+    .filter((x) => x.display.isHot)
+    .sort((a, b) => (a.cue.index ?? 0) - (b.cue.index ?? 0));
+  const memCueItems = cueItems.filter((x) => !x.display.isHot);
+
   const artworkUrl =
     currentTrack.artworkUrl ?? api.getArtworkUrl(currentTrack.filePath);
   const titleText = currentTrack.title ?? currentTrack.fileName;
@@ -856,16 +989,28 @@ export function WaveformPlayer() {
   // Zoom is available for everything except SoundCloud streams (whose ~1800
   // pre-baked samples can't resolve a few bars).
   const zoomable = selectPeaksSource(currentTrack).kind !== "soundcloud";
-  const zoomActive = zoomable && zoomBars != null;
-  const barBeat = analysis?.beatgrid.length
-    ? barBeatLabel(currentTime, analysis.beatgrid, downbeatPrefix)
+  // The detail strip (and the rail's expanded BPM/KEY boxes) show only when the
+  // user has toggled it on for a zoomable track.
+  const detailShown = zoomable && detailOpen;
+  // Key readout: the big label is the pitched key (nearest whole semitone),
+  // green while pitching; below it sits the original key + the exact (fractional)
+  // semitone shift, since a pitch often lands between two keys.
+  const playRate = computePlaybackRate(pitchEnabled, currentBpm, targetBpm);
+  const keySemitones = keySemitonesForRate(playRate);
+  const semitonesFloat = semitonesFloatForRate(playRate);
+  const baseKey = currentTrack.musicalKey ?? null;
+  const displayKey = baseKey
+    ? keySemitones
+      ? transposeKey(baseKey, keySemitones)
+      : baseKey
     : null;
+  const keyPitched = displayKey != null && displayKey !== baseKey;
   // Fraction of the track visible in the detail strip — drawn as an indicator
   // rectangle over the whole-track overview.
   const viewport =
-    zoomActive && duration > 0
+    detailShown && duration > 0
       ? (() => {
-          const half = barSpanSeconds(zoomBars!, currentBpm) / 2 / duration;
+          const half = barSpanSeconds(zoomBars, currentBpm) / 2 / duration;
           const center = currentTime / duration;
           return {
             left: Math.max(0, center - half),
@@ -874,179 +1019,214 @@ export function WaveformPlayer() {
         })()
       : null;
 
-  const remaining = Math.max(0, duration - currentTime);
+  // Cue chips for the top utility bar. Hot cues sit over the rail column;
+  // memory cues + the in-memory cue point align with the waveform's left edge.
+  // The Hot/Mem labels always show; the chips appear once the track is loaded.
+  const hotCueChips = (
+    <>
+      <span className="text-2xs text-muted-foreground mr-0.5 shrink-0 tracking-wide uppercase">
+        Hot
+      </span>
+      {duration > 0 &&
+        hotCueItems.map(({ cue, display }, i) => {
+          const isLoop = display.isLoop;
+          return (
+            <button
+              key={i}
+              type="button"
+              data-testid="player-hotcue"
+              data-cue-type={cue.type}
+              onClick={(e) => {
+                jumpToCue(
+                  cue.timeMs / 1000,
+                  cue.outMs != null ? cue.outMs / 1000 : null,
+                );
+                e.currentTarget.blur();
+              }}
+              title={
+                isLoop
+                  ? `Hot cue ${display.label} — loop`
+                  : `Hot cue ${display.label} — jump here`
+              }
+              className="hover:bg-surface-3 flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded pr-1 pl-0.5 transition-colors"
+            >
+              <span
+                className="flex size-4 items-center justify-center rounded-[3px] text-[10px] leading-none font-bold"
+                style={{
+                  backgroundColor: display.color,
+                  color: textOn(display.color),
+                }}
+              >
+                {display.label}
+              </span>
+              {isLoop && (
+                <Repeat className="size-2.5" style={{ color: display.color }} />
+              )}
+            </button>
+          );
+        })}
+    </>
+  );
+
+  const memCueChips = (
+    <>
+      <span className="text-2xs text-muted-foreground mr-0.5 shrink-0 tracking-wide uppercase">
+        Mem
+      </span>
+      {duration > 0 &&
+        memCueItems.map(({ cue, display }, i) => {
+          const isLoop = display.isLoop;
+          return (
+            <button
+              key={i}
+              type="button"
+              data-testid="player-hotcue"
+              data-cue-type={cue.type}
+              onClick={(e) => {
+                jumpToCue(
+                  cue.timeMs / 1000,
+                  cue.outMs != null ? cue.outMs / 1000 : null,
+                );
+                e.currentTarget.blur();
+              }}
+              title={
+                isLoop
+                  ? `Memory cue ${display.label} — loop`
+                  : `Memory cue ${display.label} — jump here`
+              }
+              className="hover:bg-surface-3 flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded pr-1 pl-0.5 transition-colors"
+            >
+              <span
+                className="flex size-4 items-center justify-center rounded-[3px] text-[10px] leading-none font-bold"
+                style={{
+                  backgroundColor: display.color,
+                  color: textOn(display.color),
+                }}
+              >
+                {display.label}
+              </span>
+              {isLoop && (
+                <Repeat className="size-2.5" style={{ color: display.color }} />
+              )}
+            </button>
+          );
+        })}
+      {duration > 0 && cueSec != null && (
+        <button
+          type="button"
+          data-testid="player-cue-chip"
+          onClick={(e) => {
+            seek(cueSec / duration);
+            e.currentTarget.blur();
+          }}
+          title="Cue point — jump here"
+          className="flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded px-1.5 text-[10px] font-semibold text-amber-500 uppercase transition-colors hover:bg-amber-500/10"
+        >
+          Cue
+        </button>
+      )}
+    </>
+  );
+
+  // Detail-strip toggle + zoom stepper for the top bar (hidden for SoundCloud
+  // streams, which aren't zoomable). The zoom stepper sits to the left of the
+  // expander and only appears while the strip is open.
+  const zoomControls = zoomable ? (
+    <div className="flex items-center gap-0.5">
+      {detailOpen && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => {
+              changeZoom(-1);
+              e.currentTarget.blur();
+            }}
+            disabled={zoomBars === ZOOM_LEVELS[0]}
+            className={cn(
+              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+              zoomBars === ZOOM_LEVELS[0] &&
+                "cursor-not-allowed opacity-40 hover:bg-transparent",
+            )}
+            title="Zoom out"
+            aria-label="Zoom out"
+          >
+            <ZoomOut className="size-3.5" />
+          </button>
+          <span className="text-muted-foreground w-6 text-center text-[9px] tabular-nums">
+            {zoomBars}
+          </span>
+          <button
+            type="button"
+            onClick={(e) => {
+              changeZoom(1);
+              e.currentTarget.blur();
+            }}
+            disabled={zoomBars === ZOOM_LEVELS[ZOOM_LEVELS.length - 1]}
+            className={cn(
+              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+              zoomBars === ZOOM_LEVELS[ZOOM_LEVELS.length - 1] &&
+                "cursor-not-allowed opacity-40 hover:bg-transparent",
+            )}
+            title="Zoom in"
+            aria-label="Zoom in"
+          >
+            <ZoomIn className="size-3.5" />
+          </button>
+        </>
+      )}
+      <button
+        type="button"
+        data-testid="player-detail-toggle"
+        data-active={detailOpen || undefined}
+        onClick={(e) => {
+          toggleDetail();
+          e.currentTarget.blur();
+        }}
+        className={cn(
+          "hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+          detailOpen
+            ? "text-primary"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        title={detailOpen ? "Hide zoomed waveform" : "Show zoomed waveform"}
+        aria-label={
+          detailOpen ? "Hide zoomed waveform" : "Show zoomed waveform"
+        }
+        aria-pressed={detailOpen}
+      >
+        <AudioWaveform className="size-3.5" />
+      </button>
+    </div>
+  ) : null;
 
   return (
     <div
       ref={rootRef}
       data-testid="waveform-player"
-      className="border-border fixed right-0 bottom-0 left-14 z-40 flex border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
+      className="border-border fixed right-0 bottom-0 left-14 z-40 flex flex-col border-t bg-[var(--surface-2)] shadow-[0_-8px_32px_rgba(0,0,0,0.18)]"
     >
-      {/* ===== Side rail — all controls live here; the right side is waveforms
-          only. Rows drop from four (expanded) to two (collapsed). ===== */}
-      <div className="border-border flex w-[360px] shrink-0 flex-col justify-center gap-1 border-r px-3 py-1.5">
-        {/* Artwork + title / artist */}
-        <div className="flex min-w-0 items-center gap-2.5">
-          <div
-            data-testid="player-artwork"
-            className="bg-muted size-9 shrink-0 overflow-hidden rounded-md"
-          >
-            <img
-              src={artworkUrl}
-              alt=""
-              className="size-full object-cover"
-              onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = "none";
-              }}
-            />
-          </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <span
-                className="text-primary truncate text-sm font-semibold"
-                title={titleText}
-              >
-                {titleText}
-              </span>
-              {currentTrack.permalinkUrl && (
-                <a
-                  href={currentTrack.permalinkUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
-                  title="Open on SoundCloud"
-                  aria-label="Open on SoundCloud"
-                >
-                  <img
-                    src="/icons/soundcloud.svg"
-                    alt=""
-                    className="size-3 dark:invert"
-                  />
-                </a>
-              )}
-            </div>
-            {artistText && (
-              <span
-                className="text-muted-foreground truncate text-xs"
-                title={artistText}
-              >
-                {artistText}
-              </span>
-            )}
-          </div>
+      {/* ===== Utility line — spans the whole player. Hot cues sit over the
+          rail column; memory cues start at the waveform's left edge; the merged
+          loop control stays far right. ===== */}
+      <div
+        data-testid="player-utility-bar"
+        className="border-border flex h-8 shrink-0 items-center border-b"
+      >
+        {/* Hot cues — over the rail column (matches its 360px width). */}
+        <div className="flex w-[360px] shrink-0 items-center gap-1 overflow-hidden px-3">
+          {hotCueChips}
         </div>
 
-        {/* Transport + time */}
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={(e) => {
-              previous();
-              e.currentTarget.blur();
-            }}
-            disabled={!hasPrevious && currentTime <= 3}
-            className={cn(
-              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
-              !hasPrevious &&
-                currentTime <= 3 &&
-                "cursor-not-allowed opacity-40 hover:bg-transparent",
-            )}
-            title="Previous (←)"
-            aria-label="Previous track"
-          >
-            <SkipBack className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            data-testid="player-toggle"
-            onClick={(e) => {
-              toggle();
-              // Drop focus so a subsequent Space keypress isn't captured by
-              // the button's default activation behavior (which would
-              // re-toggle on top of the window-level keyboard handler).
-              e.currentTarget.blur();
-            }}
-            className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
-            title={isPlaying ? "Pause (Space)" : "Play (Space)"}
-            aria-label={isPlaying ? "Pause" : "Play"}
-          >
-            {isPlaying ? (
-              <Pause className="size-3.5" />
-            ) : (
-              <Play className="size-3.5 translate-x-px" />
-            )}
-          </button>
-          {/* CUE — round CDJ-style button: tap sets/recalls, hold previews. */}
-          <button
-            type="button"
-            data-testid="player-cue-btn"
-            onPointerDown={handleCueDown}
-            onPointerUp={handleCueUp}
-            onPointerCancel={handleCueUp}
-            className={cn(
-              "flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-full border text-[10px] font-semibold transition-colors select-none",
-              cueSec != null
-                ? "border-amber-500 text-amber-500 hover:bg-amber-500/10"
-                : "border-border text-muted-foreground hover:text-foreground hover:bg-surface-3",
-            )}
-            title="Cue — tap to set/recall, hold to preview"
-            aria-label="Cue"
-          >
-            CUE
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              next();
-              e.currentTarget.blur();
-            }}
-            disabled={!hasNext}
-            className={cn(
-              "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
-              !hasNext && "cursor-not-allowed opacity-40 hover:bg-transparent",
-            )}
-            title="Next (→)"
-            aria-label="Next track"
-          >
-            <SkipForward className="size-3.5" />
-          </button>
-
-          {/* Right of transport: time + remaining (expanded) or the pitcher +
-              key · bar.beat inline (collapsed, so the rail stays two rows). */}
-          <div className="ml-auto flex items-center gap-2">
-            {!zoomActive && <BpmPitcher />}
-            <div className="flex flex-col items-end leading-tight tabular-nums">
-              <span className="text-sm font-medium">
-                <span className="text-foreground">
-                  {formatTime(currentTime)}
-                </span>
-                <span className="text-muted-foreground">
-                  {" "}
-                  / {formatTime(duration)}
-                </span>
-              </span>
-              {zoomActive ? (
-                <span className="text-muted-foreground text-xs">
-                  −{formatTime(remaining)} LEFT
-                </span>
-              ) : (
-                <span className="text-muted-foreground flex items-center gap-1 text-xs">
-                  <span title="Key">{currentTrack.musicalKey ?? "—"}</span>
-                  {barBeat && (
-                    <>
-                      <span>·</span>
-                      <span title="Bar.beat">{barBeat}</span>
-                    </>
-                  )}
-                </span>
-              )}
-            </div>
+        {/* Memory cues start where the waveform starts; loop control far right. */}
+        <div className="flex flex-1 items-center gap-2 pr-3 pl-2">
+          <div className="flex min-w-0 items-center gap-1 overflow-hidden">
+            {memCueChips}
           </div>
-        </div>
 
-        {/* Expanded only: loop row + BPM/KEY boxes. */}
-        {zoomActive && (
-          <>
+          {/* Loop control + detail/zoom controls, pinned to the far right. */}
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {/* Merged loop control: chevrons set the length, the icon+number
+                both shows it and toggles the loop. */}
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
@@ -1056,39 +1236,14 @@ export function WaveformPlayer() {
                 }}
                 disabled={loopBeats === LOOP_BEAT_STEPS[0]}
                 className={cn(
-                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 border-border flex size-7 cursor-pointer items-center justify-center rounded-md border transition-colors",
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
                   loopBeats === LOOP_BEAT_STEPS[0] &&
                     "cursor-not-allowed opacity-40 hover:bg-transparent",
                 )}
                 title="Halve loop length"
                 aria-label="Halve loop length"
               >
-                <ChevronLeft className="size-4" />
-              </button>
-              <span
-                className="text-foreground border-border w-9 rounded-md border py-1 text-center text-sm font-medium tabular-nums"
-                title="Loop length (beats)"
-              >
-                {loopBeats}
-              </span>
-              <button
-                type="button"
-                onClick={(e) => {
-                  changeLoopBeats(1);
-                  e.currentTarget.blur();
-                }}
-                disabled={
-                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1]
-                }
-                className={cn(
-                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 border-border flex size-7 cursor-pointer items-center justify-center rounded-md border transition-colors",
-                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1] &&
-                    "cursor-not-allowed opacity-40 hover:bg-transparent",
-                )}
-                title="Double loop length"
-                aria-label="Double loop length"
-              >
-                <ChevronRight className="size-4" />
+                <ChevronLeft className="size-3.5" />
               </button>
               <button
                 type="button"
@@ -1100,278 +1255,443 @@ export function WaveformPlayer() {
                 }}
                 disabled={!currentBpm}
                 className={cn(
-                  "ml-auto flex h-7 cursor-pointer items-center rounded-md border px-4 text-xs font-semibold transition-colors",
+                  "flex h-6 cursor-pointer items-center gap-1 rounded-md border px-2 text-xs font-semibold tabular-nums transition-colors",
                   loopActive
                     ? "border-primary text-primary hover:bg-primary/10"
                     : "border-border text-muted-foreground hover:text-foreground hover:bg-surface-3",
-                  !currentBpm && "cursor-not-allowed opacity-40",
+                  !currentBpm &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
                 )}
                 title={currentBpm ? "Toggle loop" : "Loop needs a known BPM"}
                 aria-label="Toggle loop"
               >
-                LOOP
+                <Repeat className="size-3.5" />
+                {loopBeats}
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  changeLoopBeats(1);
+                  e.currentTarget.blur();
+                }}
+                disabled={
+                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1]
+                }
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
+                  loopBeats === LOOP_BEAT_STEPS[LOOP_BEAT_STEPS.length - 1] &&
+                    "cursor-not-allowed opacity-40 hover:bg-transparent",
+                )}
+                title="Double loop length"
+                aria-label="Double loop length"
+              >
+                <ChevronRight className="size-3.5" />
               </button>
             </div>
-            <div className="flex items-stretch gap-2">
-              <div className="border-border flex flex-1 items-center rounded-md border px-1">
-                <BpmPitcher />
-              </div>
-              <div className="border-border flex flex-1 items-center gap-1.5 rounded-md border px-3">
-                <span className="text-foreground text-sm font-semibold tabular-nums">
-                  {currentTrack.musicalKey ?? "—"}
-                </span>
-                <span className="text-2xs text-muted-foreground tracking-wider uppercase">
-                  Key
-                </span>
-              </div>
-            </div>
-          </>
-        )}
+            {zoomControls && (
+              <>
+                <div className="bg-border h-4 w-px" />
+                {zoomControls}
+              </>
+            )}
+          </div>
+        </div>
       </div>
 
-      {/* ===== Waveform area — right side, waveforms only ===== */}
-      {errorMsg ? (
-        <div
-          role="alert"
-          className="text-destructive flex flex-1 items-center px-4 text-xs"
-        >
-          {errorMsg}
-        </div>
-      ) : (
-        <div className="flex min-w-0 flex-1">
-          <div className="relative flex min-w-0 flex-1 flex-col justify-center gap-1 py-2 pl-2">
-            {/* Zoom detail strip (expanded only) */}
-            {zoomActive && (
-              <div
-                data-testid="player-detail-strip"
-                data-zoom-bars={zoomBars ?? undefined}
-                className="h-20 px-1"
-                onWheel={(e) => {
-                  e.preventDefault();
-                  changeZoom(e.deltaY < 0 ? 1 : -1);
-                }}
-              >
-                <PlayerDetailWaveform
-                  track={currentTrack}
-                  zoomBars={zoomBars!}
-                  durationSec={duration}
-                  bpm={currentBpm}
-                  waveformStyle={waveformStyle}
-                  loop={
-                    loopActive && loopEndSec != null
-                      ? { startSec: loopStartSec, endSec: loopEndSec }
-                      : null
-                  }
-                  cueSec={cueSec}
-                />
-              </div>
-            )}
-
-            {/* Overview waveform */}
+      {/* ===== Body: side rail + waveforms ===== */}
+      <div className="flex min-h-0">
+        {/* ===== Side rail — transport + readouts; the right side is waveforms
+            only. ===== */}
+        <div className="border-border flex w-[360px] shrink-0 flex-col justify-end gap-1 border-r px-3 py-1.5">
+          {/* Artwork + title / artist */}
+          <div className="flex min-w-0 items-center gap-2.5">
             <div
-              className="relative flex h-12 items-center px-1"
-              onWheel={
-                zoomable
-                  ? (e) => {
-                      e.preventDefault();
-                      changeZoom(e.deltaY < 0 ? 1 : -1);
-                    }
-                  : undefined
-              }
+              data-testid="player-artwork"
+              className="bg-muted size-9 shrink-0 overflow-hidden rounded-md"
             >
-              <div
-                ref={containerRef}
-                className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
-                style={{ cursor: "pointer" }}
+              <img
+                src={artworkUrl}
+                alt=""
+                className="size-full object-cover"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.display = "none";
+                }}
               />
-              {/* Cue markers + loop region + zoom-window indicator over the
-                    whole-track overview. Phrase sections are a separate row. */}
-              {(viewport ||
-                (duration > 0 &&
-                  (analysis?.cues.length || loopActive || cueSec != null))) && (
-                <div className="pointer-events-none absolute inset-x-1 inset-y-0 z-10">
-                  {/* Loop region (drawn under the cue markers). */}
-                  {loopActive && loopEndSec != null && duration > 0 && (
-                    <div
-                      data-testid="player-loop-region"
-                      className="border-primary bg-primary/15 absolute inset-y-0 rounded-sm border"
-                      style={{
-                        left: `${(loopStartSec / duration) * 100}%`,
-                        width: `${((loopEndSec - loopStartSec) / duration) * 100}%`,
-                      }}
-                    />
-                  )}
-                  {/* Cue markers — numbered colour squares (rekordbox-style),
-                        click to seek. */}
-                  {duration > 0 &&
-                    analysis?.cues.map((c, i) => {
-                      const color =
-                        c.color ?? (c.type === "hot" ? "#f97316" : "#f43f5e");
-                      return (
-                        <div
-                          key={i}
-                          className="absolute inset-y-0"
-                          style={{
-                            left: `${(c.timeMs / 1000 / duration) * 100}%`,
-                          }}
-                        >
-                          <div
-                            className="absolute inset-y-0 w-px -translate-x-1/2"
-                            style={{ backgroundColor: color }}
-                          />
-                          <button
-                            type="button"
-                            data-testid="player-cue"
-                            data-cue-type={c.type}
-                            onClick={() => seek(c.timeMs / 1000 / duration)}
-                            title={
-                              c.type === "hot"
-                                ? `Hot cue ${hotCueLetter(c.index)}`
-                                : "Memory cue"
-                            }
-                            className="pointer-events-auto absolute top-0 flex size-3 -translate-x-1/2 cursor-pointer items-center justify-center rounded-[2px] text-[8px] leading-none font-bold transition-transform hover:scale-110"
-                            style={{
-                              backgroundColor: color,
-                              color: textOn(color),
-                            }}
-                          >
-                            {i + 1}
-                          </button>
-                        </div>
-                      );
-                    })}
-                  {/* In-memory cue point (amber flag), click to recall. */}
-                  {cueSec != null && duration > 0 && (
-                    <div
-                      className="absolute inset-y-0"
-                      style={{ left: `${(cueSec / duration) * 100}%` }}
-                    >
-                      <div className="absolute inset-y-0 w-px -translate-x-1/2 bg-amber-500" />
-                      <button
-                        type="button"
-                        data-testid="player-cue-point"
-                        onClick={() => seek(cueSec / duration)}
-                        title="Cue point"
-                        aria-label="Cue point"
-                        className="pointer-events-auto absolute top-0 block size-0 -translate-x-1/2 cursor-pointer border-t-[7px] border-r-[5px] border-l-[5px] border-t-amber-500 border-r-transparent border-l-transparent"
-                      />
-                    </div>
-                  )}
-                  {viewport && (
-                    <div
-                      className="border-primary/70 bg-primary/15 absolute inset-y-0 rounded-sm border"
-                      style={{
-                        left: `${viewport.left * 100}%`,
-                        width: `${viewport.width * 100}%`,
-                      }}
-                    />
-                  )}
-                </div>
-              )}
-              {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
-                  to keep driving audio + progress; this canvas paints the
-                  coloured waveform and owns seek/hover. */}
-              {rekColored && currentTrack.rekordboxId && (
-                <div
-                  data-testid="player-rekordbox-waveform"
-                  data-variant={rekVariant}
-                  className="absolute inset-x-1 inset-y-0 flex items-center"
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span
+                  className="text-primary truncate text-sm font-semibold"
+                  title={titleText}
                 >
-                  <PlayerRekordboxWaveform
-                    trackId={currentTrack.rekordboxId}
-                    device={currentTrack.rekordboxDevice}
-                    variant={rekVariant}
+                  {titleText}
+                </span>
+                {currentTrack.permalinkUrl && (
+                  <a
+                    href={currentTrack.permalinkUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
+                    title="Open on SoundCloud"
+                    aria-label="Open on SoundCloud"
+                  >
+                    <img
+                      src="/icons/soundcloud.svg"
+                      alt=""
+                      className="size-3 dark:invert"
+                    />
+                  </a>
+                )}
+              </div>
+              {artistText && (
+                <span
+                  className="text-muted-foreground truncate text-xs"
+                  title={artistText}
+                >
+                  {artistText}
+                </span>
+              )}
+            </div>
+            {/* Elapsed / total time — compact, up by the title. */}
+            <div className="shrink-0 text-right leading-none tabular-nums">
+              <span className="text-foreground text-xs font-medium">
+                {formatTime(currentTime)}
+              </span>
+              <span className="text-muted-foreground text-2xs">
+                {" "}
+                / {formatTime(duration)}
+              </span>
+            </div>
+          </div>
+
+          {/* Transport + BPM/KEY readouts (identical in collapsed & expanded). */}
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={(e) => {
+                previous();
+                e.currentTarget.blur();
+              }}
+              disabled={!hasPrevious && currentTime <= 3}
+              className={cn(
+                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
+                !hasPrevious &&
+                  currentTime <= 3 &&
+                  "cursor-not-allowed opacity-40 hover:bg-transparent",
+              )}
+              title="Previous (←)"
+              aria-label="Previous track"
+            >
+              <SkipBack className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              data-testid="player-toggle"
+              onClick={(e) => {
+                toggle();
+                // Drop focus so a subsequent Space keypress isn't captured by
+                // the button's default activation behavior (which would
+                // re-toggle on top of the window-level keyboard handler).
+                e.currentTarget.blur();
+              }}
+              className="bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
+              title={isPlaying ? "Pause (Space)" : "Play (Space)"}
+              aria-label={isPlaying ? "Pause" : "Play"}
+            >
+              {isPlaying ? (
+                <Pause className="size-3.5" />
+              ) : (
+                <Play className="size-3.5 translate-x-px" />
+              )}
+            </button>
+            {/* CUE — round CDJ-style button: tap sets/recalls, hold previews. */}
+            <button
+              type="button"
+              data-testid="player-cue-btn"
+              onPointerDown={handleCueDown}
+              onPointerUp={handleCueUp}
+              onPointerCancel={handleCueUp}
+              className={cn(
+                "flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-full border text-[10px] font-semibold transition-colors select-none",
+                cueSec != null
+                  ? "border-amber-500 text-amber-500 hover:bg-amber-500/10"
+                  : "border-border text-muted-foreground hover:text-foreground hover:bg-surface-3",
+              )}
+              title="Cue — tap to set/recall, hold to preview"
+              aria-label="Cue"
+            >
+              CUE
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                next();
+                e.currentTarget.blur();
+              }}
+              disabled={!hasNext}
+              className={cn(
+                "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-7 cursor-pointer items-center justify-center rounded-full transition-colors",
+                !hasNext &&
+                  "cursor-not-allowed opacity-40 hover:bg-transparent",
+              )}
+              title="Next (→)"
+              aria-label="Next track"
+            >
+              <SkipForward className="size-3.5" />
+            </button>
+
+            {/* BPM + KEY on the same level, right-aligned. Labels are never
+                tinted; the value carries the pitch colour. */}
+            <div className="ml-auto flex items-center gap-1">
+              <BpmPitcher />
+              <div className="flex h-10 flex-col items-center justify-center px-2 leading-none">
+                <span className="flex items-baseline gap-1">
+                  <span
+                    className={cn(
+                      "text-xs font-semibold tabular-nums",
+                      keyPitched ? "text-primary" : "text-foreground",
+                    )}
+                  >
+                    {displayKey ?? "—"}
+                  </span>
+                  <span className="text-muted-foreground text-[8px] tracking-wider uppercase">
+                    Key
+                  </span>
+                </span>
+                {pitchEnabled && baseKey != null && (
+                  <span className="text-2xs mt-0.5 tabular-nums">
+                    {/* Original key in gray; the shift carries the pitch colour. */}
+                    <span className="text-muted-foreground">{baseKey}</span>{" "}
+                    <span
+                      className={
+                        keyPitched ? "text-primary" : "text-muted-foreground"
+                      }
+                    >
+                      {semitonesFloat > 0 ? "+" : ""}
+                      {semitonesFloat.toFixed(1)} st
+                    </span>
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ===== Waveform area — right side, waveforms only ===== */}
+        {errorMsg ? (
+          <div
+            role="alert"
+            className="text-destructive flex flex-1 items-center px-4 text-xs"
+          >
+            {errorMsg}
+          </div>
+        ) : (
+          <div className="flex min-w-0 flex-1">
+            <div className="relative flex min-w-0 flex-1 flex-col justify-center gap-1 py-2 pl-2">
+              {/* Zoom detail strip (shown when toggled on) */}
+              {detailShown && (
+                <div
+                  data-testid="player-detail-strip"
+                  data-zoom-bars={zoomBars}
+                  className="h-20 px-1"
+                  onWheel={(e) => {
+                    e.preventDefault();
+                    changeZoom(e.deltaY < 0 ? 1 : -1);
+                  }}
+                >
+                  <PlayerDetailWaveform
+                    track={currentTrack}
+                    zoomBars={zoomBars}
                     durationSec={duration}
-                    className="h-8"
+                    bpm={currentBpm}
+                    waveformStyle={waveformStyle}
+                    loop={
+                      loopActive && loopEndSec != null
+                        ? { startSec: loopStartSec, endSec: loopEndSec }
+                        : null
+                    }
+                    cueSec={cueSec}
                   />
                 </div>
               )}
-              {/* Loading-state fallback progress — fades out once waveform is ready. */}
+
+              {/* Overview waveform */}
               <div
-                className={cn(
-                  "bg-surface-3 pointer-events-none absolute inset-x-1 bottom-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
-                  ready ? "opacity-0" : "opacity-100",
-                )}
+                className="relative flex h-12 items-center px-1"
+                onWheel={
+                  detailShown
+                    ? (e) => {
+                        e.preventDefault();
+                        changeZoom(e.deltaY < 0 ? 1 : -1);
+                      }
+                    : undefined
+                }
               >
                 <div
-                  className="bg-primary h-full"
-                  style={{
-                    width: `${Math.min(100, loadingProgress * 100)}%`,
-                  }}
+                  ref={containerRef}
+                  className={cn("min-w-0 flex-1", rekColored && "opacity-0")}
+                  style={{ cursor: "pointer" }}
                 />
-              </div>
-            </div>
-
-            {/* Phrase band — labelled song-structure sections. */}
-            {duration > 0 && analysis?.sections?.length ? (
-              <div className="relative h-3.5 px-1">
-                <div className="absolute inset-x-1 inset-y-0">
-                  {analysis.sections.map((s, i) => (
+                {/* Playhead + cue markers + loop region + zoom-window indicator
+                    over the whole-track overview. Phrase sections are a separate
+                    row. */}
+                {duration > 0 && (
+                  <div className="pointer-events-none absolute inset-x-1 inset-y-0 z-10">
+                    {/* Current play position. */}
                     <div
-                      key={i}
-                      data-testid="player-section"
-                      className="absolute inset-y-0 flex items-center overflow-hidden rounded-[1px] px-1"
-                      style={{
-                        left: `${(s.startMs / 1000 / duration) * 100}%`,
-                        width: `${((s.endMs - s.startMs) / 1000 / duration) * 100}%`,
-                        backgroundColor:
-                          SECTION_COLOR_VAR[s.kind] ?? SECTION_COLOR_VAR.other,
-                      }}
-                    >
-                      <span className="truncate text-[8px] leading-none font-semibold tracking-wide text-black/70 uppercase">
-                        {s.label}
-                      </span>
-                    </div>
-                  ))}
+                      data-testid="player-overview-playhead"
+                      className="bg-primary absolute inset-y-0 w-0.5 -translate-x-1/2 rounded-full"
+                      style={{ left: `${(currentTime / duration) * 100}%` }}
+                    />
+                    {/* Loop region (drawn under the cue markers). */}
+                    {loopActive && loopEndSec != null && duration > 0 && (
+                      <div
+                        data-testid="player-loop-region"
+                        className="border-primary bg-primary/15 absolute inset-y-0 rounded-sm border"
+                        style={{
+                          left: `${(loopStartSec / duration) * 100}%`,
+                          width: `${((loopEndSec - loopStartSec) / duration) * 100}%`,
+                        }}
+                      />
+                    )}
+                    {/* Cue markers — hot cues colour-coded (letter), memory cues
+                        numbered. Click to seek. */}
+                    {duration > 0 &&
+                      analysis?.cues.map((c, i) => {
+                        const d = cueDisplays[i];
+                        return (
+                          <div
+                            key={i}
+                            className="absolute inset-y-0"
+                            style={{
+                              left: `${(c.timeMs / 1000 / duration) * 100}%`,
+                            }}
+                          >
+                            <div
+                              className="absolute inset-y-0 w-px -translate-x-1/2"
+                              style={{ backgroundColor: d.color }}
+                            />
+                            <button
+                              type="button"
+                              data-testid="player-cue"
+                              data-cue-type={c.type}
+                              onClick={() =>
+                                jumpToCue(
+                                  c.timeMs / 1000,
+                                  c.outMs != null ? c.outMs / 1000 : null,
+                                )
+                              }
+                              title={
+                                d.isHot
+                                  ? `Hot cue ${d.label}`
+                                  : `Memory cue ${d.label}`
+                              }
+                              className="pointer-events-auto absolute top-0 flex size-3 -translate-x-1/2 cursor-pointer items-center justify-center rounded-[2px] text-[8px] leading-none font-bold transition-transform hover:scale-110"
+                              style={{
+                                backgroundColor: d.color,
+                                color: textOn(d.color),
+                              }}
+                            >
+                              {d.label}
+                            </button>
+                          </div>
+                        );
+                      })}
+                    {/* In-memory cue point (amber flag), click to recall. */}
+                    {cueSec != null && duration > 0 && (
+                      <div
+                        className="absolute inset-y-0"
+                        style={{ left: `${(cueSec / duration) * 100}%` }}
+                      >
+                        <div className="absolute inset-y-0 w-px -translate-x-1/2 bg-amber-500" />
+                        <button
+                          type="button"
+                          data-testid="player-cue-point"
+                          onClick={() => seek(cueSec / duration)}
+                          title="Cue point"
+                          aria-label="Cue point"
+                          className="pointer-events-auto absolute top-0 block size-0 -translate-x-1/2 cursor-pointer border-t-[7px] border-r-[5px] border-l-[5px] border-t-amber-500 border-r-transparent border-l-transparent"
+                        />
+                      </div>
+                    )}
+                    {viewport && (
+                      <div
+                        className="border-primary/70 bg-primary/15 absolute inset-y-0 rounded-sm border"
+                        style={{
+                          left: `${viewport.left * 100}%`,
+                          width: `${viewport.width * 100}%`,
+                        }}
+                      />
+                    )}
+                  </div>
+                )}
+                {/* Rekordbox RGB/Blue overlay — WaveSurfer stays mounted (hidden)
+                  to keep driving audio + progress; this canvas paints the
+                  coloured waveform and owns seek/hover. */}
+                {rekColored && currentTrack.rekordboxId && (
+                  <div
+                    data-testid="player-rekordbox-waveform"
+                    data-variant={rekVariant}
+                    className="absolute inset-x-1 inset-y-0 flex items-center"
+                  >
+                    <PlayerRekordboxWaveform
+                      trackId={currentTrack.rekordboxId}
+                      device={currentTrack.rekordboxDevice}
+                      variant={rekVariant}
+                      durationSec={duration}
+                      className="h-8"
+                    />
+                  </div>
+                )}
+                {/* Loading-state fallback progress — fades out once waveform is ready. */}
+                <div
+                  className={cn(
+                    "bg-surface-3 pointer-events-none absolute inset-x-1 bottom-0 h-0.5 overflow-hidden rounded-full transition-opacity duration-200",
+                    ready ? "opacity-0" : "opacity-100",
+                  )}
+                >
+                  <div
+                    className="bg-primary h-full"
+                    style={{
+                      width: `${Math.min(100, loadingProgress * 100)}%`,
+                    }}
+                  />
                 </div>
               </div>
-            ) : null}
-          </div>
 
-          {/* Zoom controls — hidden for SoundCloud streams. */}
-          {zoomable && (
-            <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 px-2">
-              <button
-                type="button"
-                onClick={(e) => {
-                  changeZoom(1);
-                  e.currentTarget.blur();
-                }}
-                disabled={zoomBars === 4}
-                className={cn(
-                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-6 cursor-pointer items-center justify-center rounded transition-colors",
-                  zoomBars === 4 &&
-                    "cursor-not-allowed opacity-40 hover:bg-transparent",
-                )}
-                title="Zoom in"
-                aria-label="Zoom in"
-              >
-                <ZoomIn className="size-4" />
-              </button>
-              <span className="text-muted-foreground text-[9px] tabular-nums">
-                {zoomBars == null ? "—" : zoomBars}
-              </span>
-              <button
-                type="button"
-                onClick={(e) => {
-                  changeZoom(-1);
-                  e.currentTarget.blur();
-                }}
-                disabled={zoomBars == null}
-                className={cn(
-                  "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-6 cursor-pointer items-center justify-center rounded transition-colors",
-                  zoomBars == null &&
-                    "cursor-not-allowed opacity-40 hover:bg-transparent",
-                )}
-                title="Zoom out"
-                aria-label="Zoom out"
-              >
-                <ZoomOut className="size-4" />
-              </button>
+              {/* Phrase band — labelled song-structure sections. */}
+              {duration > 0 && analysis?.sections?.length ? (
+                <div className="relative h-3.5 px-1">
+                  <div className="absolute inset-x-1 inset-y-0">
+                    {analysis.sections.map((s, i) => {
+                      const color =
+                        SECTION_COLOR_VAR[s.kind] ?? SECTION_COLOR_VAR.other;
+                      return (
+                        <div
+                          key={i}
+                          data-testid="player-section"
+                          className="absolute inset-y-0 flex items-center overflow-hidden rounded-[1px] px-1"
+                          style={{
+                            left: `${(s.startMs / 1000 / duration) * 100}%`,
+                            width: `${((s.endMs - s.startMs) / 1000 / duration) * 100}%`,
+                            backgroundColor: color,
+                            // Darker same-hue border separates adjacent sections.
+                            boxShadow: `inset 0 0 0 1px color-mix(in oklch, ${color} 55%, black)`,
+                          }}
+                        >
+                          <span className="truncate text-[8px] leading-none font-semibold tracking-wide text-black/70 uppercase">
+                            {s.label}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
             </div>
-          )}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/generated/backend-openapi.json
+++ b/frontend/src/generated/backend-openapi.json
@@ -480,8 +480,167 @@
           "metadata"
         ],
         "summary": "Get Folder Tree",
-        "description": "Return the folder tree built from indexed tracks.\n\nOnly folders that contain at least one track (directly or in a\ndescendant) are included \u2014 empty directories are omitted.",
+        "description": "Return the folder tree built from indexed tracks and on-disk directories.\n\nEvery directory under the root is included \u2014 empty folders too. Hidden\n(dot-prefixed) directories are skipped, matching the indexer.\n\n``track_count`` is always the unfiltered recursive total, so the tree\nstructure is stable. When any filter argument is supplied, each node's\n``filtered_count`` carries the recursive count of tracks matching those\nfilters (``None`` otherwise).",
         "operationId": "get_folder_tree_api_metadata_folders_tree_get",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "genres",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Genres"
+            }
+          },
+          {
+            "name": "keys",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Keys"
+            }
+          },
+          {
+            "name": "bpm_min",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Bpm Min"
+            }
+          },
+          {
+            "name": "bpm_max",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Bpm Max"
+            }
+          },
+          {
+            "name": "has_soundcloud_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Soundcloud Id"
+            }
+          },
+          {
+            "name": "file_formats",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "File Formats"
+            }
+          },
+          {
+            "name": "size_min",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Size Min"
+            }
+          },
+          {
+            "name": "size_max",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Size Max"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -489,6 +648,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TreeNode"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -744,7 +913,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size)$",
+              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size|duration)$",
               "default": "file_name",
               "title": "Sort By"
             }
@@ -1336,7 +1505,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size)$",
+              "pattern": "^(title|artist|genre|bpm|key|release_date|file_name|folder|mtime|file_format|file_size|duration)$",
               "default": "file_name",
               "title": "Sort By"
             }
@@ -2082,13 +2251,13 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 2000,
+              "maximum": 50000,
               "minimum": 50,
-              "description": "Number of amplitude peaks to return",
+              "description": "Number of amplitude peaks to return (up to ~150/s for zoom).",
               "default": 200,
               "title": "Num Peaks"
             },
-            "description": "Number of amplitude peaks to return"
+            "description": "Number of amplitude peaks to return (up to ~150/s for zoom)."
           }
         ],
         "responses": {
@@ -2121,7 +2290,7 @@
           "metadata"
         ],
         "summary": "Stream Audio",
-        "description": "Stream an audio file.\n\nFormats not natively supported by browsers (e.g. AIFF) are transcoded to\nWAV via ffmpeg and cached.  Transcoding is awaited before responding so\nthat the browser always receives a real file with Content-Length and range\nsupport, which is required for seeking to work.\n\nParameters\n----------\nfile_path : str\n    Relative or absolute path to audio file\nroot_folder : Path\n    Root music folder (injected)\n\nReturns\n-------\nFileResponse\n    Audio file bytes\n\nRaises\n------\nHTTPException\n    If the file doesn't exist or transcoding fails",
+        "description": "Stream an audio file.\n\nParameters\n----------\nfile_path : str\n    Relative or absolute path to audio file\nroot_folder : Path\n    Root music folder (injected)\n\nReturns\n-------\nFileResponse\n    Audio file bytes\n\nRaises\n------\nHTTPException\n    If the file doesn't exist or transcoding fails",
         "operationId": "stream_audio_api_metadata_files__file_path__audio_get",
         "parameters": [
           {
@@ -3803,6 +3972,557 @@
           }
         }
       }
+    },
+    "/api/rekordbox/usb/devices": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Usb Devices",
+        "description": "List mounted Rekordbox USB/SD exports that carry a readable library.",
+        "operationId": "get_usb_devices_api_rekordbox_usb_devices_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DevicesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/usb/eject": {
+      "post": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Eject Usb Device",
+        "description": "Safely eject a mounted Rekordbox USB/SD export.",
+        "operationId": "eject_usb_device_api_rekordbox_usb_eject_post",
+        "parameters": [
+          {
+            "name": "device",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "USB device id",
+              "title": "Device"
+            },
+            "description": "USB device id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/status": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Status",
+        "description": "Report whether the selected Rekordbox source is reachable.",
+        "operationId": "get_status_api_rekordbox_status_get",
+        "parameters": [
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RekordboxStatus"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/playlists": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Playlists",
+        "operationId": "get_playlists_api_rekordbox_playlists_get",
+        "parameters": [
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaylistsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/playlists/{playlist_id}/tracks": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Playlist Tracks",
+        "operationId": "get_playlist_tracks_api_rekordbox_playlists__playlist_id__tracks_get",
+        "parameters": [
+          {
+            "name": "playlist_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Playlist Id"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TracksResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/tracks/{track_id}/artwork": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Track Artwork",
+        "description": "Serve the cached artwork JPEG for a track.",
+        "operationId": "get_track_artwork_api_rekordbox_tracks__track_id__artwork_get",
+        "parameters": [
+          {
+            "name": "track_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Track Id"
+            }
+          },
+          {
+            "name": "small",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Small"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/tracks/{track_id}/waveform": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Track Waveform",
+        "description": "Serve a track's raw ANLZ waveform bytes for the frontend canvas.\n\nPreview variants span the whole track: ``color`` = PWV4 (1200 x 6 bytes),\n``blue`` = PWAV (400 x 1). Detail variants carry ~150 columns/second for\nzoomed playback: ``color_detail`` = PWV5 (2 bytes/column, ``.EXT``),\n``blue_detail`` = PWV3 (1 byte/column, ``.DAT``).",
+        "operationId": "get_track_waveform_api_rekordbox_tracks__track_id__waveform_get",
+        "parameters": [
+          {
+            "name": "track_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Track Id"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          },
+          {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^(color|blue|color_detail|blue_detail)$",
+              "default": "color",
+              "title": "Variant"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/tracks/{track_id}/analysis": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Track Analysis",
+        "description": "Return a track's beatgrid, phrase sections and cues as JSON.\n\nDrives the zoomed player overlay: beat ticks, the phrase band and cue\nmarkers. ``sections`` is ``null`` when the track has no phrase analysis;\nbeatgrid/cues degrade to empty lists rather than 404 when analysis is absent.",
+        "operationId": "get_track_analysis_api_rekordbox_tracks__track_id__analysis_get",
+        "parameters": [
+          {
+            "name": "track_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Track Id"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackAnalysisResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/tracks/{track_id}/audio": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Stream Track Audio",
+        "description": "Stream a track's audio file from a mounted USB export.\n\nLocal-install tracks play through the metadata audio endpoint by their\nabsolute path; USB tracks live on the device, so their device-relative path\nis resolved here (within the mount) and streamed with the same\ntranscode/range handling.",
+        "operationId": "stream_track_audio_api_rekordbox_tracks__track_id__audio_get",
+        "parameters": [
+          {
+            "name": "track_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Track Id"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "USB device id",
+              "title": "Device"
+            },
+            "description": "USB device id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rekordbox/tracks": {
+      "get": {
+        "tags": [
+          "rekordbox"
+        ],
+        "summary": "Get Tracks",
+        "operationId": "get_tracks_api_rekordbox_tracks_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 10000,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "USB device id; omit for the local install",
+              "title": "Device"
+            },
+            "description": "USB device id; omit for the local install"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TracksResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4222,6 +4942,29 @@
         "title": "BatchUpdateResponse",
         "description": "Response from a batch update operation."
       },
+      "BeatModel": {
+        "properties": {
+          "beat": {
+            "type": "integer",
+            "title": "Beat"
+          },
+          "bpm": {
+            "type": "number",
+            "title": "Bpm"
+          },
+          "timeMs": {
+            "type": "integer",
+            "title": "Timems"
+          }
+        },
+        "type": "object",
+        "required": [
+          "beat",
+          "bpm",
+          "timeMs"
+        ],
+        "title": "BeatModel"
+      },
       "Body_update_file_artwork_api_metadata_files__file_path__artwork_post": {
         "properties": {
           "file": {
@@ -4454,6 +5197,86 @@
         ],
         "title": "CollectionStatsResponse",
         "description": "Response containing collection statistics."
+      },
+      "CueModel": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index"
+          },
+          "timeMs": {
+            "type": "integer",
+            "title": "Timems"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "timeMs"
+        ],
+        "title": "CueModel"
+      },
+      "DevicesResponse": {
+        "properties": {
+          "devices": {
+            "items": {
+              "$ref": "#/components/schemas/UsbDevice"
+            },
+            "type": "array",
+            "title": "Devices"
+          }
+        },
+        "type": "object",
+        "required": [
+          "devices"
+        ],
+        "title": "DevicesResponse"
+      },
+      "EjectResponse": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "title": "EjectResponse"
       },
       "FetchCandidate": {
         "properties": {
@@ -5188,6 +6011,22 @@
         "title": "PeaksResponse",
         "description": "Waveform amplitude peak data for visualization."
       },
+      "PlaylistsResponse": {
+        "properties": {
+          "playlists": {
+            "items": {
+              "$ref": "#/components/schemas/RekordboxPlaylist"
+            },
+            "type": "array",
+            "title": "Playlists"
+          }
+        },
+        "type": "object",
+        "required": [
+          "playlists"
+        ],
+        "title": "PlaylistsResponse"
+      },
       "ProfileGroup": {
         "properties": {
           "id": {
@@ -5383,6 +6222,223 @@
         ],
         "title": "RefreshResponse",
         "description": "Token refresh response."
+      },
+      "RekordboxPlaylist": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "is_folder": {
+            "type": "boolean",
+            "title": "Is Folder"
+          },
+          "is_smart": {
+            "type": "boolean",
+            "title": "Is Smart"
+          },
+          "track_count": {
+            "type": "integer",
+            "title": "Track Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "is_folder",
+          "is_smart",
+          "track_count"
+        ],
+        "title": "RekordboxPlaylist"
+      },
+      "RekordboxStatus": {
+        "properties": {
+          "available": {
+            "type": "boolean",
+            "title": "Available"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "available"
+        ],
+        "title": "RekordboxStatus"
+      },
+      "RekordboxTrack": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artist"
+          },
+          "album": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "file_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Path"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          },
+          "soundcloud_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Soundcloud Id"
+          },
+          "date_added": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date Added"
+          },
+          "release_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Date"
+          },
+          "has_artwork": {
+            "type": "boolean",
+            "title": "Has Artwork",
+            "default": false
+          },
+          "has_waveform": {
+            "type": "boolean",
+            "title": "Has Waveform",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title"
+        ],
+        "title": "RekordboxTrack"
       },
       "RootFolderRequest": {
         "properties": {
@@ -5816,6 +6872,34 @@
         "title": "SCUserPayload",
         "description": "Loose subset of the SC user object used during suggestion."
       },
+      "SectionModel": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "startMs": {
+            "type": "integer",
+            "title": "Startms"
+          },
+          "endMs": {
+            "type": "integer",
+            "title": "Endms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "label",
+          "startMs",
+          "endMs"
+        ],
+        "title": "SectionModel"
+      },
       "SessionCookieRequest": {
         "properties": {
           "oauth_token": {
@@ -6122,6 +7206,44 @@
           "playlists"
         ],
         "title": "SystemPlaylistsResponse"
+      },
+      "TrackAnalysisResponse": {
+        "properties": {
+          "beatgrid": {
+            "items": {
+              "$ref": "#/components/schemas/BeatModel"
+            },
+            "type": "array",
+            "title": "Beatgrid"
+          },
+          "sections": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SectionModel"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sections"
+          },
+          "cues": {
+            "items": {
+              "$ref": "#/components/schemas/CueModel"
+            },
+            "type": "array",
+            "title": "Cues"
+          }
+        },
+        "type": "object",
+        "required": [
+          "beatgrid",
+          "cues"
+        ],
+        "title": "TrackAnalysisResponse"
       },
       "TrackBrowseResponse": {
         "properties": {
@@ -6717,6 +7839,22 @@
         "title": "TrackInfoUpdateRequest",
         "description": "Request to update track metadata. All fields optional."
       },
+      "TracksResponse": {
+        "properties": {
+          "tracks": {
+            "items": {
+              "$ref": "#/components/schemas/RekordboxTrack"
+            },
+            "type": "array",
+            "title": "Tracks"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tracks"
+        ],
+        "title": "TracksResponse"
+      },
       "TreeNode": {
         "properties": {
           "id": {
@@ -6739,6 +7877,17 @@
             "type": "integer",
             "title": "Track Count",
             "default": 0
+          },
+          "filtered_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filtered Count"
           }
         },
         "type": "object",
@@ -6748,6 +7897,29 @@
         ],
         "title": "TreeNode",
         "description": "A node in the folder tree."
+      },
+      "UsbDevice": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "mount_path": {
+            "type": "string",
+            "title": "Mount Path"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "label",
+          "mount_path"
+        ],
+        "title": "UsbDevice"
       },
       "UserInfo": {
         "properties": {

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -342,10 +342,15 @@ export interface paths {
         };
         /**
          * Get Folder Tree
-         * @description Return the folder tree built from indexed tracks.
+         * @description Return the folder tree built from indexed tracks and on-disk directories.
          *
-         *     Only folders that contain at least one track (directly or in a
-         *     descendant) are included — empty directories are omitted.
+         *     Every directory under the root is included — empty folders too. Hidden
+         *     (dot-prefixed) directories are skipped, matching the indexer.
+         *
+         *     ``track_count`` is always the unfiltered recursive total, so the tree
+         *     structure is stable. When any filter argument is supplied, each node's
+         *     ``filtered_count`` carries the recursive count of tracks matching those
+         *     filters (``None`` otherwise).
          */
         get: operations["get_folder_tree_api_metadata_folders_tree_get"];
         put?: never;
@@ -848,11 +853,6 @@ export interface paths {
         /**
          * Stream Audio
          * @description Stream an audio file.
-         *
-         *     Formats not natively supported by browsers (e.g. AIFF) are transcoded to
-         *     WAV via ffmpeg and cached.  Transcoding is awaited before responding so
-         *     that the browser always receives a real file with Content-Length and range
-         *     support, which is required for seeking to work.
          *
          *     Parameters
          *     ----------
@@ -1687,6 +1687,211 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/rekordbox/usb/devices": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Usb Devices
+         * @description List mounted Rekordbox USB/SD exports that carry a readable library.
+         */
+        get: operations["get_usb_devices_api_rekordbox_usb_devices_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/usb/eject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Eject Usb Device
+         * @description Safely eject a mounted Rekordbox USB/SD export.
+         */
+        post: operations["eject_usb_device_api_rekordbox_usb_eject_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Status
+         * @description Report whether the selected Rekordbox source is reachable.
+         */
+        get: operations["get_status_api_rekordbox_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/playlists": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Playlists */
+        get: operations["get_playlists_api_rekordbox_playlists_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/playlists/{playlist_id}/tracks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Playlist Tracks */
+        get: operations["get_playlist_tracks_api_rekordbox_playlists__playlist_id__tracks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/tracks/{track_id}/artwork": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Track Artwork
+         * @description Serve the cached artwork JPEG for a track.
+         */
+        get: operations["get_track_artwork_api_rekordbox_tracks__track_id__artwork_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/tracks/{track_id}/waveform": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Track Waveform
+         * @description Serve a track's raw ANLZ waveform bytes for the frontend canvas.
+         *
+         *     Preview variants span the whole track: ``color`` = PWV4 (1200 x 6 bytes),
+         *     ``blue`` = PWAV (400 x 1). Detail variants carry ~150 columns/second for
+         *     zoomed playback: ``color_detail`` = PWV5 (2 bytes/column, ``.EXT``),
+         *     ``blue_detail`` = PWV3 (1 byte/column, ``.DAT``).
+         */
+        get: operations["get_track_waveform_api_rekordbox_tracks__track_id__waveform_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/tracks/{track_id}/analysis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Track Analysis
+         * @description Return a track's beatgrid, phrase sections and cues as JSON.
+         *
+         *     Drives the zoomed player overlay: beat ticks, the phrase band and cue
+         *     markers. ``sections`` is ``null`` when the track has no phrase analysis;
+         *     beatgrid/cues degrade to empty lists rather than 404 when analysis is absent.
+         */
+        get: operations["get_track_analysis_api_rekordbox_tracks__track_id__analysis_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/tracks/{track_id}/audio": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream Track Audio
+         * @description Stream a track's audio file from a mounted USB export.
+         *
+         *     Local-install tracks play through the metadata audio endpoint by their
+         *     absolute path; USB tracks live on the device, so their device-relative path
+         *     is resolved here (within the mount) and streamed with the same
+         *     transcode/range handling.
+         */
+        get: operations["stream_track_audio_api_rekordbox_tracks__track_id__audio_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rekordbox/tracks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Tracks */
+        get: operations["get_tracks_api_rekordbox_tracks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1889,6 +2094,15 @@ export interface components {
             /** Results */
             results: components["schemas"]["BatchResultItem"][];
         };
+        /** BeatModel */
+        BeatModel: {
+            /** Beat */
+            beat: number;
+            /** Bpm */
+            bpm: number;
+            /** Timems */
+            timeMs: number;
+        };
         /** Body_update_file_artwork_api_metadata_files__file_path__artwork_post */
         Body_update_file_artwork_api_metadata_files__file_path__artwork_post: {
             /** File */
@@ -1991,6 +2205,29 @@ export interface components {
             bpm_min?: number | null;
             /** Bpm Max */
             bpm_max?: number | null;
+        };
+        /** CueModel */
+        CueModel: {
+            /** Type */
+            type: string;
+            /** Index */
+            index?: number | null;
+            /** Timems */
+            timeMs: number;
+            /** Color */
+            color?: string | null;
+            /** Comment */
+            comment?: string | null;
+        };
+        /** DevicesResponse */
+        DevicesResponse: {
+            /** Devices */
+            devices: components["schemas"]["UsbDevice"][];
+        };
+        /** EjectResponse */
+        EjectResponse: {
+            /** Ok */
+            ok: boolean;
         };
         /**
          * FetchCandidate
@@ -2351,6 +2588,11 @@ export interface components {
             /** Peaks */
             peaks: number[];
         };
+        /** PlaylistsResponse */
+        PlaylistsResponse: {
+            /** Playlists */
+            playlists: components["schemas"]["RekordboxPlaylist"][];
+        };
         /**
          * ProfileGroup
          * @description A persisted ProfileGroup.
@@ -2440,6 +2682,67 @@ export interface components {
             refresh_token: string | null;
             /** Expires In */
             expires_in?: number | null;
+        };
+        /** RekordboxPlaylist */
+        RekordboxPlaylist: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Parent Id */
+            parent_id?: string | null;
+            /** Is Folder */
+            is_folder: boolean;
+            /** Is Smart */
+            is_smart: boolean;
+            /** Track Count */
+            track_count: number;
+        };
+        /** RekordboxStatus */
+        RekordboxStatus: {
+            /** Available */
+            available: boolean;
+            /** Reason */
+            reason?: string | null;
+        };
+        /** RekordboxTrack */
+        RekordboxTrack: {
+            /** Id */
+            id: string;
+            /** Title */
+            title: string;
+            /** Artist */
+            artist?: string | null;
+            /** Album */
+            album?: string | null;
+            /** Genre */
+            genre?: string | null;
+            /** Bpm */
+            bpm?: number | null;
+            /** Key */
+            key?: string | null;
+            /** Duration Seconds */
+            duration_seconds?: number | null;
+            /** File Path */
+            file_path?: string | null;
+            /** Comment */
+            comment?: string | null;
+            /** Soundcloud Id */
+            soundcloud_id?: number | null;
+            /** Date Added */
+            date_added?: string | null;
+            /** Release Date */
+            release_date?: string | null;
+            /**
+             * Has Artwork
+             * @default false
+             */
+            has_artwork: boolean;
+            /**
+             * Has Waveform
+             * @default false
+             */
+            has_waveform: boolean;
         };
         /** RootFolderRequest */
         RootFolderRequest: {
@@ -2576,6 +2879,17 @@ export interface components {
         SCUserPayload: {
             /** Username */
             username?: string | null;
+        };
+        /** SectionModel */
+        SectionModel: {
+            /** Kind */
+            kind: string;
+            /** Label */
+            label: string;
+            /** Startms */
+            startMs: number;
+            /** Endms */
+            endMs: number;
         };
         /**
          * SessionCookieRequest
@@ -2725,6 +3039,15 @@ export interface components {
             /** Playlists */
             playlists: components["schemas"]["SystemPlaylistSummary"][];
         };
+        /** TrackAnalysisResponse */
+        TrackAnalysisResponse: {
+            /** Beatgrid */
+            beatgrid: components["schemas"]["BeatModel"][];
+            /** Sections */
+            sections?: components["schemas"]["SectionModel"][] | null;
+            /** Cues */
+            cues: components["schemas"]["CueModel"][];
+        };
         /**
          * TrackBrowseResponse
          * @description Lightweight response for collection browse/table view.
@@ -2856,6 +3179,11 @@ export interface components {
             /** Artwork Data */
             artwork_data?: string | null;
         };
+        /** TracksResponse */
+        TracksResponse: {
+            /** Tracks */
+            tracks: components["schemas"]["RekordboxTrack"][];
+        };
         /**
          * TreeNode
          * @description A node in the folder tree.
@@ -2875,6 +3203,17 @@ export interface components {
              * @default 0
              */
             track_count: number;
+            /** Filtered Count */
+            filtered_count?: number | null;
+        };
+        /** UsbDevice */
+        UsbDevice: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Mount Path */
+            mount_path: string;
         };
         /**
          * UserInfo
@@ -3266,7 +3605,17 @@ export interface operations {
     };
     get_folder_tree_api_metadata_folders_tree_get: {
         parameters: {
-            query?: never;
+            query?: {
+                search?: string | null;
+                genres?: string[] | null;
+                keys?: string[] | null;
+                bpm_min?: number | null;
+                bpm_max?: number | null;
+                has_soundcloud_id?: boolean | null;
+                file_formats?: string[] | null;
+                size_min?: number | null;
+                size_max?: number | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3280,6 +3629,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TreeNode"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -3852,7 +4210,7 @@ export interface operations {
     get_file_peaks_api_metadata_files__file_path__peaks_get: {
         parameters: {
             query?: {
-                /** @description Number of amplitude peaks to return */
+                /** @description Number of amplitude peaks to return (up to ~150/s for zoom). */
                 num_peaks?: number;
             };
             header?: never;
@@ -5176,6 +5534,327 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SuggestionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_usb_devices_api_rekordbox_usb_devices_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DevicesResponse"];
+                };
+            };
+        };
+    };
+    eject_usb_device_api_rekordbox_usb_eject_post: {
+        parameters: {
+            query: {
+                /** @description USB device id */
+                device: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_status_api_rekordbox_status_get: {
+        parameters: {
+            query?: {
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RekordboxStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_playlists_api_rekordbox_playlists_get: {
+        parameters: {
+            query?: {
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlaylistsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_playlist_tracks_api_rekordbox_playlists__playlist_id__tracks_get: {
+        parameters: {
+            query?: {
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path: {
+                playlist_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TracksResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_track_artwork_api_rekordbox_tracks__track_id__artwork_get: {
+        parameters: {
+            query?: {
+                small?: boolean;
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path: {
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_track_waveform_api_rekordbox_tracks__track_id__waveform_get: {
+        parameters: {
+            query?: {
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+                variant?: string;
+            };
+            header?: never;
+            path: {
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_track_analysis_api_rekordbox_tracks__track_id__analysis_get: {
+        parameters: {
+            query?: {
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path: {
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrackAnalysisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_track_audio_api_rekordbox_tracks__track_id__audio_get: {
+        parameters: {
+            query: {
+                /** @description USB device id */
+                device: string;
+            };
+            header?: never;
+            path: {
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tracks_api_rekordbox_tracks_get: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                /** @description USB device id; omit for the local install */
+                device?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TracksResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/generated/backend.ts
+++ b/frontend/src/generated/backend.ts
@@ -2218,6 +2218,8 @@ export interface components {
             color?: string | null;
             /** Comment */
             comment?: string | null;
+            /** Outms */
+            outMs?: number | null;
         };
         /** DevicesResponse */
         DevicesResponse: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -439,17 +439,30 @@ export const api = {
     return `${API_BASE_URL}/api/rekordbox/tracks/${encodeURIComponent(trackId)}/artwork?${params}`;
   },
 
-  // Rekordbox PWV4 color preview entries (raw 1200 × 6 bytes)
+  // Rekordbox waveform bytes. Preview variants span the whole track (`color` =
+  // PWV4 1200×6, `blue` = PWAV 400×1); detail variants carry ~150 columns/second
+  // for zoom (`color_detail` = PWV5, `blue_detail` = PWV3).
   getRekordboxWaveformUrl(
     trackId: string,
     device?: string,
-    variant: "color" | "blue" = "color",
+    variant: "color" | "blue" | "color_detail" | "blue_detail" = "color",
   ): string {
     const params = new URLSearchParams();
     if (device) params.set("device", device);
     if (variant !== "color") params.set("variant", variant);
     const q = params.toString();
     return `${API_BASE_URL}/api/rekordbox/tracks/${encodeURIComponent(trackId)}/waveform${q ? `?${q}` : ""}`;
+  },
+
+  // Rekordbox beatgrid / phrase sections / cues as JSON.
+  async getRekordboxAnalysis(
+    trackId: string,
+    device?: string,
+  ): Promise<components["schemas"]["TrackAnalysisResponse"]> {
+    const q = device ? `?device=${encodeURIComponent(device)}` : "";
+    return fetchApi<components["schemas"]["TrackAnalysisResponse"]>(
+      `/api/rekordbox/tracks/${encodeURIComponent(trackId)}/analysis${q}`,
+    );
   },
 
   // Audio stream for a track on a mounted USB export.

--- a/frontend/src/lib/looping-web-audio-player.ts
+++ b/frontend/src/lib/looping-web-audio-player.ts
@@ -1,0 +1,198 @@
+import WebAudioPlayer from "wavesurfer.js/dist/webaudio.js";
+
+export interface LoopRegion {
+  /** Loop start, in seconds. */
+  start: number;
+  /** Loop end, in seconds. */
+  end: number;
+}
+
+/**
+ * One AudioContext for the whole app, reused across every track.
+ *
+ * Browsers cap the number of concurrent `AudioContext`s (~6 in Chrome). The
+ * base player creates one per instance and closes it on `destroy()`, but
+ * `close()` is async and the hardware slots free lazily — so skipping through a
+ * handful of tracks can momentarily exceed the cap. Contexts created past it
+ * come up without an output device: the clock still advances (so the waveform
+ * keeps scrolling) while nothing is audible, and it stays broken. Sharing a
+ * single long-lived context sidesteps that entirely and means we only ever
+ * resume-after-gesture once.
+ */
+let sharedContext: AudioContext | null = null;
+function getSharedAudioContext(): AudioContext {
+  if (!sharedContext || sharedContext.state === "closed") {
+    sharedContext = new AudioContext();
+  }
+  return sharedContext;
+}
+
+/**
+ * The private fields we reach into on the base {@link WebAudioPlayer}. They are
+ * TypeScript-`private` (compile-time only), so we cast through this shape rather
+ * than fork the vendored class. Pinned to `wavesurfer.js@^7.12` — revisit on a
+ * major bump.
+ */
+interface WebAudioInternals {
+  bufferNode: AudioBufferSourceNode | null;
+  buffer: AudioBuffer | null;
+  currentSrc: string;
+  playbackPosition: number;
+  _destroyed: boolean;
+  unAll(): void;
+}
+
+/**
+ * A WaveSurfer `WebAudioPlayer` (Web Audio buffer source emulating an
+ * `<audio>` element) extended with **gapless, sample-accurate looping** and
+ * instant cue.
+ *
+ * The base player restarts its `AudioBufferSourceNode` on every seek — which on
+ * Web Audio is instant (no HTMLMediaElement seek stall), so cue points and loop
+ * restarts have no audible delay. For looping we go one better and use the
+ * native `AudioBufferSourceNode.loop`/`loopStart`/`loopEnd`, so the wrap happens
+ * on the audio thread with sample accuracy instead of a JS-polled seek.
+ *
+ * The base player tracks position linearly (`playbackPosition + elapsed`), which
+ * a native loop would let grow unbounded past the loop end. We reconcile that:
+ * - `currentTime` reports the position wrapped into the loop region;
+ * - `pause()` stores the wrapped position so resume starts in the right place;
+ * - clearing the loop resyncs by seeking to the wrapped position.
+ */
+export class LoopingWebAudioPlayer extends WebAudioPlayer {
+  private loopRegion: LoopRegion | null = null;
+
+  constructor() {
+    // Reuse the app-wide context instead of minting one per track.
+    super(getSharedAudioContext());
+  }
+
+  private get internals(): WebAudioInternals {
+    return this as unknown as WebAudioInternals;
+  }
+
+  private get context(): BaseAudioContext {
+    return this.getGainNode().context;
+  }
+
+  /**
+   * Fetch and decode `url` into the playback buffer. Unlike the base `src`
+   * setter (which swallows decode errors silently), this rejects on failure so
+   * the caller can surface an error instead of hanging on a `canplay` that
+   * never comes.
+   */
+  async loadBuffer(url: string): Promise<void> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch audio: ${response.status}`);
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = await this.context.decodeAudioData(arrayBuffer);
+    this.internals.buffer = buffer;
+    this.internals.currentSrc = url;
+    this.emit("loadedmetadata");
+    this.emit("canplay");
+  }
+
+  /** Set (or clear) the active loop region. */
+  setLoop(region: LoopRegion | null): void {
+    const wasLooping = this.loopRegion != null && !this.paused;
+    // Clearing an active loop: the base player's linear position may have run
+    // past the loop end, so seek to the wrapped position to resync before
+    // linear playback continues.
+    if (wasLooping && region == null) {
+      const wrapped = this.currentTime;
+      this.loopRegion = null;
+      this.currentTime = wrapped;
+      return;
+    }
+    this.loopRegion = region;
+    this.applyLoop();
+  }
+
+  /** Push the current loop region onto the live buffer node (if any). */
+  private applyLoop(): void {
+    const node = this.internals.bufferNode;
+    if (!node) return;
+    const region = this.loopRegion;
+    if (region && region.end > region.start) {
+      node.loop = true;
+      node.loopStart = region.start;
+      node.loopEnd = region.end;
+    } else {
+      node.loop = false;
+    }
+  }
+
+  get currentTime(): number {
+    const raw = super.currentTime;
+    const region = this.loopRegion;
+    if (region && region.end > region.start && raw > region.end) {
+      const span = region.end - region.start;
+      return region.start + ((raw - region.start) % span);
+    }
+    return raw;
+  }
+
+  set currentTime(value: number) {
+    super.currentTime = value;
+    this.applyLoop();
+  }
+
+  get playbackRate(): number {
+    return super.playbackRate;
+  }
+
+  set playbackRate(value: number) {
+    super.playbackRate = value;
+    this.applyLoop();
+  }
+
+  async play(): Promise<void> {
+    // A context created before a user gesture starts suspended; resume it now
+    // (playback is always triggered by a click, so activation is present).
+    // Guard against a context torn down mid-track-switch.
+    if (this.context.state === "suspended") {
+      await (this.context as AudioContext).resume().catch(() => {});
+    }
+    await super.play();
+    this.applyLoop();
+  }
+
+  pause(): void {
+    if (this.paused) return;
+    // Snapshot the wrapped position before the base player folds the (possibly
+    // past-loop-end) linear elapsed time into `playbackPosition`, so resume
+    // starts inside the loop instead of clamping to 0.
+    const wrapped = this.loopRegion ? this.currentTime : null;
+    super.pause();
+    if (wrapped != null) {
+      this.internals.playbackPosition = wrapped;
+    }
+  }
+
+  /**
+   * Tear down this player's nodes but leave the shared AudioContext open — the
+   * base `destroy()` would close it, breaking every later track. Mirrors the
+   * base cleanup minus the `context.close()` call.
+   */
+  destroy(): void {
+    const it = this.internals;
+    if (it._destroyed) return;
+    it._destroyed = true;
+    it.currentSrc = "";
+    if (it.bufferNode) {
+      it.bufferNode.onended = null;
+      try {
+        it.bufferNode.stop();
+      } catch {
+        /* already stopped */
+      }
+      it.bufferNode.disconnect();
+      it.bufferNode = null;
+    }
+    this.getGainNode().disconnect();
+    it.buffer = null;
+    it.unAll();
+  }
+}

--- a/frontend/src/lib/player-context.tsx
+++ b/frontend/src/lib/player-context.tsx
@@ -49,6 +49,8 @@ export interface PlayerTrack {
    * export. Threads through to the PWV4 waveform fetch so it targets the
    * device rather than the local install. */
   rekordboxDevice?: string;
+  /** Musical key (e.g. "8A", "Fm"), when known. Shown next to the BPM. */
+  musicalKey?: string;
 }
 
 interface PlayerContextValue {

--- a/frontend/src/lib/rekordbox-analysis.ts
+++ b/frontend/src/lib/rekordbox-analysis.ts
@@ -1,0 +1,40 @@
+import type { components } from "@/generated/backend";
+import { api } from "@/lib/api";
+
+export type TrackAnalysis = components["schemas"]["TrackAnalysisResponse"];
+export type AnalysisBeat = components["schemas"]["BeatModel"];
+export type AnalysisSection = components["schemas"]["SectionModel"];
+export type AnalysisCue = components["schemas"]["CueModel"];
+
+// Module-level cache keyed by device+trackId, mirroring `loadWaveform` — the
+// player and (later) row overlays request the same analysis; refetching per
+// render would spam the backend.
+const cache = new Map<string, TrackAnalysis | null>();
+const inflight = new Map<string, Promise<TrackAnalysis | null>>();
+
+function key(trackId: string, device: string | undefined): string {
+  return device ? `${device}:${trackId}` : trackId;
+}
+
+/** Fetch a track's beatgrid/sections/cues once, cached and inflight-deduped. */
+export function getCachedRekordboxAnalysis(
+  trackId: string,
+  device?: string,
+): Promise<TrackAnalysis | null> {
+  const k = key(trackId, device);
+  const hit = cache.get(k);
+  if (hit !== undefined) return Promise.resolve(hit);
+  let p = inflight.get(k);
+  if (!p) {
+    p = api
+      .getRekordboxAnalysis(trackId, device)
+      .catch(() => null)
+      .then((data) => {
+        cache.set(k, data);
+        inflight.delete(k);
+        return data;
+      });
+    inflight.set(k, p);
+  }
+  return p;
+}

--- a/frontend/src/lib/waveform-detail.test.ts
+++ b/frontend/src/lib/waveform-detail.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  barBeatLabel,
+  barSpanSeconds,
+  buildDownbeatPrefix,
+  decodeFloatPeaks,
+  decodePwv3,
+  decodePwv5,
+  rgbCss,
+  type BeatTick,
+} from "@/lib/waveform-detail";
+
+describe("decodePwv5", () => {
+  it("unpacks 3-bit RGB and 5-bit height from big-endian columns", () => {
+    // Column bits: rrr ggg bbb hhhhh 00. Max R (7), zero G/B, max height (31).
+    const maxRedFullHeight = 0b111_000_000_11111_00; // 0xE07C
+    // Full green, half-ish height.
+    const green = 0b000_111_000_10000_00; // 0x1C40
+    const bytes = new Uint8Array([
+      (maxRedFullHeight >> 8) & 0xff,
+      maxRedFullHeight & 0xff,
+      (green >> 8) & 0xff,
+      green & 0xff,
+    ]);
+    const wave = decodePwv5(bytes);
+    expect(wave.heights.length).toBe(2);
+    expect(wave.heights[0]).toBeCloseTo(1, 5);
+    expect(wave.colors).not.toBeNull();
+    expect(rgbCss(wave.colors![0])).toBe("rgb(255, 0, 0)");
+    expect(rgbCss(wave.colors![1])).toBe("rgb(0, 255, 0)");
+    expect(wave.columnsPerSecond).toBe(150);
+  });
+});
+
+describe("decodePwv3", () => {
+  it("unpacks 5-bit height and produces a blue-palette colour", () => {
+    const wave = decodePwv3(new Uint8Array([0x1f, 0x00]));
+    expect(wave.heights[0]).toBeCloseTo(1, 5);
+    expect(wave.heights[1]).toBe(0);
+    expect(wave.colors).not.toBeNull();
+    // No whiteness bits → the dim blue base colour.
+    expect(rgbCss(wave.colors![1])).toBe("rgb(40, 120, 220)");
+  });
+});
+
+describe("decodeFloatPeaks", () => {
+  it("derives columns-per-second from the track length", () => {
+    const wave = decodeFloatPeaks([0, 0.5, 1, 0.5], 2);
+    expect(Array.from(wave.heights)).toEqual([0, 0.5, 1, 0.5]);
+    expect(wave.colors).toBeNull();
+    expect(wave.columnsPerSecond).toBe(2); // 4 columns / 2 s
+  });
+});
+
+describe("barSpanSeconds", () => {
+  it("maps bars to seconds at the given tempo", () => {
+    // 4 bars * 4 beats = 16 beats; at 120 BPM that's 16 * 0.5 s = 8 s.
+    expect(barSpanSeconds(4, 120)).toBeCloseTo(8, 5);
+    // 8 bars at 128 BPM.
+    expect(barSpanSeconds(8, 128)).toBeCloseTo((8 * 4 * 60) / 128, 5);
+  });
+
+  it("falls back to 120 BPM when tempo is unknown", () => {
+    expect(barSpanSeconds(4, null)).toBe(barSpanSeconds(4, 120));
+    expect(barSpanSeconds(4, 0)).toBe(barSpanSeconds(4, 120));
+  });
+});
+
+describe("barBeatLabel", () => {
+  const grid: BeatTick[] = [];
+  // 8 beats at 120 BPM (500 ms/beat), beat cycling 1..4.
+  for (let i = 0; i < 8; i++) {
+    grid.push({ beat: (i % 4) + 1, timeMs: i * 500 });
+  }
+  const prefix = buildDownbeatPrefix(grid);
+
+  it("counts bars from downbeats and reports beat-in-bar", () => {
+    expect(barBeatLabel(0, grid, prefix)).toBe("1.1");
+    expect(barBeatLabel(0.75, grid, prefix)).toBe("1.2"); // 750 ms → beat idx 1
+    expect(barBeatLabel(2.0, grid, prefix)).toBe("2.1"); // 2000 ms → 5th beat, bar 2
+    expect(barBeatLabel(3.5, grid, prefix)).toBe("2.4"); // 3500 ms → 8th beat
+  });
+
+  it("returns a dash before the first beat or without a grid", () => {
+    expect(barBeatLabel(-1, grid, prefix)).toBe("–");
+    expect(barBeatLabel(5, [], new Uint32Array())).toBe("–");
+  });
+});

--- a/frontend/src/lib/waveform-detail.test.ts
+++ b/frontend/src/lib/waveform-detail.test.ts
@@ -4,10 +4,14 @@ import {
   barBeatLabel,
   barSpanSeconds,
   buildDownbeatPrefix,
+  computeCueDisplays,
   decodeFloatPeaks,
   decodePwv3,
   decodePwv5,
+  keySemitonesForRate,
   rgbCss,
+  semitonesFloatForRate,
+  transposeKey,
   type BeatTick,
 } from "@/lib/waveform-detail";
 
@@ -85,5 +89,101 @@ describe("barBeatLabel", () => {
   it("returns a dash before the first beat or without a grid", () => {
     expect(barBeatLabel(-1, grid, prefix)).toBe("–");
     expect(barBeatLabel(5, [], new Uint32Array())).toBe("–");
+  });
+});
+
+describe("keySemitonesForRate", () => {
+  it("is zero at unity and rounds to whole semitones", () => {
+    expect(keySemitonesForRate(1)).toBe(0);
+    expect(keySemitonesForRate(2)).toBe(12); // octave up
+    expect(keySemitonesForRate(0.5)).toBe(-12); // octave down
+    expect(keySemitonesForRate(140 / 124.5)).toBe(2); // +12.5%ish ≈ +2
+  });
+
+  it("guards against non-positive or non-finite rates", () => {
+    expect(keySemitonesForRate(0)).toBe(0);
+    expect(keySemitonesForRate(-1)).toBe(0);
+    expect(keySemitonesForRate(Number.NaN)).toBe(0);
+  });
+});
+
+describe("semitonesFloatForRate", () => {
+  it("returns the unrounded shift so between-key pitches read honestly", () => {
+    expect(semitonesFloatForRate(1)).toBe(0);
+    expect(semitonesFloatForRate(2)).toBeCloseTo(12, 5);
+    // +12.5% pitch lands ~+2.04 semitones — between keys, not exactly +2.
+    expect(semitonesFloatForRate(1.125)).toBeCloseTo(2.039, 3);
+    expect(keySemitonesForRate(1.125)).toBe(2); // nearest key still +2
+  });
+
+  it("guards against non-positive or non-finite rates", () => {
+    expect(semitonesFloatForRate(0)).toBe(0);
+    expect(semitonesFloatForRate(Number.NaN)).toBe(0);
+  });
+});
+
+describe("transposeKey", () => {
+  it("returns the input unchanged for a zero shift", () => {
+    expect(transposeKey("8A", 0)).toBe("8A");
+  });
+
+  it("moves Camelot keys +7 wheel positions per semitone, wrapping", () => {
+    expect(transposeKey("8A", 2)).toBe("10A");
+    expect(transposeKey("8A", 1)).toBe("3A"); // 8 + 7 = 15 → 3
+    expect(transposeKey("11B", 3)).toBe("8B"); // +21 → +9 → 11+9=20 → 8
+    expect(transposeKey("1a", -1)).toBe("6A"); // wraps, letter normalised
+  });
+
+  it("transposes standard note names and preserves minor quality", () => {
+    expect(transposeKey("C", 2)).toBe("D");
+    expect(transposeKey("Am", 3)).toBe("Cm");
+    expect(transposeKey("Db", 1)).toBe("D"); // enharmonic flat → sharp scale
+    expect(transposeKey("B", 1)).toBe("C"); // wraps octave
+  });
+
+  it("leaves unrecognised keys alone", () => {
+    expect(transposeKey("", 2)).toBe("");
+    expect(transposeKey("N/A", 2)).toBe("N/A");
+  });
+});
+
+describe("computeCueDisplays", () => {
+  it("colours hot cues by slot with letters, numbers memory cues from 1", () => {
+    const displays = computeCueDisplays([
+      { type: "hot", index: 1 },
+      { type: "memory", index: null },
+      { type: "hot", index: 3 },
+      { type: "memory", index: null },
+    ]);
+    // Hot cues → letter labels, palette colour, isHot true.
+    expect(displays[0]).toEqual({
+      color: "#eb4b71",
+      label: "A",
+      isHot: true,
+      isLoop: false,
+    });
+    expect(displays[2].label).toBe("C");
+    expect(displays[2].isHot).toBe(true);
+    expect(displays[2].color).not.toBe(displays[0].color); // slot-varied
+    // Memory cues → sequential numbers from 1, not hot.
+    expect(displays[1]).toMatchObject({ label: "1", isHot: false });
+    expect(displays[3].label).toBe("2");
+  });
+
+  it("honours an explicit cue colour over the slot palette", () => {
+    const [d] = computeCueDisplays([
+      { type: "hot", index: 1, color: "#00ff00" },
+    ]);
+    expect(d.color).toBe("#00ff00");
+  });
+
+  it("renders loops in Rekordbox loop orange, overriding the slot colour", () => {
+    const [loop, point] = computeCueDisplays([
+      { type: "hot", index: 1, timeMs: 1000, outMs: 5000 }, // loop
+      { type: "hot", index: 1, timeMs: 1000, outMs: 500 }, // out < in → not a loop
+    ]);
+    expect(loop).toMatchObject({ color: "#f09235", label: "A", isLoop: true });
+    expect(point.isLoop).toBe(false);
+    expect(point.color).toBe("#eb4b71");
   });
 });

--- a/frontend/src/lib/waveform-detail.ts
+++ b/frontend/src/lib/waveform-detail.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure decoders and window math for the zoomed ("detail") waveform.
+ *
+ * The bottom player can zoom down to a few bars. At that scale the whole-track
+ * preview waveforms (1200/400 columns) are far too coarse, so we decode the
+ * high-resolution ANLZ detail waveforms (~150 columns/second) — PWV5 colour or
+ * PWV3 monochrome — or, for local files, the backend's high-resolution ffmpeg
+ * peaks. All three normalize to a {@link DetailWave}: per-column heights in
+ * `[0, 1]`, optional packed RGB colours, and a columns-per-second rate so the
+ * renderer can map playback time to a column.
+ *
+ * These functions are deliberately free of React/canvas so they can be unit
+ * tested and reused by the row waveforms later.
+ */
+
+export interface DetailWave {
+  /** Per-column amplitude, normalized to `[0, 1]`. */
+  heights: Float32Array;
+  /** Packed `0xRRGGBB` per column, or `null` to let the renderer theme it. */
+  colors: Uint32Array | null;
+  /** Columns per second — maps a time (s) to a fractional column index. */
+  columnsPerSecond: number;
+}
+
+/** Rekordbox detail waveforms carry 150 columns per second. */
+export const DETAIL_COLUMNS_PER_SECOND = 150;
+
+/** Pack 8-bit R/G/B into a single `0xRRGGBB` number. */
+function pack(r: number, g: number, b: number): number {
+  return ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
+}
+
+/** Format a packed `0xRRGGBB` colour as a CSS `rgb(...)` string. */
+export function rgbCss(packed: number): string {
+  return `rgb(${(packed >> 16) & 0xff}, ${(packed >> 8) & 0xff}, ${packed & 0xff})`;
+}
+
+/**
+ * Decode PWV5 colour-detail bytes (2 bytes/column, big-endian). Bit layout per
+ * column: `rrr ggg bbb hhhhh 00` (3-bit R/G/B, 5-bit height).
+ */
+export function decodePwv5(bytes: Uint8Array): DetailWave {
+  const n = Math.floor(bytes.length / 2);
+  const heights = new Float32Array(n);
+  const colors = new Uint32Array(n);
+  for (let i = 0; i < n; i++) {
+    const x = (bytes[i * 2] << 8) | bytes[i * 2 + 1];
+    const r = (x >> 13) & 0x7;
+    const g = (x >> 10) & 0x7;
+    const b = (x >> 7) & 0x7;
+    const h = (x >> 2) & 0x1f;
+    heights[i] = h / 31;
+    colors[i] = pack(
+      Math.round((r / 7) * 255),
+      Math.round((g / 7) * 255),
+      Math.round((b / 7) * 255),
+    );
+  }
+  return { heights, colors, columnsPerSecond: DETAIL_COLUMNS_PER_SECOND };
+}
+
+/**
+ * Decode PWV3 monochrome-detail bytes (1 byte/column): 5-bit height (low) +
+ * 3-bit whiteness (high). Rendered as the Rekordbox "blue" palette — a dim blue
+ * silhouette brightening toward cyan-white where whiteness bits are set.
+ */
+export function decodePwv3(bytes: Uint8Array): DetailWave {
+  const n = bytes.length;
+  const heights = new Float32Array(n);
+  const colors = new Uint32Array(n);
+  for (let i = 0; i < n; i++) {
+    const height = (bytes[i] & 0x1f) / 31;
+    const white = ((bytes[i] >> 5) & 0x7) / 7;
+    heights[i] = height;
+    colors[i] = pack(
+      Math.round(40 + white * 150),
+      Math.round(120 + white * 110),
+      Math.round(220 + white * 35),
+    );
+  }
+  return { heights, colors, columnsPerSecond: DETAIL_COLUMNS_PER_SECOND };
+}
+
+/**
+ * Wrap high-resolution local-file peaks (already `[0, 1]`) as a themed
+ * (colourless) detail wave. `columnsPerSecond` is derived from the track length.
+ */
+export function decodeFloatPeaks(
+  peaks: number[],
+  durationSec: number,
+): DetailWave {
+  const heights = Float32Array.from(peaks);
+  const cps =
+    durationSec > 0 ? peaks.length / durationSec : DETAIL_COLUMNS_PER_SECOND;
+  return { heights, colors: null, columnsPerSecond: cps };
+}
+
+/**
+ * Seconds spanned by `zoomBars` bars at `bpm` (4 beats/bar). Falls back to
+ * 120 BPM when the tempo is unknown so local files without a BPM still zoom.
+ */
+export function barSpanSeconds(
+  zoomBars: number,
+  bpm: number | null | undefined,
+): number {
+  const effective = bpm && bpm > 0 ? bpm : 120;
+  return (zoomBars * 4 * 60) / effective;
+}
+
+export interface BeatTick {
+  beat: number;
+  timeMs: number;
+}
+
+/**
+ * Precompute, for each beatgrid entry, how many downbeats (bar starts) have
+ * occurred up to and including it — so bar numbers are an O(log n) lookup.
+ */
+export function buildDownbeatPrefix(
+  beatgrid: readonly BeatTick[],
+): Uint32Array {
+  const prefix = new Uint32Array(beatgrid.length);
+  let bars = 0;
+  for (let i = 0; i < beatgrid.length; i++) {
+    if (beatgrid[i].beat === 1) bars++;
+    prefix[i] = bars;
+  }
+  return prefix;
+}
+
+/** Index of the last beat at or before `timeMs` (binary search), or -1. */
+function beatIndexAt(timeMs: number, beatgrid: readonly BeatTick[]): number {
+  let lo = 0;
+  let hi = beatgrid.length - 1;
+  let ans = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (beatgrid[mid].timeMs <= timeMs) {
+      ans = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return ans;
+}
+
+/**
+ * Render a `bar.beat` counter (e.g. `"33.2"`) for a playback time, using the
+ * beatgrid and a downbeat prefix from {@link buildDownbeatPrefix}. Returns `"–"`
+ * before the first beat or when there is no beatgrid.
+ */
+export function barBeatLabel(
+  timeSec: number,
+  beatgrid: readonly BeatTick[],
+  downbeatPrefix: Uint32Array,
+): string {
+  if (beatgrid.length === 0) return "–";
+  const idx = beatIndexAt(timeSec * 1000, beatgrid);
+  if (idx < 0) return "–";
+  const bar = Math.max(1, downbeatPrefix[idx]);
+  return `${bar}.${beatgrid[idx].beat}`;
+}

--- a/frontend/src/lib/waveform-detail.ts
+++ b/frontend/src/lib/waveform-detail.ts
@@ -35,6 +35,25 @@ export function rgbCss(packed: number): string {
   return `rgb(${(packed >> 16) & 0xff}, ${(packed >> 8) & 0xff}, ${packed & 0xff})`;
 }
 
+/** Perceived luminance of a `#RRGGBB` colour (0–255). */
+export function hexLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** Black or white text, whichever reads on `hex`. */
+export function textOn(hex: string): string {
+  return hexLuminance(hex) > 150 ? "#000" : "#fff";
+}
+
+/** Hot-cue slot (1-based) to its rekordbox letter: 1 → "A". */
+export function hotCueLetter(index: number | null | undefined): string {
+  return index != null ? String.fromCharCode(64 + index) : "H";
+}
+
 /**
  * Decode PWV5 colour-detail bytes (2 bytes/column, big-endian). Bit layout per
  * column: `rrr ggg bbb hhhhh 00` (3-bit R/G/B, 5-bit height).

--- a/frontend/src/lib/waveform-detail.ts
+++ b/frontend/src/lib/waveform-detail.ts
@@ -55,6 +55,81 @@ export function hotCueLetter(index: number | null | undefined): string {
 }
 
 /**
+ * Rekordbox's "Colourful" hot-cue palette, per slot A–H (wrapping past H).
+ * Local-install cues store no colour — Rekordbox applies the scheme by slot —
+ * so we tint each hot cue by its slot; an explicit colour (e.g. a USB export's
+ * ANLZ RGB) always wins. Values sampled from Rekordbox's own hot-cue pads.
+ */
+const HOT_CUE_PALETTE = [
+  "#eb4b71", // A
+  "#62aad7", // B
+  "#8cbf52", // C
+  "#a274f7", // D
+  "#68cf78", // E
+  "#d16b32", // F
+  "#3a59f6", // G
+  "#c0b039", // H
+];
+/** Neutral marker colour for memory cues (they aren't colour-coded). */
+const MEMORY_CUE_COLOR = "#f43f5e";
+/** Rekordbox shows loops in a fixed orange, overriding the slot colour. */
+const LOOP_CUE_COLOR = "#f09235";
+
+export interface CueDisplayInput {
+  type: string;
+  index?: number | null;
+  color?: string | null;
+  timeMs?: number;
+  /** Loop out-point (ms); a cue with `outMs > timeMs` is a loop. */
+  outMs?: number | null;
+}
+
+export interface CueDisplay {
+  /** Resolved marker colour (`#RRGGBB`). */
+  color: string;
+  /** Marker glyph: a letter (A, B…) for hot cues, a number for memory cues. */
+  label: string;
+  /** True for hot cues (colour-coded), false for memory cues (numbered). */
+  isHot: boolean;
+  /** True when the cue is a loop (out-point set) → orange + loop glyph. */
+  isLoop: boolean;
+}
+
+/**
+ * Resolve how each cue renders: hot cues get a colour (from the cue, else its
+ * slot palette) and their letter; memory cues get a sequential number from 1
+ * (they carry no label in Rekordbox). Loops override the colour with Rekordbox's
+ * loop orange. Input order is assumed time-sorted, so memory numbering follows
+ * playback order.
+ */
+export function computeCueDisplays(
+  cues: readonly CueDisplayInput[],
+): CueDisplay[] {
+  let memoryNumber = 0;
+  return cues.map((c) => {
+    const isLoop = c.outMs != null && c.timeMs != null && c.outMs > c.timeMs;
+    if (c.type === "hot") {
+      const slot = c.index ?? 1;
+      const base =
+        c.color ?? HOT_CUE_PALETTE[(slot - 1) % HOT_CUE_PALETTE.length];
+      return {
+        color: isLoop ? LOOP_CUE_COLOR : base,
+        label: hotCueLetter(c.index),
+        isHot: true,
+        isLoop,
+      };
+    }
+    memoryNumber += 1;
+    return {
+      color: isLoop ? LOOP_CUE_COLOR : (c.color ?? MEMORY_CUE_COLOR),
+      label: String(memoryNumber),
+      isHot: false,
+      isLoop,
+    };
+  });
+}
+
+/**
  * Decode PWV5 colour-detail bytes (2 bytes/column, big-endian). Bit layout per
  * column: `rrr ggg bbb hhhhh 00` (3-bit R/G/B, 5-bit height).
  */
@@ -179,4 +254,81 @@ export function barBeatLabel(
   if (idx < 0) return "–";
   const bar = Math.max(1, downbeatPrefix[idx]);
   return `${bar}.${beatgrid[idx].beat}`;
+}
+
+/**
+ * Continuous (unrounded) semitone shift for a playback rate — a pitch of +12.5%
+ * is +2.04 semitones, landing *between* two keys. Use this for the numeric
+ * readout so the fraction is honest; use {@link keySemitonesForRate} to pick the
+ * nearest key label.
+ */
+export function semitonesFloatForRate(rate: number): number {
+  if (!Number.isFinite(rate) || rate <= 0) return 0;
+  return 12 * Math.log2(rate);
+}
+
+/** Whole semitones a playback rate shifts pitch (rate 1 → 0, up → positive). */
+export function keySemitonesForRate(rate: number): number {
+  return Math.round(semitonesFloatForRate(rate));
+}
+
+const CAMELOT_RE = /^\s*(\d{1,2})\s*([AB])\s*$/i;
+const CHROMATIC = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+const ENHARMONIC: Record<string, string> = {
+  Db: "C#",
+  Eb: "D#",
+  Fb: "E",
+  Gb: "F#",
+  Ab: "G#",
+  Bb: "A#",
+  Cb: "B",
+  "E#": "F",
+  "B#": "C",
+};
+
+/**
+ * Transpose a musical key by `semitones`. Handles Camelot notation (`"8A"` →
+ * +1 semitone is +7 wheel positions, same letter) and standard note names
+ * (`"Am"`, `"C#"`, `"Db"`). Returns the input unchanged for 0 semitones or an
+ * unrecognised key.
+ */
+export function transposeKey(key: string, semitones: number): string {
+  if (!semitones) return key;
+
+  const cam = key.match(CAMELOT_RE);
+  if (cam) {
+    const n = Number(cam[1]);
+    if (n >= 1 && n <= 12) {
+      const shifted = ((((n - 1 + 7 * semitones) % 12) + 12) % 12) + 1;
+      return `${shifted}${cam[2].toUpperCase()}`;
+    }
+  }
+
+  const std = key.match(/^\s*([A-Ga-g][#b]?)\s*(m|min|maj|major|minor)?\s*$/);
+  if (std) {
+    const root = std[1][0].toUpperCase() + std[1].slice(1);
+    const canon = ENHARMONIC[root] ?? root;
+    const idx = CHROMATIC.indexOf(canon);
+    if (idx >= 0) {
+      const shifted = (((idx + semitones) % 12) + 12) % 12;
+      const quality = std[2]?.toLowerCase() ?? "";
+      const minor = quality === "m" || quality.startsWith("min") ? "m" : "";
+      return `${CHROMATIC[shifted]}${minor}`;
+    }
+  }
+
+  return key;
 }

--- a/tests/test_rekordbox_analysis.py
+++ b/tests/test_rekordbox_analysis.py
@@ -1,0 +1,119 @@
+"""Tests for the Rekordbox ANLZ analysis parsers.
+
+Builds synthetic ANLZ tag bytes (beatgrid, detail waveform, phrase sections,
+cues) so the parsers are exercised offline without real Rekordbox files.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from pyrekordbox.anlz.file import XOR_MASK
+
+from backend.core.services.rekordbox import analysis as A
+from backend.core.services.rekordbox.base import extract_pwv3, extract_pwv5
+
+
+def _anlz(*tags: bytes) -> bytes:
+    body = b"".join(tags)
+    return b"PMAI" + struct.pack(">II", 16, 16 + len(body)) + struct.pack(">I", 0) + body
+
+
+def _pqtz(beats: list[tuple[int, int, int]]) -> bytes:
+    content = struct.pack(">II", 0, 0x80000) + struct.pack(">I", len(beats))
+    for beat, tempo, time_ms in beats:
+        content += struct.pack(">HHI", beat, tempo, time_ms)
+    return b"PQTZ" + struct.pack(">II", 24, 12 + len(content)) + content
+
+
+def _detail(fourcc: bytes, entry_bytes: int, entries: bytes) -> bytes:
+    n = len(entries) // entry_bytes
+    body = struct.pack(">III", entry_bytes, n, 0) + entries
+    return fourcc + struct.pack(">II", 24, 12 + len(body)) + body
+
+
+def _pcp2(hot_cue: int, time_ms: int, rgb: tuple[int, int, int]) -> bytes:
+    r, g, b = rgb
+    e = b"PCP2" + struct.pack(">III", 16, 48, hot_cue) + struct.pack(">B", 1) + b"\x00" * 3
+    e += struct.pack(">i", time_ms) + struct.pack(">i", -1) + struct.pack(">B", 0) + b"\x00" * 7
+    e += struct.pack(">HH", 0, 0) + struct.pack(">I", 0) + struct.pack(">BBBB", 0, r, g, b)
+    return e
+
+
+def _pco2(cue_type: int, entries: list[bytes]) -> bytes:
+    content = struct.pack(">I", cue_type) + struct.pack(">HH", len(entries), 0) + b"".join(entries)
+    return b"PCO2" + struct.pack(">II", 20, 12 + len(content)) + content
+
+
+def _pssi(mood: int, end_beat: int, entries: list[tuple[int, int, int]], *, garble: bool = False) -> bytes:
+    """Build a PSSI tag; ``entries`` are ``(index, beat, kind)`` triples."""
+    body = struct.pack(">IHH", 24, len(entries), mood)
+    body += b"\x00" * 6 + struct.pack(">H", end_beat) + b"\x00" * 2 + b"\x00" + b"\x00"
+    for index, beat, kind in entries:
+        body += struct.pack(">HHH", index, beat, kind) + b"\x00" * 18
+    tag = b"PSSI" + struct.pack(">II", 32, 12 + len(body)) + body
+    if garble:
+        # Scramble every byte past offset 18 exactly as Rekordbox exports do.
+        out = bytearray(tag)
+        len_entries = len(entries)
+        for x in range(len(out) - 18):
+            out[18 + x] ^= (XOR_MASK[x % len(XOR_MASK)] + len_entries) & 0xFF
+        tag = bytes(out)
+    return tag
+
+
+_BEATS = [((i % 4) + 1, 12800, i * 469) for i in range(64)]
+
+
+def test_parse_beatgrid() -> None:
+    beats = A.parse_beatgrid(_anlz(_pqtz(_BEATS[:4])))
+    assert len(beats) == 4
+    assert beats[0] == A.Beat(beat=1, bpm=128.0, time_ms=0)
+    assert beats[3].beat == 4
+
+
+def test_parse_beatgrid_absent() -> None:
+    assert A.parse_beatgrid(None) == []
+    assert A.parse_beatgrid(_anlz()) == []
+
+
+def test_extract_detail_waveforms() -> None:
+    color = struct.pack(">HHH", 0xE07C, 0x1C40, 0x0380)
+    assert extract_pwv5(_anlz(_detail(b"PWV5", 2, color))) == color
+    blue = bytes([0x1F, 0xE0, 0x05])
+    assert extract_pwv3(_anlz(_detail(b"PWV3", 1, blue))) == blue
+
+
+def test_extract_detail_wrong_width_rejected() -> None:
+    # A PWV5 tag claiming 1 byte/column is malformed and must be rejected.
+    assert extract_pwv5(_anlz(_detail(b"PWV5", 1, b"\x00\x00"))) is None
+
+
+def test_parse_cues_prefers_pco2() -> None:
+    ext = _anlz(
+        _pco2(1, [_pcp2(1, 1406, (0xFF, 0x88, 0x00))]),
+        _pco2(0, [_pcp2(0, 5000, (0, 0, 0))]),
+    )
+    cues = A.parse_cues(None, ext)
+    assert cues[0] == A.Cue(type="hot", index=1, time_ms=1406, color="#ff8800", comment=None)
+    assert cues[1] == A.Cue(type="memory", index=None, time_ms=5000, color=None, comment=None)
+
+
+def test_parse_sections_plain() -> None:
+    ext = _anlz(_pssi(2, 33, [(1, 1, 1), (2, 17, 9)]))
+    sections = A.parse_sections(ext, [A.Beat((i % 4) + 1, 128.0, i * 469) for i in range(40)])
+    assert sections is not None
+    assert sections[0] == A.Section(kind="intro", label="Intro", start_ms=0, end_ms=7504)
+    assert sections[1].label == "Chorus"
+
+
+def test_parse_sections_unmasks_garbled_pssi() -> None:
+    beatgrid = [A.Beat((i % 4) + 1, 128.0, i * 469) for i in range(40)]
+    plain = A.parse_sections(_anlz(_pssi(2, 33, [(1, 1, 1), (2, 17, 9)])), beatgrid)
+    garbled = A.parse_sections(_anlz(_pssi(2, 33, [(1, 1, 1), (2, 17, 9)], garble=True)), beatgrid)
+    assert garbled == plain
+
+
+def test_parse_sections_absent() -> None:
+    assert A.parse_sections(None, [A.Beat(1, 128.0, 0)]) is None
+    assert A.parse_sections(_anlz(), [A.Beat(1, 128.0, 0)]) is None

--- a/tests/test_rekordbox_analysis.py
+++ b/tests/test_rekordbox_analysis.py
@@ -99,6 +99,33 @@ def test_parse_cues_prefers_pco2() -> None:
     assert cues[1] == A.Cue(type="memory", index=None, time_ms=5000, color=None, comment=None)
 
 
+class _CueRow:
+    """Minimal stand-in for a pyrekordbox ``djmdCue`` ORM row."""
+
+    def __init__(self, **kw: object) -> None:
+        self.__dict__.update(kw)
+
+
+def test_cues_from_db_rows_maps_kind_time_and_sorts() -> None:
+    rows = [
+        _CueRow(Kind=0, InMsec=25387, OutMsec=-1, Comment=None),
+        _CueRow(Kind=1, InMsec=124, OutMsec=12756, Comment=""),  # hot loop → slot A
+        _CueRow(Kind=2, InMsec=5000, OutMsec=-1, Comment="drop"),
+        _CueRow(Kind=0, InMsec=-1, OutMsec=-1, Comment=None),  # negative → dropped
+    ]
+    cues = A.cues_from_db_rows(rows)
+    assert [c.time_ms for c in cues] == [124, 5000, 25387]  # sorted, negative gone
+    # Loop hot cue carries its out-point; point cues have out_ms=None.
+    assert cues[0] == A.Cue(type="hot", index=1, time_ms=124, color=None, comment=None, out_ms=12756)
+    assert cues[1] == A.Cue(type="hot", index=2, time_ms=5000, color=None, comment="drop")
+    assert cues[1].out_ms is None
+    assert cues[2].type == "memory" and cues[2].index is None
+
+
+def test_cues_from_db_rows_empty() -> None:
+    assert A.cues_from_db_rows([]) == []
+
+
 def test_parse_sections_plain() -> None:
     ext = _anlz(_pssi(2, 33, [(1, 1, 1), (2, 17, 9)]))
     sections = A.parse_sections(ext, [A.Beat((i % 4) + 1, 128.0, i * 469) for i in range(40)])


### PR DESCRIPTION
## What

Adds rekordbox-style **zoom** to the bottom waveform player, down to 4/8 bars, plus the beatgrid, phrase sections, cues, a bar.beat readout, and key display.

When zoomed, the player expands into a **dual strip**: a scrolling detail waveform (playhead fixed at centre) on top, with the whole-track overview kept below for orientation.

## Why parsing had to change

The existing rekordbox overlays decode the *preview* waveforms — 1200 (colour) / 400 (blue) columns for the **whole track**, useless at 8 bars. This PR reads the ANLZ **detail** waveforms (PWV5 colour / PWV3 blue, ~150 columns/second) plus the beatgrid (PQTZ), phrase sections (PSSI) and cues (PCO2/PCOB) — none of which were parsed before. Local files get a high-resolution mode of the existing ffmpeg peaks pipeline.

## Backend

- `rekordbox/analysis.py` (new): parses beatgrid, phrase sections (incl. Rekordbox's XOR "garbage mask" on exported/USB `PSSI`, replicated from pyrekordbox) and cues into JSON. Reuses pyrekordbox's `construct` structs for the fiddly cue/section records but only feeds them the small tags, so it stays fast.
- `rekordbox/base.py`: `extract_pwv5`/`extract_pwv3` detail-waveform byte extractors + cached analysis/detail methods on the source ABC (implemented in `local.py` + `usb.py`).
- `api/rekordbox.py`: `/waveform` gains `color_detail`/`blue_detail` variants; new `GET /tracks/{id}/analysis`. Missing analysis degrades to empty/`null`, never 404.
- Raised the local peaks cap (2000 → 50000) for the high-res zoom mode.

## Frontend

- `lib/waveform-detail.ts`: pure PWV5/PWV3/float-peaks decoders, bars↔seconds math, bar.beat counter (unit-tested).
- `components/player-detail-waveform.tsx` (new): the zoomed strip — waveform + beatgrid (numbered downbeats) + cue markers, scrolling via `subscribeProgress`.
- `components/waveform-player.tsx`: dual-strip layout, zoom via +/- buttons and scroll-wheel (persisted), bar.beat readout, key display. The **overview** carries the phrase-section band, cue ticks and a zoom-window indicator. Zoom hidden for SoundCloud streams.

**Scope:** zoom works for rekordbox tracks (full grid/sections/cues) and local files (high-res peaks, no downbeat anchor so no grid). SoundCloud stays overview-only. Section colours use existing `--chart-*` tokens.

## Tests

- 8 Python parser tests (synthetic ANLZ fixtures incl. masked PSSI).
- 7 vitest tests for the decoders / window math / bar.beat.
- 3 Playwright specs: rekordbox key + bar.beat + section band, zoom expand/collapse, local-file zoom.

All green: pytest, vitest (71), playwright, tsc, eslint, prettier, ruff, mypy, pydoclint.