### PR TITLE
fix(player): drop filtered-out tracks from SoundCloud autoplay queue

### DIFF
--- a/frontend/e2e/soundcloud-filter-autoplay.spec.ts
+++ b/frontend/e2e/soundcloud-filter-autoplay.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Bugfix: when a filter is applied while autoplay is running in the SoundCloud
+ * view, tracks that the filter excludes must drop out of the autoplay queue.
+ * The queue is snapshotted when playback starts, so without reconciliation the
+ * player would keep advancing into now-hidden tracks.
+ */
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: 42,
+            urn: "soundcloud:tracks:42",
+            title: "Keep Alpha",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/alpha",
+          },
+          {
+            id: 99,
+            urn: "soundcloud:tracks:99",
+            title: "Drop Bravo",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/bravo",
+          },
+          {
+            id: 7,
+            urn: "soundcloud:tracks:7",
+            title: "Keep Charlie",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/charlie",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/tracks*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+  await page.route("**/api/soundcloud/tracks/*/stream*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        url: "https://example.com/fake.m3u8",
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    }),
+  );
+}
+
+test.describe("soundcloud filter + autoplay", () => {
+  test("filtering out a queued track drops it from autoplay", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+
+    await expect(page.locator("[data-index]")).toHaveCount(3, {
+      timeout: 5000,
+    });
+
+    // Start playing Alpha — queues [Alpha, Bravo, Charlie].
+    await page
+      .locator('[data-index="0"]')
+      .getByRole("button", { name: /play/i })
+      .first()
+      .click()
+      .catch(async () => {
+        await page.locator('[data-index="0"]').click();
+      });
+
+    const player = page.getByTestId("waveform-player");
+    await expect(player).toBeVisible();
+    await expect(player).toContainText("Keep Alpha");
+
+    // Apply a filter that hides Bravo but keeps Alpha (still playing) and
+    // Charlie. This mutates the URL client-side — no reload — so the player
+    // and its queue survive.
+    await page.getByRole("button", { name: /^filters$/i }).click();
+    await page.getByPlaceholder("…").fill("keep");
+
+    // Bravo drops out of the visible table (Alpha + Charlie remain).
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    // Autoplay's "next" must now skip the filtered-out Bravo and land on
+    // Charlie. Pre-fix it would have advanced to Bravo.
+    await player.getByRole("button", { name: "Next track" }).click();
+    await expect(player).toContainText("Keep Charlie");
+    await expect(player).not.toContainText("Drop Bravo");
+  });
+});

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -327,6 +327,27 @@ function artworkUrl(track: SCTrack): string | null {
   return api.proxyImageUrl(url);
 }
 
+// Build a PlayerTrack skeleton from an SC track. Every entry is a skeleton —
+// the player resolves streamUrl on demand via the shared TTL cache. Shared by
+// the play-to-start path and the mid-playback queue reconcile.
+function scTrackToPlayerTrack(
+  track: SCTrack,
+  bpmCache: Map<number, number>,
+): PlayerTrack {
+  const id = extractId(track);
+  return {
+    filePath: `soundcloud:${id}`,
+    fileName: track.title ?? String(id),
+    title: track.title ?? undefined,
+    artist: track.user?.username ?? undefined,
+    waveformUrl: track.waveform_url ?? undefined,
+    streamRefreshKey: id,
+    permalinkUrl: track.permalink_url ?? undefined,
+    artworkUrl: artworkUrl(track) ?? undefined,
+    bpm: bpmCache.get(id) ?? track.bpm ?? null,
+  };
+}
+
 function searchQuery(track: SCTrack): string {
   const artist = track.user?.username ?? "";
   const title = track.title ?? "";
@@ -770,7 +791,16 @@ export function LikesTable({
   onVisibleOrderChange,
 }: LikesTableProps) {
   const reorderEnabled = !!onReorderTracks;
-  const { playQueue } = usePlayer();
+  const { playQueue, currentTrack, replaceUpcoming } = usePlayer();
+  // Mirror the current track into a ref so the reconcile effect can read it
+  // without making it a dependency — otherwise reconciling (which changes
+  // `currentTrack`'s reference) would re-trigger the effect and loop. This
+  // effect is declared before the reconcile effect, so the ref is fresh by the
+  // time reconcile runs on the same render.
+  const currentTrackRef = useRef(currentTrack);
+  useEffect(() => {
+    currentTrackRef.current = currentTrack;
+  }, [currentTrack]);
 
   // Pre-fill cached BPMs for all tracks in this table in a single bulk
   // request, rather than making one GET per visible row. The map survives
@@ -883,30 +913,37 @@ export function LikesTable({
   const reorderable = reorderEnabled && !sortBy;
 
   // Build a PlayerTrack queue from the currently visible (sorted) SC tracks
-  // and start playback at `index`. Every entry is a skeleton — the player
-  // resolves streamUrl on demand via the shared TTL cache, so the clicked
-  // row's URL is fetched in parallel with peaks + waveform init rather
-  // than serialised before the UI updates.
+  // and start playback at `index`. The clicked row's URL is fetched in
+  // parallel with peaks + waveform init rather than serialised before the UI
+  // updates.
   const handleStartPlay = useCallback(
     (index: number) => {
-      const queue: PlayerTrack[] = sortedTracks.map((t) => {
-        const id = extractId(t);
-        return {
-          filePath: `soundcloud:${id}`,
-          fileName: t.title ?? String(id),
-          title: t.title ?? undefined,
-          artist: t.user?.username ?? undefined,
-          waveformUrl: t.waveform_url ?? undefined,
-          streamRefreshKey: id,
-          permalinkUrl: t.permalink_url ?? undefined,
-          artworkUrl: artworkUrl(t) ?? undefined,
-          bpm: bpmCache.get(id) ?? t.bpm ?? null,
-        };
-      });
-      playQueue(queue, index);
+      playQueue(
+        sortedTracks.map((t) => scTrackToPlayerTrack(t, bpmCache)),
+        index,
+      );
     },
     [sortedTracks, playQueue, bpmCache],
   );
+
+  // Keep autoplay in step with the filtered/sorted view. The queue is a
+  // snapshot taken when playback starts, so a filter applied mid-playback
+  // would otherwise keep autoplaying tracks the user just filtered out. When
+  // the currently playing track is still visible here (so this table owns the
+  // queue), re-derive the upcoming tail from the current visible order after
+  // it — leaving the current entry and its index untouched so playback never
+  // restarts.
+  useEffect(() => {
+    const current = currentTrackRef.current;
+    if (!current) return;
+    const pos = sortedTracks.findIndex(
+      (t) => `soundcloud:${extractId(t)}` === current.filePath,
+    );
+    if (pos < 0) return;
+    replaceUpcoming(
+      sortedTracks.slice(pos + 1).map((t) => scTrackToPlayerTrack(t, bpmCache)),
+    );
+  }, [sortedTracks, bpmCache, replaceUpcoming]);
 
   // Report the current visible order (after sort) to callers so they can save
   // whatever the user currently sees.

--- a/frontend/src/lib/player-context.tsx
+++ b/frontend/src/lib/player-context.tsx
@@ -86,6 +86,12 @@ interface PlayerContextValue {
     index: number,
     startRatio?: number,
   ) => void;
+  /** Replace the not-yet-played tail of the queue (every entry after the
+   * current index) without disturbing the current track or its index. Lets a
+   * caller re-derive "what plays next" mid-playback — e.g. after the user
+   * filters the visible list — so autoplay stops walking into tracks that are
+   * no longer shown. No-op when nothing is loaded. */
+  replaceUpcoming: (upcoming: PlayerTrack[]) => void;
   pause: () => void;
   toggle: (track?: PlayerTrack) => void;
   stop: () => void;
@@ -298,6 +304,25 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     [setQueueState],
   );
 
+  // Swap the tail after the current entry, keeping the current track and its
+  // index untouched so the player never re-decodes (its init effect keys on
+  // `${queueIndex}:${filePath}`). The preserved head is sliced from the live
+  // queue, so `currentTrack`'s object identity is unchanged too.
+  const replaceUpcoming = useCallback(
+    (upcoming: PlayerTrack[]) => {
+      const idx = queueIndexRef.current;
+      if (idx < 0) return;
+      const currentTail = queueRef.current.slice(idx + 1);
+      const unchanged =
+        currentTail.length === upcoming.length &&
+        currentTail.every((t, i) => t.filePath === upcoming[i]?.filePath);
+      if (unchanged) return;
+      const head = queueRef.current.slice(0, idx + 1);
+      setQueueState([...head, ...upcoming], idx);
+    },
+    [setQueueState],
+  );
+
   const load = useCallback(
     (track: PlayerTrack) => {
       setQueueState([track], 0);
@@ -434,6 +459,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
       load,
       play,
       playQueue,
+      replaceUpcoming,
       pause,
       toggle,
       stop,
@@ -466,6 +492,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
       load,
       play,
       playQueue,
+      replaceUpcoming,
       pause,
       toggle,
       stop,


### PR DESCRIPTION
Autoplay in the SoundCloud view snapshotted the queue at play time, so a filter applied mid-playback kept autoplaying tracks the user had just filtered out. The player now reconciles the not-yet-played tail from the visible list whenever it changes and the current track is still shown — leaving the current entry and its index untouched so playback never restarts.

Test plan: `e2e/soundcloud-filter-autoplay.spec.ts` starts autoplay, filters out a queued track, and asserts "next" skips it (fails before the fix, passes after).