### PR TITLE
feat(player): streamline now-playing indicator across all three views

### DIFF
--- a/backend/api/metadata/audio.py
+++ b/backend/api/metadata/audio.py
@@ -206,16 +206,26 @@ def _cached_wav_path(path: Path, cache_dir: Path) -> Path:
 
 
 def _transcode_to_wav(path: Path, wav_path: Path) -> None:
-    """Transcode *path* to a WAV file at *wav_path* using ffmpeg."""
+    """Transcode *path* to a WAV file at *wav_path* using ffmpeg.
+
+    ffmpeg's stderr is captured and logged on failure so a transcode error
+    (the usual cause of a 500 from the audio endpoint) is diagnosable instead
+    of vanishing into ``/dev/null``.
+    """
     tmp_path = wav_path.with_suffix(".tmp")
     try:
         subprocess.run(
             [_find_ffmpeg(), "-i", str(path), "-f", "wav", str(tmp_path), "-y"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             check=True,
         )
         tmp_path.rename(wav_path)
+    except subprocess.CalledProcessError as e:
+        tmp_path.unlink(missing_ok=True)
+        stderr = (e.stderr or b"").decode("utf-8", "replace").strip()
+        logger.error("ffmpeg failed to transcode %s: %s", path.name, stderr[-2000:] or "(no stderr)")
+        raise
     except Exception:
         tmp_path.unlink(missing_ok=True)
         raise

--- a/frontend/e2e/crossfade-soundcloud-audio.spec.ts
+++ b/frontend/e2e/crossfade-soundcloud-audio.spec.ts
@@ -209,3 +209,62 @@ test.describe(
     });
   },
 );
+
+test.describe(
+  "Auto-mix crossfade — table highlight follows the audible track",
+  { tag: "@slow" },
+  () => {
+    test("incoming SoundCloud row is marked current mid-fade, not only at fade end", async ({
+      page,
+    }) => {
+      test.setTimeout(60_000);
+      await setup(page);
+      await page.goto("/library?source=soundcloud");
+
+      await expect(page.locator("[data-index]")).toHaveCount(2, {
+        timeout: 5000,
+      });
+
+      const alphaRow = page.locator('[data-index="0"] [role="row"]').first();
+      const betaRow = page.locator('[data-index="1"] [role="row"]').first();
+
+      await page
+        .locator('[data-index="0"]')
+        .getByRole("button", { name: /Play Alpha/ })
+        .click()
+        .catch(async () => {
+          await page.locator('[data-index="0"]').click();
+        });
+
+      const player = page.getByTestId("waveform-player");
+      await expect(player).toBeVisible();
+      await page.mouse.move(0, 0);
+      await expect(alphaRow).toHaveAttribute("aria-current", "true");
+
+      await player.getByTestId("mix-controls-trigger").click();
+      await page.getByTestId("mix-enabled-toggle").click();
+      await page.keyboard.press("Escape");
+
+      await expect(player).toHaveAttribute("data-mix-state", "transitioning", {
+        timeout: 20000,
+      });
+
+      // The marker flips to the incoming track WHILE the fade is still running
+      // (state stays "transitioning" until the fade completes and the queue
+      // advances). Before the fix it only flipped at fade end. Poll for the
+      // simultaneous state so the assertion can't straddle the completion seam.
+      await expect
+        .poll(
+          async () => {
+            const [state, betaCurrent] = await Promise.all([
+              player.getAttribute("data-mix-state"),
+              betaRow.getAttribute("aria-current"),
+            ]);
+            return state === "transitioning" && betaCurrent === "true";
+          },
+          { timeout: 20000 },
+        )
+        .toBe(true);
+    });
+  },
+);

--- a/frontend/e2e/library-playing-indicator.spec.ts
+++ b/frontend/e2e/library-playing-indicator.spec.ts
@@ -1,0 +1,144 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
+
+/**
+ * The filesystem library marks the *playing* track — green highlight
+ * (aria-current) + a persistent Pause on its cover — the same way the
+ * SoundCloud and Rekordbox tables do. Crucially this follows the track in the
+ * player, not the row whose single-track editor is open. Regression: the
+ * filesystem cover's play/pause state (and the green row) tracked the *edited*
+ * row, so a track played from its cover had no constant indicator.
+ */
+
+/** Silent mono 8-bit WAV of `seconds` at 8kHz. Long enough that playback does
+ * not finish (and auto-advance) during the assertions. */
+function makeSilentWav(seconds: number): Buffer {
+  const rate = 8000;
+  const numSamples = rate * seconds;
+  const buf = Buffer.alloc(44 + numSamples);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + numSamples, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(rate, 24);
+  buf.writeUInt32LE(rate, 28);
+  buf.writeUInt16LE(1, 32);
+  buf.writeUInt16LE(8, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(numSamples, 40);
+  buf.fill(0x80, 44);
+  return buf;
+}
+
+function file(name: string) {
+  return {
+    file_path: name,
+    file_name: name,
+    file_size: 5 * 1024 * 1024,
+    file_format: ".mp3",
+    has_artwork: false,
+  };
+}
+
+async function setup(page: Page) {
+  const listing = {
+    items: [file("a.mp3"), file("b.mp3")],
+    total: 2,
+    page: 1,
+    size: 50,
+    pages: 1,
+  };
+  await page.route("**/api/metadata/folders/*/browse*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(listing),
+    }),
+  );
+  await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(listing),
+    }),
+  );
+  await page.route("**/api/metadata/files/*/info", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        file_path: "a.mp3",
+        file_name: "a.mp3",
+        title: null,
+        artist: null,
+        bpm: null,
+        key: null,
+        genre: null,
+        comment: null,
+        release_date: null,
+        remixers: [],
+        has_artwork: false,
+        is_ready: false,
+        missing_fields: [],
+        issues: [],
+      }),
+    }),
+  );
+  await page.route("**/api/metadata/files/*/peaks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ peaks: Array(200).fill(0.3) }),
+    }),
+  );
+  await page.route("**/api/metadata/files/*/audio", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "audio/wav",
+      body: makeSilentWav(30),
+    }),
+  );
+}
+
+const rowFor = (page: Page, name: string) =>
+  page.locator(`[role="row"]:has([data-file-path="${name}"])`).first();
+
+const coverOverlay = (page: Page, name: string) =>
+  page
+    .getByRole("button", { name: new RegExp(name.replace(".", "\\.")) })
+    .locator("span")
+    .first();
+
+test("filesystem marks the playing track green + Pause, not the edited row", async ({
+  page,
+}) => {
+  await setup(page);
+  await page.goto("/library");
+  await page.waitForLoadState("networkidle");
+
+  const rowA = rowFor(page, "a.mp3");
+  const rowB = rowFor(page, "b.mp3");
+
+  // Open A's single-track editor by clicking its row (also loads A, paused).
+  await rowA.locator('[data-file-path="a.mp3"]').click();
+  await expect(page.getByTestId("waveform-player")).toBeVisible();
+
+  // Now play B from its cover. B becomes the playing track while the editor
+  // stays open on A.
+  await page.getByRole("button", { name: "Play b.mp3" }).click();
+  await page.mouse.move(0, 0);
+
+  // B is the playing row: marked, with a persistent Pause overlay (no hover).
+  await expect(rowB).toHaveAttribute("aria-current", "true");
+  await expect(page.getByRole("button", { name: "Pause b.mp3" })).toBeVisible();
+  await expect(coverOverlay(page, "b.mp3")).toHaveCSS("opacity", "1");
+
+  // A — still the edited row — is NOT marked as playing and its cover is idle.
+  await expect(rowA).not.toHaveAttribute("aria-current", "true");
+  await expect(page.getByRole("button", { name: "Play a.mp3" })).toBeVisible();
+  await expect(coverOverlay(page, "a.mp3")).toHaveCSS("opacity", "0");
+});

--- a/frontend/e2e/soundcloud-playing-indicator.spec.ts
+++ b/frontend/e2e/soundcloud-playing-indicator.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * The currently-playing SoundCloud row shows its hover affordance persistently
+ * — the row highlight (aria-current) and the cover's Pause overlay stay on
+ * without a hovering cursor, so the playing track stays identifiable as the
+ * queue auto-advances. Regression: the SC table only revealed the cover
+ * overlay on hover and never marked the current row, so autoplayed tracks (the
+ * cursor no longer over them) looked like nothing was playing.
+ */
+
+/** Silent mono 8-bit WAV of `seconds` at 8kHz — playback just needs to start
+ * and stay playing; the content is irrelevant. */
+function makeSilentWav(seconds: number): Buffer {
+  const rate = 8000;
+  const numSamples = rate * seconds;
+  const buf = Buffer.alloc(44 + numSamples);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + numSamples, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(rate, 24);
+  buf.writeUInt32LE(rate, 28);
+  buf.writeUInt16LE(1, 32);
+  buf.writeUInt16LE(8, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(numSamples, 40);
+  buf.fill(0x80, 44);
+  return buf;
+}
+
+function scTrack(id: number, title: string) {
+  return {
+    id,
+    urn: `soundcloud:tracks:${id}`,
+    title,
+    user: { id: 1, username: "me" },
+    duration: 180_000,
+    permalink_url: `https://soundcloud.com/me/${title.toLowerCase()}`,
+    artwork_url: null,
+  };
+}
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [scTrack(101, "Alpha"), scTrack(102, "Beta")],
+        next_href: null,
+      }),
+    }),
+  );
+  for (const url of [
+    "https://api.soundcloud.com/me/reposts/tracks*",
+    "https://api.soundcloud.com/me/playlists*",
+  ]) {
+    await page.route(url, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+  }
+  await page.route("**/api/soundcloud/system-playlists", (route) =>
+    route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "unavailable" }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+
+  // Resolve every SC stream to a short silent wav so playback starts and the
+  // queue can advance offline.
+  await page.route("**/api/soundcloud/tracks/*/stream*", (route) => {
+    const id =
+      route
+        .request()
+        .url()
+        .match(/tracks\/(\d+)\/stream/)?.[1] ?? "0";
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        url: `https://cdn.example.com/sc-${id}.wav`,
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    });
+  });
+  await page.route("https://cdn.example.com/sc-*.wav", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "audio/wav",
+      body: makeSilentWav(5),
+    }),
+  );
+}
+
+/** The cover overlay (dark scrim + play/pause icon) for the row at `index`. */
+function coverOverlay(page: import("@playwright/test").Page, index: number) {
+  return page
+    .locator(`[data-index="${index}"]`)
+    .getByRole("button", { name: /Alpha|Beta/ })
+    .locator("span")
+    .first();
+}
+
+function row(page: import("@playwright/test").Page, index: number) {
+  return page.locator(`[data-index="${index}"] [role="row"]`).first();
+}
+
+test("current SoundCloud row keeps its hover affordance without a cursor over it", async ({
+  page,
+}) => {
+  await setup(page);
+  await page.goto("/library?source=soundcloud");
+
+  await expect(page.locator("[data-index]")).toHaveCount(2, { timeout: 5000 });
+
+  // Start the first track from its cover play button.
+  await page
+    .locator('[data-index="0"]')
+    .getByRole("button", { name: /Play Alpha/ })
+    .click();
+
+  await expect(page.getByTestId("waveform-player")).toBeVisible();
+  // Move the cursor off the list so any assertion below reflects the current-
+  // track state, not a hover.
+  await page.mouse.move(0, 0);
+
+  // Row 0 is the current track: marked, and its cover shows a persistent Pause.
+  await expect(row(page, 0)).toHaveAttribute("aria-current", "true");
+  await expect(
+    page
+      .locator('[data-index="0"]')
+      .getByRole("button", { name: /Pause Alpha/ }),
+  ).toBeVisible();
+  await expect(coverOverlay(page, 0)).toHaveCSS("opacity", "1");
+
+  // Row 1 is not current and not hovered: overlay hidden, row unmarked.
+  await expect(row(page, 1)).not.toHaveAttribute("aria-current", "true");
+  await expect(coverOverlay(page, 1)).toHaveCSS("opacity", "0");
+
+  // Auto-advance (same primitive end-of-track autoplay uses) moves the marker.
+  await page.getByRole("button", { name: "Next track" }).click();
+  await page.mouse.move(0, 0);
+
+  await expect(row(page, 1)).toHaveAttribute("aria-current", "true");
+  await expect(
+    page
+      .locator('[data-index="1"]')
+      .getByRole("button", { name: /Pause Beta/ }),
+  ).toBeVisible();
+  await expect(coverOverlay(page, 1)).toHaveCSS("opacity", "1");
+
+  await expect(row(page, 0)).not.toHaveAttribute("aria-current", "true");
+  await expect(coverOverlay(page, 0)).toHaveCSS("opacity", "0");
+});

--- a/frontend/src/app/library/rekordbox-view.tsx
+++ b/frontend/src/app/library/rekordbox-view.tsx
@@ -646,7 +646,7 @@ export function RekordboxView() {
                 const t = item;
                 const playable = !!t.file_path;
                 const isCurrent =
-                  player.currentTrack?.filePath === t.file_path && playable;
+                  player.activeTrack?.filePath === t.file_path && playable;
                 const isSelected = selectedIds.has(t.id);
                 return (
                   // Clicking anywhere on the row starts playback; the cover's

--- a/frontend/src/components/collection-table.tsx
+++ b/frontend/src/components/collection-table.tsx
@@ -370,7 +370,13 @@ function EditableCell({
 interface EditRowProps {
   item: TrackBrowse;
   isSelected: boolean;
+  /** The row whose single-track editor is open — drives the inline
+   * click-to-edit affordance, not playback. */
   isCurrent: boolean;
+  /** This row's file is the one playing in the shared player. Drives the green
+   * "now playing" highlight + the cover's persistent Pause, consistent with
+   * the SoundCloud and Rekordbox tables. */
+  isPlaying: boolean;
   changes: Partial<Record<EditableField, string>>;
   hasChanges: boolean;
   onToggleSelect: (shiftKey: boolean) => void;
@@ -391,6 +397,7 @@ function EditRow({
   item,
   isSelected,
   isCurrent,
+  isPlaying,
   changes,
   onToggleSelect,
   onFieldChange,
@@ -421,12 +428,15 @@ function EditRow({
   return (
     <div
       role="row"
-      aria-current={isCurrent ? "true" : undefined}
+      aria-current={isPlaying ? "true" : undefined}
       className={cn(
         "group/row border-border relative flex h-10 cursor-pointer items-center gap-1.5 border-b pr-0 pl-3 transition-colors",
-        isCurrent && "bg-[var(--brand-soft)]",
-        isSelected && !isCurrent && "bg-[var(--surface-3)]",
-        !isCurrent && !isSelected && "hover:bg-[var(--surface-3)]",
+        isPlaying && "bg-[var(--brand-soft)]",
+        !isPlaying && (isCurrent || isSelected) && "bg-[var(--surface-3)]",
+        !isPlaying &&
+          !isCurrent &&
+          !isSelected &&
+          "hover:bg-[var(--surface-3)]",
         justSaved && "saved-pulse",
       )}
       onClick={(e) => {
@@ -443,7 +453,7 @@ function EditRow({
         onSelect();
       }}
     >
-      {isCurrent && (
+      {isPlaying && (
         <span
           aria-hidden
           className="bg-primary absolute inset-y-0 left-0 w-0.5"
@@ -467,7 +477,7 @@ function EditRow({
       {/* Artwork thumbnail with hover play/pause overlay */}
       <CoverPlayButton
         artworkUrl={artworkUrl}
-        isCurrent={isCurrent}
+        isCurrent={isPlaying}
         onStartPlay={onStartPlay}
         label={item.title ?? item.file_name}
         className={`ring-1 ${pendingArtworkB64 ? "ring-primary/40" : "ring-transparent"}`}
@@ -706,7 +716,7 @@ export function CollectionTable({
   const abortRef = useRef<AbortController | null>(null);
   const itemsRef = useRef<TrackBrowse[]>([]);
 
-  const { playQueue, load } = usePlayer();
+  const { playQueue, load, activeTrack } = usePlayer();
 
   const tableRef = useRef<TrackTableHandle>(null);
 
@@ -1673,6 +1683,9 @@ export function CollectionTable({
               item={item}
               isSelected={selectedPaths.has(item.file_path)}
               isCurrent={selectedFilePath === item.file_path}
+              isPlaying={
+                !!activeTrack && activeTrack.filePath === item.file_path
+              }
               changes={changes.get(item.file_path) ?? {}}
               hasChanges={
                 changes.has(item.file_path) ||

--- a/frontend/src/components/cover-play-button.tsx
+++ b/frontend/src/components/cover-play-button.tsx
@@ -99,7 +99,9 @@ export function CoverPlayButton({
         className={cn(
           "absolute inset-0 flex items-center justify-center bg-black/45 text-white opacity-0 transition-opacity",
           "group-hover/cover:opacity-100 group-focus-visible/cover:opacity-100",
-          loading && "opacity-100",
+          // The loaded track keeps its play/pause state visible without hover,
+          // so the playing row is identifiable as autoplay advances the queue.
+          (loading || isCurrent) && "opacity-100",
         )}
       >
         {loading ? (

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -488,8 +488,8 @@ function TrackRowInner({
 }: TrackRowProps) {
   const imgUrl = artworkUrl(track);
   const scTrackId = extractId(track);
-  const { currentTrack } = usePlayer();
-  const isCurrent = currentTrack?.filePath === `soundcloud:${scTrackId}`;
+  const { activeTrack } = usePlayer();
+  const isCurrent = activeTrack?.filePath === `soundcloud:${scTrackId}`;
   const unplayable = useIsScUnplayable(scTrackId || null);
 
   // Hover prefetch: warm the stream URL + peaks cache after a short dwell.
@@ -521,7 +521,8 @@ function TrackRowInner({
       <div
         role="row"
         tabIndex={0}
-        className={`group border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isSelected ? "bg-[var(--brand-soft)]" : isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
+        aria-current={isCurrent ? "true" : undefined}
+        className={`group border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isCurrent ? "bg-[var(--brand-soft)]" : isSelected || isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
         onClick={onExpand}
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -256,6 +256,7 @@ export function WaveformPlayer() {
     targetBpm,
     pitchEnabled,
     mixConfig,
+    reportCrossfadeMidpoint,
   } = usePlayer();
   const containerRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -1173,6 +1174,9 @@ export function WaveformPlayer() {
         setMixState("idle");
       } else {
         // No transition, or a manual skip mid-fade: abort and discard deck B.
+        // Drop any past-midpoint marker so `activeTrack` snaps back to the
+        // (possibly user-chosen) current entry rather than leading it.
+        if (transitionStartedRef.current) reportCrossfadeMidpoint(false);
         if (transitionStartedRef.current) transitionHandleRef.current?.cancel();
         transitionStartedRef.current = false;
         if (mixDeckBRef.current) {
@@ -1267,9 +1271,20 @@ export function WaveformPlayer() {
       Math.max(0, deckA.currentTime - plan.deckAMixOutSec) / mediaRate;
 
     const launch = (elapsed: number) => {
-      const onMidpoint = () => setMixPastMid(true);
+      const onMidpoint = () => {
+        setMixPastMid(true);
+        // The incoming deck is now the audible track — flip the "now playing"
+        // marker the track lists read, so the highlight follows the sound
+        // instead of waiting for the fade to finish.
+        reportCrossfadeMidpoint(true);
+      };
       const onComplete = () => {
         transitionCompletedRef.current = true;
+        // Clear the marker in the same React batch as `next()` (which advances
+        // queueIndex onto the incoming track): once queueIndex catches up,
+        // `currentTrack` is the audible track again and the override must be
+        // off, or `activeTrack` would jump one entry too far.
+        reportCrossfadeMidpoint(false);
         nextRef.current();
       };
       // Loop-eq runs its own two-phase automation (loop + 3-band EQ + long
@@ -1311,7 +1326,7 @@ export function WaveformPlayer() {
       old: deckA.currentTime / (deckA.duration || 1),
       new: deckB.duration > 0 ? deckB.currentTime / deckB.duration : 0,
     });
-  }, [peekNext]);
+  }, [peekNext, reportCrossfadeMidpoint]);
 
   useEffect(() => {
     startTransitionRef.current = startTransition;

--- a/frontend/src/lib/player-context.tsx
+++ b/frontend/src/lib/player-context.tsx
@@ -62,6 +62,13 @@ export interface PlayerTrack {
 
 interface PlayerContextValue {
   currentTrack: PlayerTrack | null;
+  /** The track that is actually audible right now. Equals `currentTrack`
+   * except during the second half of an auto-mix crossfade, when the next
+   * queue entry is already playing at (or past) equal gain while
+   * `currentTrack` — which keys the player's own decode/init — stays put until
+   * the fade completes. Track lists mark their "now playing" row from this so
+   * the highlight follows the sound instead of lagging a whole fade behind. */
+  activeTrack: PlayerTrack | null;
   /** Position of `currentTrack` in the queue (-1 when nothing is loaded).
    * Queues can hold the same file twice in a row, so per-entry identity is
    * `${queueIndex}:${filePath}` — filePath alone is not unique. */
@@ -116,6 +123,10 @@ interface PlayerContextValue {
   /** Auto-mix (crossfade) configuration. Persisted to the UI store. */
   mixConfig: MixConfig;
   setMixConfig: (config: MixConfig) => void;
+  /** WaveformPlayer reports whether a running crossfade has passed its
+   * midpoint — the point where the incoming (next) queue entry becomes the
+   * audible track. Drives `activeTrack`. */
+  reportCrossfadeMidpoint: (reached: boolean) => void;
 }
 
 const PITCH_TARGET_KEY = "starlib.pitcher.targetBpm";
@@ -139,6 +150,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   const [pitchEnabled, setPitchEnabledState] = useState<boolean>(false);
   const [mixConfig, setMixConfigState] =
     useState<MixConfig>(DEFAULT_MIX_CONFIG);
+  // True while a crossfade is past its midpoint: the next queue entry is the
+  // audible track, but `queueIndex` hasn't advanced yet (that happens when the
+  // fade completes and the rebuilt player adopts the incoming deck).
+  const [crossfadePastMid, setCrossfadePastMid] = useState(false);
 
   // Hydrate the auto-mix config from the UI store on mount.
   useEffect(() => {
@@ -196,6 +211,16 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   const pendingSeekRef = useRef<number | null>(null);
 
   const currentTrack = queueIndex >= 0 ? (queue[queueIndex] ?? null) : null;
+  // See `activeTrack` on PlayerContextValue: the audible track, which leads
+  // `currentTrack` by one entry during a crossfade's second half.
+  const activeTrack =
+    crossfadePastMid && queueIndex >= 0 && queueIndex + 1 < queue.length
+      ? (queue[queueIndex + 1] ?? currentTrack)
+      : currentTrack;
+
+  const reportCrossfadeMidpoint = useCallback((reached: boolean) => {
+    setCrossfadePastMid(reached);
+  }, []);
 
   // Re-seed `currentBpm` whenever the loaded track changes. If the caller
   // supplied a `bpm` hint on the PlayerTrack, use it; otherwise reset to
@@ -403,6 +428,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo<PlayerContextValue>(
     () => ({
       currentTrack,
+      activeTrack,
       queueIndex,
       isPlaying,
       load,
@@ -430,9 +456,11 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
       setPitchEnabled,
       mixConfig,
       setMixConfig,
+      reportCrossfadeMidpoint,
     }),
     [
       currentTrack,
+      activeTrack,
       queueIndex,
       isPlaying,
       load,
@@ -460,6 +488,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
       setPitchEnabled,
       mixConfig,
       setMixConfig,
+      reportCrossfadeMidpoint,
     ],
   );
 


### PR DESCRIPTION
## What

The Filesystem, SoundCloud and Rekordbox tables each marked the "current" row differently, so the playing track's indicator was inconsistent between views:

- **Filesystem** — no persistent cover Pause, and the cover's play/pause state tracked the *edited* row, not the playing one.
- **SoundCloud** — never highlighted the playing row at all.
- **Rekordbox** — the only view with the green highlight.

Now all three mark the **playing track** identically: **green highlight + `aria-current`** on the row and a **persistent Pause** on its cover (no hover needed), so the playing track stays identifiable as the queue auto-advances.

## Changes

- **`player-context`** — add `activeTrack`: the audible track. Equals `currentTrack` except during the second half of an auto-mix crossfade, where it leads by one queue entry so the highlight follows the sound instead of lagging a whole fade behind. `WaveformPlayer` reports the crossfade midpoint to drive it.
- **`cover-play-button`** — keep the play/pause overlay visible for the loaded track without hover.
- **`likes-table` (SoundCloud)** — highlight the playing row green; selection/expanded now use `surface-3` (consistent with the other two views).
- **`rekordbox-view`** — read `activeTrack`.
- **`collection-table` (filesystem)** — split editor-active (`isCurrent`, drives inline click-to-edit) from playing (`isPlaying`, drives green + accent bar + cover Pause), so a track played from its cover is marked even when a different row's editor is open.
- **`backend/api/metadata/audio.py`** — capture ffmpeg stderr on transcode failure so a 500 from the local audio endpoint is diagnosable in logs instead of vanishing into `/dev/null`. (Unblocks diagnosing a reported filesystem playback 500 — likely a file-specific AIFF transcode failure.)

## Tests

- `frontend/e2e/library-playing-indicator.spec.ts` — filesystem: playing B from its cover while A's editor is open → B is green + Pause, A is not.
- `frontend/e2e/soundcloud-playing-indicator.spec.ts` — SC playing row keeps its green highlight + persistent Pause with no cursor over it; marker follows a Next-track advance.
- `frontend/e2e/crossfade-soundcloud-audio.spec.ts` — asserts the incoming row is marked mid-fade, not only at fade end.

All affected e2e suites (filesystem / SoundCloud / Rekordbox / crossfade / player), plus typecheck, lint, prettier, ruff, mypy and pydoclint pass.