### PR TITLE
feat(player): queue preview panel with add-to-queue

### DIFF
--- a/frontend/e2e/queue-panel.spec.ts
+++ b/frontend/e2e/queue-panel.spec.ts
@@ -1,0 +1,276 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Queue Preview panel: a right-side sheet opened from the player bar that lists
+ * the now-playing track and the upcoming queue. Upcoming rows support
+ * click-to-jump, remove, and drag/keyboard reorder. Driven through the
+ * SoundCloud view, whose autoplay snapshots the visible list into the queue.
+ */
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: 42,
+            urn: "soundcloud:tracks:42",
+            title: "Track Alpha",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/alpha",
+          },
+          {
+            id: 99,
+            urn: "soundcloud:tracks:99",
+            title: "Track Bravo",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/bravo",
+          },
+          {
+            id: 7,
+            urn: "soundcloud:tracks:7",
+            title: "Track Charlie",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/charlie",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/tracks*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+  await page.route("**/api/soundcloud/tracks/*/stream*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        url: "https://example.com/fake.m3u8",
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    }),
+  );
+}
+
+/** Start Alpha, queueing [Alpha, Bravo, Charlie]. Leaves the panel closed. */
+async function startPlaying(page: import("@playwright/test").Page) {
+  await page.goto("/library?source=soundcloud");
+  await expect(page.locator("[data-index]")).toHaveCount(3, { timeout: 5000 });
+
+  await page
+    .locator('[data-index="0"]')
+    .getByRole("button", { name: /play/i })
+    .first()
+    .click()
+    .catch(async () => {
+      await page.locator('[data-index="0"]').click();
+    });
+
+  const player = page.getByTestId("waveform-player");
+  await expect(player).toBeVisible();
+  await expect(player).toContainText("Track Alpha");
+  return player;
+}
+
+/** Start Alpha, queueing [Alpha, Bravo, Charlie], and open the queue panel. */
+async function startAndOpenQueue(page: import("@playwright/test").Page) {
+  const player = await startPlaying(page);
+  await page.getByTestId("queue-trigger").click();
+  const panel = page.getByTestId("queue-panel");
+  await expect(panel).toBeVisible();
+  return { player, panel };
+}
+
+test.describe("queue panel", () => {
+  test("lists now-playing and upcoming tracks", async ({ page }) => {
+    await setup(page);
+    const { panel } = await startAndOpenQueue(page);
+
+    await expect(panel.getByTestId("queue-now-playing")).toContainText(
+      "Track Alpha",
+    );
+    const items = panel.getByTestId("queue-item");
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toContainText("Track Bravo");
+    await expect(items.nth(1)).toContainText("Track Charlie");
+  });
+
+  test("clicking an upcoming track jumps playback to it", async ({ page }) => {
+    await setup(page);
+    const { player, panel } = await startAndOpenQueue(page);
+
+    await panel.getByRole("button", { name: /play track charlie/i }).click();
+
+    await expect(player).toContainText("Track Charlie");
+    await expect(panel.getByTestId("queue-now-playing")).toContainText(
+      "Track Charlie",
+    );
+    // Charlie is last — nothing left to queue.
+    await expect(panel.getByTestId("queue-item")).toHaveCount(0);
+  });
+
+  test("removing an upcoming track drops it from the queue", async ({
+    page,
+  }) => {
+    await setup(page);
+    const { player, panel } = await startAndOpenQueue(page);
+
+    await panel
+      .getByTestId("queue-item")
+      .filter({ hasText: "Track Bravo" })
+      .getByTestId("queue-item-remove")
+      .click();
+
+    const items = panel.getByTestId("queue-item");
+    await expect(items).toHaveCount(1);
+    await expect(items.nth(0)).toContainText("Track Charlie");
+
+    // The removed track is gone from autoplay too: after closing the panel,
+    // Next lands on Charlie rather than the removed Bravo.
+    await page.keyboard.press("Escape");
+    await expect(panel).toBeHidden();
+    await player.getByRole("button", { name: "Next track" }).click();
+    await expect(player).toContainText("Track Charlie");
+  });
+
+  test("drag-reordering an upcoming track changes the order", async ({
+    page,
+  }) => {
+    await setup(page);
+    const { panel } = await startAndOpenQueue(page);
+
+    // Drag Bravo's handle down past Charlie. Position the press with hover()
+    // (reliable hit-testing on the handle), then drive the drag with real
+    // pointermove events — dnd-kit needs them past its 6px activation distance,
+    // plus a settle move at the destination so onDragOver fires before release.
+    const handle = panel
+      .getByTestId("queue-item")
+      .filter({ hasText: "Track Bravo" })
+      .getByRole("button", { name: "Reorder track" });
+    const charlie = panel
+      .getByTestId("queue-item")
+      .filter({ hasText: "Track Charlie" });
+
+    await handle.hover();
+    await page.mouse.down();
+    const to = await charlie.boundingBox();
+    if (!to) throw new Error("missing Charlie bounding box");
+    const targetX = to.x + to.width / 2;
+    const targetY = to.y + to.height * 0.9;
+    await page.mouse.move(targetX, targetY, { steps: 20 });
+    await page.mouse.move(targetX, targetY, { steps: 5 });
+    await page.mouse.up();
+
+    const items = panel.getByTestId("queue-item");
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toContainText("Track Charlie");
+    await expect(items.nth(1)).toContainText("Track Bravo");
+  });
+
+  test("right-click 'Add to queue' appends the track to the end", async ({
+    page,
+  }) => {
+    await setup(page);
+    await startPlaying(page); // queue [Alpha, Bravo, Charlie]
+
+    // Append Charlie again via its row context menu.
+    await page.locator('[data-index="2"]').click({ button: "right" });
+    await page.getByTestId("queue-add").click();
+
+    await page.getByTestId("queue-trigger").click();
+    const items = page.getByTestId("queue-panel").getByTestId("queue-item");
+    await expect(items).toHaveCount(3); // Bravo, Charlie, + appended Charlie
+    await expect(items.nth(2)).toContainText("Track Charlie");
+  });
+
+  test("right-click 'Play next' inserts after the current track", async ({
+    page,
+  }) => {
+    await setup(page);
+    await startPlaying(page); // queue [Alpha, Bravo, Charlie]
+
+    await page.locator('[data-index="2"]').click({ button: "right" });
+    await page.getByTestId("queue-play-next").click();
+
+    await page.getByTestId("queue-trigger").click();
+    const items = page.getByTestId("queue-panel").getByTestId("queue-item");
+    // Charlie is now first up (inserted right after Alpha), ahead of Bravo.
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toContainText("Track Charlie");
+    await expect(items.nth(1)).toContainText("Track Bravo");
+  });
+
+  test("a hand-added track survives filtering (queue freezes)", async ({
+    page,
+  }) => {
+    await setup(page);
+    await startPlaying(page); // queue [Alpha, Bravo, Charlie]
+
+    await page.locator('[data-index="2"]').click({ button: "right" });
+    await page.getByTestId("queue-add").click(); // freezes the queue
+
+    // Filter down to just Alpha. Without the freeze, the SoundCloud view would
+    // reconcile "up next" to the visible list (emptying it); frozen, it holds.
+    await page.getByRole("button", { name: /^filters$/i }).click();
+    await page.getByPlaceholder("…").fill("alpha");
+    await expect(page.locator("[data-index]")).toHaveCount(1);
+
+    await page.getByTestId("queue-trigger").click();
+    const items = page.getByTestId("queue-panel").getByTestId("queue-item");
+    await expect(items).toHaveCount(3); // Bravo, Charlie, Charlie — untouched
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -237,6 +237,12 @@
   --text-2xs--letter-spacing: 0.06em;
   --text-2xs--font-weight: 600;
 
+  /* Align the dense scale with DESIGN.md §3.2 — the app runs 1–2px tighter than
+   * Tailwind's stock text-xs/sm (12/14px). Size only; line-height and weight
+   * keep Tailwind's proportional defaults so nothing re-weights. */
+  --text-xs: 0.6875rem; /* 11px */
+  --text-sm: 0.75rem; /* 12px */
+
   /* Radii — derived from single knob. */
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/frontend/src/app/library/rekordbox-view.tsx
+++ b/frontend/src/app/library/rekordbox-view.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/layout/top-bar-context";
 import { LogoSpinner } from "@/components/logo-spinner";
 import { RekordboxWaveform } from "@/components/rekordbox-waveform";
+import { TrackQueueMenu } from "@/components/track-queue-menu";
 import {
   TrackTable,
   type ResolvedColumn,
@@ -652,86 +653,98 @@ export function RekordboxView() {
                   // Clicking anywhere on the row starts playback; the cover's
                   // play button is the keyboard/AT-accessible control, so the
                   // row stays a plain div (no nested-button ARIA).
-                  <div
-                    onClick={() => playable && handleStartPlay(index)}
-                    title={
-                      playable
-                        ? undefined
-                        : "Missing local file — not playable from Rekordbox"
-                    }
-                    className={cn(
-                      "group border-border flex h-10 items-center gap-1.5 border-b pr-0 pl-3 text-xs transition-colors select-none",
-                      playable
-                        ? "cursor-pointer hover:bg-[var(--surface-3)]"
-                        : "text-muted-foreground/60 cursor-default",
-                      isCurrent && "bg-[var(--brand-soft)]",
-                      isSelected && !isCurrent && "bg-[var(--surface-3)]",
-                    )}
+                  <TrackQueueMenu
+                    disabled={!playable}
+                    onPlayNext={() => {
+                      const pt = toPlayerTrack(t, device);
+                      if (pt) player.playNext(pt);
+                    }}
+                    onAddToQueue={() => {
+                      const pt = toPlayerTrack(t, device);
+                      if (pt) player.enqueue(pt);
+                    }}
                   >
                     <div
-                      className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleSelect(index, e.shiftKey);
-                      }}
+                      onClick={() => playable && handleStartPlay(index)}
+                      title={
+                        playable
+                          ? undefined
+                          : "Missing local file — not playable from Rekordbox"
+                      }
+                      className={cn(
+                        "group border-border flex h-10 items-center gap-1.5 border-b pr-0 pl-3 text-xs transition-colors select-none",
+                        playable
+                          ? "cursor-pointer hover:bg-[var(--surface-3)]"
+                          : "text-muted-foreground/60 cursor-default",
+                        isCurrent && "bg-[var(--brand-soft)]",
+                        isSelected && !isCurrent && "bg-[var(--surface-3)]",
+                      )}
                     >
-                      <Checkbox
-                        checked={isSelected}
-                        tabIndex={-1}
-                        className="pointer-events-none size-3.5"
-                      />
-                    </div>
-                    <CoverPlayButton
-                      artworkUrl={
-                        t.has_artwork
-                          ? api.getRekordboxArtworkUrl(
-                              t.id,
-                              true,
-                              deviceId ?? undefined,
-                            )
-                          : null
-                      }
-                      isCurrent={isCurrent}
-                      onStartPlay={
-                        playable ? () => handleStartPlay(index) : undefined
-                      }
-                      label={t.title}
-                    />
-                    <div className="flex h-10 w-24 shrink-0 items-center">
-                      {t.has_waveform ? (
-                        <RekordboxWaveform
-                          trackId={t.id}
-                          device={deviceId ?? undefined}
-                          track={playable ? toPlayerTrack(t, device) : null}
-                          onStartPlay={
-                            playable
-                              ? (startRatio) =>
-                                  handleStartPlay(index, startRatio)
-                              : undefined
-                          }
-                          width={96}
-                          height={20}
-                        />
-                      ) : null}
-                    </div>
-                    {visibleColumns.map((col) => (
                       <div
-                        key={col.id}
-                        // truncate lives on the same element as the explicit
-                        // width so resizes reflow the ellipsis immediately —
-                        // an inner span with `truncate` doesn't always pick
-                        // up the new available width on a numeric style
-                        // change.
-                        className={cn(
-                          "min-w-0 shrink-0 truncate",
-                          col.className,
-                        )}
-                        style={{ width: col.width }}
+                        className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleSelect(index, e.shiftKey);
+                        }}
                       >
-                        {renderCell(col, t, isCurrent)}
+                        <Checkbox
+                          checked={isSelected}
+                          tabIndex={-1}
+                          className="pointer-events-none size-3.5"
+                        />
                       </div>
-                    ))}
-                  </div>
+                      <CoverPlayButton
+                        artworkUrl={
+                          t.has_artwork
+                            ? api.getRekordboxArtworkUrl(
+                                t.id,
+                                true,
+                                deviceId ?? undefined,
+                              )
+                            : null
+                        }
+                        isCurrent={isCurrent}
+                        onStartPlay={
+                          playable ? () => handleStartPlay(index) : undefined
+                        }
+                        label={t.title}
+                      />
+                      <div className="flex h-10 w-24 shrink-0 items-center">
+                        {t.has_waveform ? (
+                          <RekordboxWaveform
+                            trackId={t.id}
+                            device={deviceId ?? undefined}
+                            track={playable ? toPlayerTrack(t, device) : null}
+                            onStartPlay={
+                              playable
+                                ? (startRatio) =>
+                                    handleStartPlay(index, startRatio)
+                                : undefined
+                            }
+                            width={96}
+                            height={20}
+                          />
+                        ) : null}
+                      </div>
+                      {visibleColumns.map((col) => (
+                        <div
+                          key={col.id}
+                          // truncate lives on the same element as the explicit
+                          // width so resizes reflow the ellipsis immediately —
+                          // an inner span with `truncate` doesn't always pick
+                          // up the new available width on a numeric style
+                          // change.
+                          className={cn(
+                            "min-w-0 shrink-0 truncate",
+                            col.className,
+                          )}
+                          style={{ width: col.width }}
+                        >
+                          {renderCell(col, t, isCurrent)}
+                        </div>
+                      ))}
+                    </div>
+                  </TrackQueueMenu>
                 );
               }}
             />

--- a/frontend/src/components/collection-table.tsx
+++ b/frontend/src/components/collection-table.tsx
@@ -21,6 +21,7 @@ import { LogoSpinner } from "@/components/logo-spinner";
 import { MiniWaveform } from "@/components/mini-waveform";
 import { RulesetPreview } from "@/components/rulesets/ruleset-preview";
 import { Spinner } from "@/components/spinner";
+import { TrackQueueMenu } from "@/components/track-queue-menu";
 import {
   TrackTable,
   TrailingSortButton,
@@ -64,7 +65,7 @@ import {
   type TrackBrowse,
   type TrackInfoUpdateRequest,
 } from "@/lib/api";
-import { usePlayer } from "@/lib/player-context";
+import { usePlayer, type PlayerTrack } from "@/lib/player-context";
 import { searchParams } from "@/lib/search-params";
 import { soundCloudSource } from "@/lib/sources/soundcloud";
 import { parseRemix, removeMix } from "@/lib/string-utils";
@@ -409,6 +410,17 @@ function EditRow({
   folderPath,
   visibleFields,
 }: EditRowProps) {
+  const { enqueue, playNext } = usePlayer();
+  const playerTrack: PlayerTrack = {
+    filePath: item.file_path,
+    fileName: item.file_name,
+    title: item.title ?? undefined,
+    artist: Array.isArray(item.artist)
+      ? item.artist.join(", ")
+      : (item.artist ?? undefined),
+    bpm: item.bpm ?? null,
+  };
+
   const artworkUrl = item.has_artwork
     ? api.getArtworkUrl(item.file_path)
     : pendingArtworkB64
@@ -426,187 +438,192 @@ function EditRow({
   const isChanged = (field: EditableField): boolean => field in changes;
 
   return (
-    <div
-      role="row"
-      aria-current={isPlaying ? "true" : undefined}
-      className={cn(
-        "group/row border-border relative flex h-10 cursor-pointer items-center gap-1.5 border-b pr-0 pl-3 transition-colors",
-        isPlaying && "bg-[var(--brand-soft)]",
-        !isPlaying && (isCurrent || isSelected) && "bg-[var(--surface-3)]",
-        !isPlaying &&
-          !isCurrent &&
-          !isSelected &&
-          "hover:bg-[var(--surface-3)]",
-        justSaved && "saved-pulse",
-      )}
-      onClick={(e) => {
-        // Row click only opens the single-track editor / player.
-        // Multi-select is exclusively driven by the checkbox column.
-        const t = e.target as HTMLElement;
-        if (
-          t.closest(
-            'input, textarea, button, [role="menuitem"], [role="menuitemcheckbox"], [data-row-noselect]',
-          )
-        ) {
-          return;
-        }
-        onSelect();
-      }}
+    <TrackQueueMenu
+      onPlayNext={() => playNext(playerTrack)}
+      onAddToQueue={() => enqueue(playerTrack)}
     >
-      {isPlaying && (
-        <span
-          aria-hidden
-          className="bg-primary absolute inset-y-0 left-0 w-0.5"
-        />
-      )}
-      {/* Checkbox */}
       <div
-        className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
+        role="row"
+        aria-current={isPlaying ? "true" : undefined}
+        className={cn(
+          "group/row border-border relative flex h-10 cursor-pointer items-center gap-1.5 border-b pr-0 pl-3 transition-colors",
+          isPlaying && "bg-[var(--brand-soft)]",
+          !isPlaying && (isCurrent || isSelected) && "bg-[var(--surface-3)]",
+          !isPlaying &&
+            !isCurrent &&
+            !isSelected &&
+            "hover:bg-[var(--surface-3)]",
+          justSaved && "saved-pulse",
+        )}
         onClick={(e) => {
-          e.stopPropagation();
-          onToggleSelect(e.shiftKey);
+          // Row click only opens the single-track editor / player.
+          // Multi-select is exclusively driven by the checkbox column.
+          const t = e.target as HTMLElement;
+          if (
+            t.closest(
+              'input, textarea, button, [role="menuitem"], [role="menuitemcheckbox"], [data-row-noselect]',
+            )
+          ) {
+            return;
+          }
+          onSelect();
         }}
       >
-        <Checkbox
-          checked={isSelected}
-          tabIndex={-1}
-          className="cursor-pointer"
-        />
-      </div>
-
-      {/* Artwork thumbnail with hover play/pause overlay */}
-      <CoverPlayButton
-        artworkUrl={artworkUrl}
-        isCurrent={isPlaying}
-        onStartPlay={onStartPlay}
-        label={item.title ?? item.file_name}
-        className={`ring-1 ${pendingArtworkB64 ? "ring-primary/40" : "ring-transparent"}`}
-      />
-
-      {/* Mini waveform (top-half) */}
-      <div className="h-6 w-20 shrink-0">
-        <MiniWaveform
-          track={{
-            filePath: item.file_path,
-            fileName: item.file_name,
-            title: item.title ?? undefined,
-            artist: Array.isArray(item.artist)
-              ? item.artist.join(", ")
-              : (item.artist ?? undefined),
-          }}
-          halfHeight
-          onStartPlay={onStartPlay}
-        />
-      </div>
-
-      {/* Column cells — order driven by visibleFields (user-reorderable). */}
-      {visibleFields.map((f) => {
-        if (f.key === "folder") {
-          return (
-            <span
-              key={f.key}
-              className="text-muted-foreground min-w-0 shrink-0 truncate text-xs"
-              style={{ width: f.width }}
-              title={item.folder ?? ""}
-            >
-              {item.folder && folderPath
-                ? item.folder.startsWith(folderPath)
-                  ? item.folder.slice(folderPath.length + 1) || "."
-                  : item.folder
-                : "—"}
-            </span>
-          );
-        }
-        if (f.key === "file_size") {
-          const bytes = item.file_size ?? 0;
-          return (
-            <span
-              key={f.key}
-              data-size-cell
-              className="text-muted-foreground min-w-0 shrink-0 truncate text-right text-xs tabular-nums"
-              style={{ width: f.width }}
-              title={bytes ? `${bytes.toLocaleString()} bytes` : ""}
-            >
-              {bytes ? formatFileSize(bytes) : "—"}
-            </span>
-          );
-        }
-        if (f.key === "duration") {
-          const secs = item.duration ?? null;
-          return (
-            <span
-              key={f.key}
-              data-duration-cell
-              className="text-muted-foreground min-w-0 shrink-0 truncate text-right text-xs tabular-nums"
-              style={{ width: f.width }}
-            >
-              {secs != null ? formatDuration(secs) : "—"}
-            </span>
-          );
-        }
-        if (f.key === "file_format") {
-          const fmt = item.file_format
-            ? item.file_format.replace(/^\./, "").toLowerCase()
-            : "";
-          return (
-            <span
-              key={f.key}
-              data-format-cell
-              className="text-muted-foreground min-w-0 shrink-0 truncate text-xs tabular-nums"
-              style={{ width: f.width }}
-              title={item.file_format ?? ""}
-            >
-              {fmt || "—"}
-            </span>
-          );
-        }
-        if (f.key === "soundcloud_linked") {
-          return (
-            <div
-              key={f.key}
-              className="flex shrink-0 items-center justify-center"
-              style={{ width: f.width }}
-              title={isScLinked ? "Linked to SoundCloud" : "Not linked"}
-            >
-              <SoundCloudLogo
-                className={cn(
-                  "size-3.5",
-                  isScLinked ? "text-primary" : "text-muted-foreground/40",
-                )}
-              />
-            </div>
-          );
-        }
-        return (
-          <EditableCell
-            key={f.key}
-            value={getValue(f.key as EditableField)}
-            onCommit={(v) => onFieldChange(f.key as EditableField, v)}
-            onActivate={onSelect}
-            isCurrent={isCurrent}
-            placeholder={f.label}
-            isChanged={isChanged(f.key as EditableField)}
-            width={f.width}
+        {isPlaying && (
+          <span
+            aria-hidden
+            className="bg-primary absolute inset-y-0 left-0 w-0.5"
           />
-        );
-      })}
+        )}
+        {/* Checkbox */}
+        <div
+          className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect(e.shiftKey);
+          }}
+        >
+          <Checkbox
+            checked={isSelected}
+            tabIndex={-1}
+            className="cursor-pointer"
+          />
+        </div>
 
-      {/* Added date (read-only) */}
-      <span className="text-muted-foreground w-20 shrink-0 text-xs tabular-nums">
-        {item.mtime
-          ? new Date(item.mtime * 1000).toISOString().slice(0, 10)
-          : "—"}
-      </span>
+        {/* Artwork thumbnail with hover play/pause overlay */}
+        <CoverPlayButton
+          artworkUrl={artworkUrl}
+          isCurrent={isPlaying}
+          onStartPlay={onStartPlay}
+          label={item.title ?? item.file_name}
+          className={`ring-1 ${pendingArtworkB64 ? "ring-primary/40" : "ring-transparent"}`}
+        />
 
-      {/* File name — moved to the end; folder is more relevant in tree view */}
-      <span
-        data-file-path={item.file_path}
-        className="text-muted-foreground w-32 shrink-0 truncate text-xs"
-        title={item.file_name}
-      >
-        {item.file_name}
-      </span>
-    </div>
+        {/* Mini waveform (top-half) */}
+        <div className="h-6 w-20 shrink-0">
+          <MiniWaveform
+            track={{
+              filePath: item.file_path,
+              fileName: item.file_name,
+              title: item.title ?? undefined,
+              artist: Array.isArray(item.artist)
+                ? item.artist.join(", ")
+                : (item.artist ?? undefined),
+            }}
+            halfHeight
+            onStartPlay={onStartPlay}
+          />
+        </div>
+
+        {/* Column cells — order driven by visibleFields (user-reorderable). */}
+        {visibleFields.map((f) => {
+          if (f.key === "folder") {
+            return (
+              <span
+                key={f.key}
+                className="text-muted-foreground min-w-0 shrink-0 truncate text-xs"
+                style={{ width: f.width }}
+                title={item.folder ?? ""}
+              >
+                {item.folder && folderPath
+                  ? item.folder.startsWith(folderPath)
+                    ? item.folder.slice(folderPath.length + 1) || "."
+                    : item.folder
+                  : "—"}
+              </span>
+            );
+          }
+          if (f.key === "file_size") {
+            const bytes = item.file_size ?? 0;
+            return (
+              <span
+                key={f.key}
+                data-size-cell
+                className="text-muted-foreground min-w-0 shrink-0 truncate text-right text-xs tabular-nums"
+                style={{ width: f.width }}
+                title={bytes ? `${bytes.toLocaleString()} bytes` : ""}
+              >
+                {bytes ? formatFileSize(bytes) : "—"}
+              </span>
+            );
+          }
+          if (f.key === "duration") {
+            const secs = item.duration ?? null;
+            return (
+              <span
+                key={f.key}
+                data-duration-cell
+                className="text-muted-foreground min-w-0 shrink-0 truncate text-right text-xs tabular-nums"
+                style={{ width: f.width }}
+              >
+                {secs != null ? formatDuration(secs) : "—"}
+              </span>
+            );
+          }
+          if (f.key === "file_format") {
+            const fmt = item.file_format
+              ? item.file_format.replace(/^\./, "").toLowerCase()
+              : "";
+            return (
+              <span
+                key={f.key}
+                data-format-cell
+                className="text-muted-foreground min-w-0 shrink-0 truncate text-xs tabular-nums"
+                style={{ width: f.width }}
+                title={item.file_format ?? ""}
+              >
+                {fmt || "—"}
+              </span>
+            );
+          }
+          if (f.key === "soundcloud_linked") {
+            return (
+              <div
+                key={f.key}
+                className="flex shrink-0 items-center justify-center"
+                style={{ width: f.width }}
+                title={isScLinked ? "Linked to SoundCloud" : "Not linked"}
+              >
+                <SoundCloudLogo
+                  className={cn(
+                    "size-3.5",
+                    isScLinked ? "text-primary" : "text-muted-foreground/40",
+                  )}
+                />
+              </div>
+            );
+          }
+          return (
+            <EditableCell
+              key={f.key}
+              value={getValue(f.key as EditableField)}
+              onCommit={(v) => onFieldChange(f.key as EditableField, v)}
+              onActivate={onSelect}
+              isCurrent={isCurrent}
+              placeholder={f.label}
+              isChanged={isChanged(f.key as EditableField)}
+              width={f.width}
+            />
+          );
+        })}
+
+        {/* Added date (read-only) */}
+        <span className="text-muted-foreground w-20 shrink-0 text-xs tabular-nums">
+          {item.mtime
+            ? new Date(item.mtime * 1000).toISOString().slice(0, 10)
+            : "—"}
+        </span>
+
+        {/* File name — moved to the end; folder is more relevant in tree view */}
+        <span
+          data-file-path={item.file_path}
+          className="text-muted-foreground w-32 shrink-0 truncate text-xs"
+          title={item.file_name}
+        >
+          {item.file_name}
+        </span>
+      </div>
+    </TrackQueueMenu>
   );
 }
 

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/soundcloud-bpm-cell";
 import { SoundcloudLikeButton } from "@/components/soundcloud-like-button";
 import { SourceProfileAvatar } from "@/components/source-profile-avatar";
+import { TrackQueueMenu } from "@/components/track-queue-menu";
 import {
   TrackTable,
   type TrackTableColumn,
@@ -567,6 +568,10 @@ interface TrackRowProps {
   onExpand: () => void;
   /** Install the queue starting at this row and begin playback. */
   onStartPlay: () => Promise<void> | void;
+  /** Append this track to the end of the play queue. */
+  onAddToQueue: () => void;
+  /** Insert this track right after the current one. */
+  onPlayNext: () => void;
   /** Columns filtered and ordered per user preferences, with resolved widths. */
   visibleColumns: ResolvedLikesCol[];
   /** When set, the row renders a drag handle and participates in SortableContext. */
@@ -587,6 +592,8 @@ function TrackRowInner({
   onToggleSelect,
   onExpand,
   onStartPlay,
+  onAddToQueue,
+  onPlayNext,
   visibleColumns,
   dragHandle,
 }: TrackRowProps) {
@@ -621,89 +628,95 @@ function TrackRowInner({
   }, []);
 
   return (
-    <div>
-      <div
-        role="row"
-        tabIndex={0}
-        aria-current={isCurrent ? "true" : undefined}
-        className={`group border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isCurrent ? "bg-[var(--brand-soft)]" : isSelected || isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
-        onClick={onExpand}
-        onPointerEnter={onPointerEnter}
-        onPointerLeave={onPointerLeave}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") onExpand();
-          if (e.key === " ") {
-            e.preventDefault();
-            onToggleSelect(e.shiftKey);
-          }
-        }}
-      >
-        {/* Drag handle */}
-        {dragHandle && (
-          <button
-            {...dragHandle.attributes}
-            {...dragHandle.listeners}
-            tabIndex={-1}
-            aria-label="Drag to reorder"
-            data-testid="likes-row-drag-handle"
-            onClick={(e) => e.stopPropagation()}
-            className="text-muted-foreground/50 hover:text-foreground flex size-4 shrink-0 cursor-grab items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 active:cursor-grabbing"
-          >
-            <GripVertical className="size-3" />
-          </button>
-        )}
-
-        {/* Checkbox */}
+    <TrackQueueMenu
+      onPlayNext={onPlayNext}
+      onAddToQueue={onAddToQueue}
+      disabled={unplayable}
+    >
+      <div>
         <div
-          className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleSelect(e.shiftKey);
+          role="row"
+          tabIndex={0}
+          aria-current={isCurrent ? "true" : undefined}
+          className={`group border-border flex h-10 cursor-pointer items-center gap-2 border-b px-3 transition-colors select-none ${isCurrent ? "bg-[var(--brand-soft)]" : isSelected || isExpanded ? "bg-[var(--surface-3)]" : "hover:bg-[var(--surface-3)]"} ${dragHandle?.isDragging ? "opacity-40" : ""}`}
+          onClick={onExpand}
+          onPointerEnter={onPointerEnter}
+          onPointerLeave={onPointerLeave}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onExpand();
+            if (e.key === " ") {
+              e.preventDefault();
+              onToggleSelect(e.shiftKey);
+            }
           }}
         >
-          <Checkbox
-            checked={isSelected}
-            className="pointer-events-none size-3.5"
-          />
-        </div>
+          {/* Drag handle */}
+          {dragHandle && (
+            <button
+              {...dragHandle.attributes}
+              {...dragHandle.listeners}
+              tabIndex={-1}
+              aria-label="Drag to reorder"
+              data-testid="likes-row-drag-handle"
+              onClick={(e) => e.stopPropagation()}
+              className="text-muted-foreground/50 hover:text-foreground flex size-4 shrink-0 cursor-grab items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 active:cursor-grabbing"
+            >
+              <GripVertical className="size-3" />
+            </button>
+          )}
 
-        {/* Artwork with hover play/pause overlay — streams via the backend
-            HLS endpoint when playback starts. */}
-        <CoverPlayButton
-          artworkUrl={imgUrl}
-          isCurrent={isCurrent}
-          onStartPlay={scTrackId ? onStartPlay : undefined}
-          unplayable={unplayable}
-          label={track.title ?? undefined}
-        />
-
-        {/* Reorderable column cells */}
-        {visibleColumns.map((col) => (
+          {/* Checkbox */}
           <div
-            key={col.id}
-            className={col.cellClassName}
-            style={{ width: col.width }}
+            className="flex w-6 shrink-0 cursor-pointer items-center justify-center self-stretch"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSelect(e.shiftKey);
+            }}
           >
-            {col.renderBody({
-              track,
-              isExpanded,
-              inCollection,
-              isLiked,
-              isNew: isNew ?? false,
-            })}
+            <Checkbox
+              checked={isSelected}
+              className="pointer-events-none size-3.5"
+            />
           </div>
-        ))}
-      </div>
 
-      {/* Expanded detail: description */}
-      {isExpanded && track.description && (
-        <div className="border-border bg-muted border-b px-3 py-2">
-          <p className="text-muted-foreground max-w-prose text-xs whitespace-pre-line">
-            {track.description}
-          </p>
+          {/* Artwork with hover play/pause overlay — streams via the backend
+            HLS endpoint when playback starts. */}
+          <CoverPlayButton
+            artworkUrl={imgUrl}
+            isCurrent={isCurrent}
+            onStartPlay={scTrackId ? onStartPlay : undefined}
+            unplayable={unplayable}
+            label={track.title ?? undefined}
+          />
+
+          {/* Reorderable column cells */}
+          {visibleColumns.map((col) => (
+            <div
+              key={col.id}
+              className={col.cellClassName}
+              style={{ width: col.width }}
+            >
+              {col.renderBody({
+                track,
+                isExpanded,
+                inCollection,
+                isLiked,
+                isNew: isNew ?? false,
+              })}
+            </div>
+          ))}
         </div>
-      )}
-    </div>
+
+        {/* Expanded detail: description */}
+        {isExpanded && track.description && (
+          <div className="border-border bg-muted border-b px-3 py-2">
+            <p className="text-muted-foreground max-w-prose text-xs whitespace-pre-line">
+              {track.description}
+            </p>
+          </div>
+        )}
+      </div>
+    </TrackQueueMenu>
   );
 }
 
@@ -791,7 +804,8 @@ export function LikesTable({
   onVisibleOrderChange,
 }: LikesTableProps) {
   const reorderEnabled = !!onReorderTracks;
-  const { playQueue, currentTrack, replaceUpcoming } = usePlayer();
+  const { playQueue, currentTrack, reconcileUpcoming, enqueue, playNext } =
+    usePlayer();
   // Mirror the current track into a ref so the reconcile effect can read it
   // without making it a dependency — otherwise reconciling (which changes
   // `currentTrack`'s reference) would re-trigger the effect and loop. This
@@ -940,10 +954,10 @@ export function LikesTable({
       (t) => `soundcloud:${extractId(t)}` === current.filePath,
     );
     if (pos < 0) return;
-    replaceUpcoming(
+    reconcileUpcoming(
       sortedTracks.slice(pos + 1).map((t) => scTrackToPlayerTrack(t, bpmCache)),
     );
-  }, [sortedTracks, bpmCache, replaceUpcoming]);
+  }, [sortedTracks, bpmCache, reconcileUpcoming]);
 
   // Report the current visible order (after sort) to callers so they can save
   // whatever the user currently sees.
@@ -1125,6 +1139,8 @@ export function LikesTable({
             }}
             onExpand={() => handleExpand(track)}
             onStartPlay={() => handleStartPlay(index)}
+            onAddToQueue={() => enqueue(scTrackToPlayerTrack(track, bpmCache))}
+            onPlayNext={() => playNext(scTrackToPlayerTrack(track, bpmCache))}
             visibleColumns={rowCols}
           />
         );
@@ -1161,6 +1177,8 @@ export function LikesTable({
                   onToggleSelect={() => undefined}
                   onExpand={() => undefined}
                   onStartPlay={() => undefined}
+                  onAddToQueue={() => undefined}
+                  onPlayNext={() => undefined}
                   visibleColumns={visibleColumns}
                   dragHandle={{
                     attributes: {},

--- a/frontend/src/components/queue-panel.tsx
+++ b/frontend/src/components/queue-panel.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, ListMusic, X } from "lucide-react";
+import { useState } from "react";
+
+import { CoverPlayButton } from "@/components/cover-play-button";
+import { MarqueeText } from "@/components/marquee-text";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { api } from "@/lib/api";
+import { usePlayer, type PlayerTrack } from "@/lib/player-context";
+import { cn } from "@/lib/utils";
+
+/** Artwork for a queue row: prefer the track's own art (SoundCloud CDN), fall
+ * back to the local `/artwork` endpoint for filesystem tracks, and let
+ * CoverPlayButton render its music-note glyph when neither applies. */
+function artworkFor(track: PlayerTrack): string | undefined {
+  if (track.artworkUrl) return track.artworkUrl;
+  if (track.filePath.startsWith("soundcloud:")) return undefined;
+  return api.getArtworkUrl(track.filePath);
+}
+
+function trackTitle(track: PlayerTrack): string {
+  return track.title ?? track.fileName;
+}
+
+/**
+ * A single upcoming-track row: drag handle, artwork, title/artist, remove
+ * button. The whole row (outside the handle and remove button) is a click
+ * target that jumps playback to this entry. `index` is the entry's absolute
+ * position in the full queue; `id` is that index as a string (dnd-kit ids).
+ */
+function UpcomingRow({
+  id,
+  track,
+  onJump,
+  onRemove,
+}: {
+  id: string;
+  track: PlayerTrack;
+  onJump: () => void;
+  onRemove: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+  const style: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    // A DragOverlay clone follows the pointer, so the source slot just dims to
+    // a gap — the shuffle of the other rows still animates via `transition`.
+    opacity: isDragging ? 0 : undefined,
+  };
+  const title = trackTitle(track);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-testid="queue-item"
+      data-queue-index={id}
+      className="group/qrow hover:bg-surface-3 flex items-center gap-2 rounded-md px-1 py-1"
+    >
+      <button
+        type="button"
+        aria-label="Reorder track"
+        className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 cursor-grab items-center justify-center active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-3.5" />
+      </button>
+      <CoverPlayButton
+        artworkUrl={artworkFor(track)}
+        isCurrent={false}
+        onStartPlay={onJump}
+        label={title}
+      />
+      <button
+        type="button"
+        onClick={onJump}
+        className="min-w-0 flex-1 cursor-pointer text-left"
+        title={title}
+      >
+        <MarqueeText
+          text={title}
+          className="text-foreground text-xs font-medium"
+        />
+        {track.artist && (
+          <div className="text-muted-foreground text-2xs truncate">
+            {track.artist}
+          </div>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        data-testid="queue-item-remove"
+        aria-label={`Remove ${title} from queue`}
+        className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 cursor-pointer items-center justify-center rounded opacity-0 transition-opacity group-hover/qrow:opacity-100 focus-visible:opacity-100"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+/** The floating clone rendered under the pointer while a row is dragged. A
+ * static mirror of UpcomingRow's layout — no interactive controls. */
+function DragRow({ track }: { track: PlayerTrack }) {
+  const title = trackTitle(track);
+  return (
+    <div className="bg-surface-3 flex items-center gap-2 rounded-md px-1 py-1 shadow-lg">
+      <span className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
+        <GripVertical className="size-3.5" />
+      </span>
+      <CoverPlayButton
+        artworkUrl={artworkFor(track)}
+        isCurrent={false}
+        label={title}
+      />
+      <div className="min-w-0 flex-1">
+        <MarqueeText
+          text={title}
+          className="text-foreground text-xs font-medium"
+        />
+        {track.artist && (
+          <div className="text-muted-foreground text-2xs truncate">
+            {track.artist}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Compact, non-draggable row for the "Now playing" track. */
+function NowPlayingRow({ track }: { track: PlayerTrack }) {
+  const title = trackTitle(track);
+  return (
+    <div
+      data-testid="queue-now-playing"
+      className="flex items-center gap-2 rounded-md px-1 py-1"
+    >
+      <CoverPlayButton artworkUrl={artworkFor(track)} isCurrent label={title} />
+      <div className="min-w-0 flex-1">
+        <MarqueeText
+          text={title}
+          className="text-primary text-xs font-medium"
+        />
+        {track.artist && (
+          <div className="text-muted-foreground text-2xs truncate">
+            {track.artist}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The Queue Preview: a player-bar trigger that opens a right-side sheet listing
+ * the now-playing track and the upcoming queue. Upcoming rows are drag-
+ * reorderable, removable, and click-to-play. Reorder/remove reuse the player
+ * context's `replaceUpcoming` (which swaps the tail after the current index).
+ */
+export function QueuePanel() {
+  const { queue, queueIndex, currentTrack, jumpTo, replaceUpcoming } =
+    usePlayer();
+  const [open, setOpen] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  // Everything after the current entry, tagged with its absolute queue index.
+  const upcoming = queue
+    .slice(queueIndex + 1)
+    .map((track, i) => ({ track, index: queueIndex + 1 + i }));
+  const ids = upcoming.map((u) => String(u.index));
+  const activeTrack =
+    activeId != null
+      ? (upcoming.find((u) => String(u.index) === activeId)?.track ?? null)
+      : null;
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = ids.indexOf(String(active.id));
+    const to = ids.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+    const tail = upcoming.map((u) => u.track);
+    const [moved] = tail.splice(from, 1);
+    tail.splice(to, 0, moved);
+    replaceUpcoming(tail);
+  }
+
+  function handleRemove(absoluteIndex: number) {
+    const tail = upcoming
+      .filter((u) => u.index !== absoluteIndex)
+      .map((u) => u.track);
+    replaceUpcoming(tail);
+  }
+
+  const hasQueue = queueIndex >= 0 && !!currentTrack;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          data-testid="queue-trigger"
+          disabled={!hasQueue}
+          className={cn(
+            "text-muted-foreground hover:text-foreground hover:bg-surface-3 flex size-6 cursor-pointer items-center justify-center rounded-full transition-colors",
+            !hasQueue && "cursor-not-allowed opacity-40 hover:bg-transparent",
+          )}
+          title="Queue"
+          aria-label="Show queue"
+        >
+          <ListMusic className="size-3.5" />
+        </button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        data-testid="queue-panel"
+        className="w-80 max-w-[90vw] gap-0"
+      >
+        <SheetHeader>
+          <SheetTitle>Queue</SheetTitle>
+        </SheetHeader>
+        <ScrollArea className="flex-1">
+          <div className="flex flex-col gap-1 px-4 pt-2 pb-4">
+            {currentTrack && (
+              <>
+                <div className="text-muted-foreground text-2xs px-1 pt-1 pb-1 tracking-wider uppercase">
+                  Now playing
+                </div>
+                <NowPlayingRow track={currentTrack} />
+              </>
+            )}
+            <div className="text-muted-foreground text-2xs px-1 pt-3 pb-1 tracking-wider uppercase">
+              Next up
+            </div>
+            {upcoming.length === 0 ? (
+              <div className="text-muted-foreground px-1 py-2 text-xs">
+                Nothing queued next.
+              </div>
+            ) : (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={(e: DragStartEvent) =>
+                  setActiveId(String(e.active.id))
+                }
+                onDragEnd={handleDragEnd}
+                onDragCancel={() => setActiveId(null)}
+              >
+                <SortableContext
+                  items={ids}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {upcoming.map((u) => (
+                    <UpcomingRow
+                      key={u.index}
+                      id={String(u.index)}
+                      track={u.track}
+                      onJump={() => jumpTo(u.index)}
+                      onRemove={() => handleRemove(u.index)}
+                    />
+                  ))}
+                </SortableContext>
+                <DragOverlay>
+                  {activeTrack ? <DragRow track={activeTrack} /> : null}
+                </DragOverlay>
+              </DndContext>
+            )}
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/track-queue-menu.tsx
+++ b/frontend/src/components/track-queue-menu.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { CornerDownRight, ListPlus } from "lucide-react";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+/**
+ * Right-click wrapper that adds "Play next" and "Add to queue" to a track row.
+ * The parent supplies the actions (each view builds its own PlayerTrack and
+ * calls the player context), so this component stays presentation-only.
+ * `disabled` greys the items out for rows that can't be played (e.g. an
+ * unresolved Rekordbox track).
+ */
+export function TrackQueueMenu({
+  onPlayNext,
+  onAddToQueue,
+  disabled = false,
+  children,
+}: {
+  onPlayNext: () => void;
+  onAddToQueue: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-40">
+        <ContextMenuItem
+          data-testid="queue-play-next"
+          disabled={disabled}
+          onSelect={onPlayNext}
+          className="text-xs"
+        >
+          <CornerDownRight className="size-3.5" />
+          Play next
+        </ContextMenuItem>
+        <ContextMenuItem
+          data-testid="queue-add"
+          disabled={disabled}
+          onSelect={onAddToQueue}
+          className="text-xs"
+        >
+          <ListPlus className="size-3.5" />
+          Add to queue
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/frontend/src/components/waveform-player.tsx
+++ b/frontend/src/components/waveform-player.tsx
@@ -35,6 +35,7 @@ import { MixOverviewSwipe } from "@/components/mix-overview-swipe";
 import { PeaksWaveform } from "@/components/peaks-waveform";
 import { PlayerDetailWaveform } from "@/components/player-detail-waveform";
 import { PlayerRekordboxWaveform } from "@/components/player-rekordbox-waveform";
+import { QueuePanel } from "@/components/queue-panel";
 import { loadWaveform, pwv4ToPeaks } from "@/components/rekordbox-waveform";
 import { api } from "@/lib/api";
 import { onHlsFatalExpiry } from "@/lib/hls-expiry";
@@ -2515,6 +2516,7 @@ export function WaveformPlayer() {
               >
                 <SkipForward className="size-3" />
               </button>
+              <QueuePanel />
 
               {/* BPM + KEY on the same level, right-aligned. Labels are never
                 tinted; the value carries the pitch colour. */}

--- a/frontend/src/lib/player-context.tsx
+++ b/frontend/src/lib/player-context.tsx
@@ -69,6 +69,11 @@ interface PlayerContextValue {
    * the fade completes. Track lists mark their "now playing" row from this so
    * the highlight follows the sound instead of lagging a whole fade behind. */
   activeTrack: PlayerTrack | null;
+  /** The full play queue (past + current + upcoming). Consumed by the queue
+   * panel to render the "next up" list; slice from `queueIndex + 1` for the
+   * not-yet-played tail. Per-entry identity is `${index}:${filePath}` — the
+   * same file can appear more than once, so filePath alone is not unique. */
+  queue: PlayerTrack[];
   /** Position of `currentTrack` in the queue (-1 when nothing is loaded).
    * Queues can hold the same file twice in a row, so per-entry identity is
    * `${queueIndex}:${filePath}` — filePath alone is not unique. */
@@ -87,11 +92,22 @@ interface PlayerContextValue {
     startRatio?: number,
   ) => void;
   /** Replace the not-yet-played tail of the queue (every entry after the
-   * current index) without disturbing the current track or its index. Lets a
-   * caller re-derive "what plays next" mid-playback — e.g. after the user
-   * filters the visible list — so autoplay stops walking into tracks that are
-   * no longer shown. No-op when nothing is loaded. */
+   * current index) without disturbing the current track or its index, and mark
+   * the queue user-managed. Used by the queue panel's reorder/remove — a
+   * deliberate hand-edit that should stick, so it also freezes out
+   * `reconcileUpcoming`. No-op when nothing is loaded. */
   replaceUpcoming: (upcoming: PlayerTrack[]) => void;
+  /** Like `replaceUpcoming`, but a no-op once the queue has been hand-edited
+   * (add/play-next/reorder/remove). The visible-list views call this to keep
+   * autoplay in step with sort/filter changes — without clobbering a queue the
+   * user has taken manual control of. A fresh `playQueue` re-enables it. */
+  reconcileUpcoming: (upcoming: PlayerTrack[]) => void;
+  /** Append a track to the end of the queue; starts playback if nothing is
+   * loaded. Marks the queue user-managed. */
+  enqueue: (track: PlayerTrack) => void;
+  /** Insert a track immediately after the current one; starts playback if
+   * nothing is loaded. Marks the queue user-managed. */
+  playNext: (track: PlayerTrack) => void;
   pause: () => void;
   toggle: (track?: PlayerTrack) => void;
   stop: () => void;
@@ -99,6 +115,9 @@ interface PlayerContextValue {
   seek: (ratio: number) => void;
   /** Advance to the next track in the queue. No-op at end. */
   next: () => void;
+  /** Jump playback to an arbitrary queue index and play. No-op when the index
+   * is out of range or already current. Used by the queue panel's click-to-play. */
+  jumpTo: (index: number) => void;
   /** Go to previous track, or restart current if playback is past 3s. */
   previous: () => void;
   /** Peek at the next queued track without advancing. Used by the player
@@ -209,6 +228,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
 
   const queueRef = useRef<PlayerTrack[]>([]);
   const queueIndexRef = useRef(-1);
+  // True once the user has hand-edited the queue (add/play-next/reorder/remove).
+  // Freezes out `reconcileUpcoming` so the visible-list views stop rewriting a
+  // queue the user is curating. Reset by `playQueue` (a fresh auto queue).
+  const userManagedRef = useRef(false);
   const progressRef = useRef(0);
   const progressCallbacksRef = useRef<Set<(p: number) => void>>(new Set());
   const seekFnRef = useRef<((ratio: number) => void) | null>(null);
@@ -298,6 +321,9 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         startRatio != null && startRatio > 0
           ? Math.max(0, Math.min(1, startRatio))
           : null;
+      // A fresh queue from a play action returns to auto mode: the visible-list
+      // views may reconcile its tail again.
+      userManagedRef.current = false;
       setQueueState(tracks, index);
       setIsPlaying(true);
     },
@@ -308,7 +334,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   // index untouched so the player never re-decodes (its init effect keys on
   // `${queueIndex}:${filePath}`). The preserved head is sliced from the live
   // queue, so `currentTrack`'s object identity is unchanged too.
-  const replaceUpcoming = useCallback(
+  const setUpcoming = useCallback(
     (upcoming: PlayerTrack[]) => {
       const idx = queueIndexRef.current;
       if (idx < 0) return;
@@ -319,6 +345,55 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
       if (unchanged) return;
       const head = queueRef.current.slice(0, idx + 1);
       setQueueState([...head, ...upcoming], idx);
+    },
+    [setQueueState],
+  );
+
+  // A deliberate hand-edit: apply it and freeze out auto-reconciliation.
+  const replaceUpcoming = useCallback(
+    (upcoming: PlayerTrack[]) => {
+      userManagedRef.current = true;
+      setUpcoming(upcoming);
+    },
+    [setUpcoming],
+  );
+
+  // Auto-reconcile from the visible list — skipped once the user is curating.
+  const reconcileUpcoming = useCallback(
+    (upcoming: PlayerTrack[]) => {
+      if (userManagedRef.current) return;
+      setUpcoming(upcoming);
+    },
+    [setUpcoming],
+  );
+
+  const enqueue = useCallback(
+    (track: PlayerTrack) => {
+      userManagedRef.current = true;
+      const idx = queueIndexRef.current;
+      if (idx < 0 || queueRef.current.length === 0) {
+        seekFnRef.current = null;
+        setQueueState([track], 0);
+        setIsPlaying(true);
+        return;
+      }
+      setQueueState([...queueRef.current, track], idx);
+    },
+    [setQueueState],
+  );
+
+  const playNext = useCallback(
+    (track: PlayerTrack) => {
+      userManagedRef.current = true;
+      const idx = queueIndexRef.current;
+      if (idx < 0 || queueRef.current.length === 0) {
+        seekFnRef.current = null;
+        setQueueState([track], 0);
+        setIsPlaying(true);
+        return;
+      }
+      const q = queueRef.current;
+      setQueueState([...q.slice(0, idx + 1), track, ...q.slice(idx + 1)], idx);
     },
     [setQueueState],
   );
@@ -379,6 +454,21 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     if (nextIdx < 0 || nextIdx >= queueRef.current.length) return;
     queueIndexRef.current = nextIdx;
     setQueueIndex(nextIdx);
+    setIsPlaying(true);
+  }, []);
+
+  const jumpTo = useCallback((index: number) => {
+    if (
+      index < 0 ||
+      index >= queueRef.current.length ||
+      index === queueIndexRef.current
+    ) {
+      return;
+    }
+    // Drop the outgoing player's seek fn — it isn't valid for the new track.
+    seekFnRef.current = null;
+    queueIndexRef.current = index;
+    setQueueIndex(index);
     setIsPlaying(true);
   }, []);
 
@@ -454,17 +544,22 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     () => ({
       currentTrack,
       activeTrack,
+      queue,
       queueIndex,
       isPlaying,
       load,
       play,
       playQueue,
       replaceUpcoming,
+      reconcileUpcoming,
+      enqueue,
+      playNext,
       pause,
       toggle,
       stop,
       seek,
       next,
+      jumpTo,
       previous,
       peekNext,
       hasNext,
@@ -487,17 +582,22 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     [
       currentTrack,
       activeTrack,
+      queue,
       queueIndex,
       isPlaying,
       load,
       play,
       playQueue,
       replaceUpcoming,
+      reconcileUpcoming,
+      enqueue,
+      playNext,
       pause,
       toggle,
       stop,
       seek,
       next,
+      jumpTo,
       previous,
       peekNext,
       hasNext,


### PR DESCRIPTION
Adds a right-side Queue panel (opened from the player bar) showing the now-playing track and upcoming queue, with click-to-jump, remove, and drag reorder. Right-clicking any track row in the three views adds it to the queue or plays it next; hand-editing freezes the queue so the SoundCloud visible-list reconcile stops overwriting a curated order. Also aligns `text-xs`/`text-sm` with DESIGN.md's dense scale (12/14px → 11/12px), which the codebase never actually applied.

Test plan: `e2e/queue-panel.spec.ts` covers listing, jump, remove, reorder, add-to-queue, play-next, and the freeze-on-filter behavior; typecheck/lint/format green.