### PR TITLE
feat(soundcloud): playlist management from track rows and sidebar

### DIFF
--- a/backend/api/soundcloud.py
+++ b/backend/api/soundcloud.py
@@ -364,6 +364,53 @@ async def unlike_track(
     return await _proxy_like(track_id, "DELETE", token)
 
 
+async def _proxy_playlist_delete(playlist_id: int, token: str) -> Response:
+    """Forward a playlist delete to the SoundCloud public API."""
+    url = f"{_PUBLIC_API_BASE}/playlists/soundcloud:playlists:{playlist_id}"
+    headers = {"Authorization": f"OAuth {token}", "Accept": "application/json"}
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            resp = await client.request("DELETE", url, headers=headers)
+    except Exception as exc:
+        logger.exception("SoundCloud playlist delete proxy transport error")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="SoundCloud upstream error",
+        ) from exc
+
+    if resp.status_code in (401, 403):
+        raise HTTPException(
+            status_code=resp.status_code,
+            detail="SoundCloud rejected the user token",
+        )
+    if not resp.is_success:
+        logger.warning(
+            "SoundCloud DELETE /playlists returned %s for playlist %s",
+            resp.status_code,
+            playlist_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"SoundCloud returned {resp.status_code}",
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/playlists/{playlist_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_playlist(
+    playlist_id: int,
+    authorization: str | None = Header(default=None),
+) -> Response:
+    """Delete a SoundCloud playlist on behalf of the authenticated user.
+
+    The browser can't call ``DELETE /playlists/...`` directly — SoundCloud
+    doesn't expose that method in its CORS policy — so this endpoint forwards
+    the request with the user's own token.
+    """
+    token = _user_token_from_authorization(authorization)
+    return await _proxy_playlist_delete(playlist_id, token)
+
+
 def _reset_cache_for_tests() -> None:
     """Clear the in-memory cache. Intended for tests only."""
     _cache.clear()

--- a/frontend/e2e/soundcloud-add-to-playlist.spec.ts
+++ b/frontend/e2e/soundcloud-add-to-playlist.spec.ts
@@ -1,0 +1,573 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SoundCloud playlist actions on a track row's context menu:
+ *  - "Add to playlist ▸" submenu listing the user's own playlists, with a
+ *    check on playlists that already contain the track.
+ *  - "Remove from playlist" when viewing one of the user's own playlists.
+ * SoundCloud's playlist PUT replaces the whole track set, so both actions read
+ * the current tracks first and write the merged/filtered set back.
+ */
+
+function authInit(page: import("@playwright/test").Page) {
+  return page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+}
+
+function commonRoutes(page: import("@playwright/test").Page) {
+  return Promise.all([
+    page.route("https://api.soundcloud.com/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      }),
+    ),
+    page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    ),
+    page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      }),
+    ),
+    page.route("**/api/bpm/soundcloud/bulk", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ bpms: {} }),
+      }),
+    ),
+    page.route("**/api/settings/root-folder", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ root_music_folder: "/music" }),
+      }),
+    ),
+  ]);
+}
+
+const MY_PLAYLISTS = {
+  collection: [
+    {
+      urn: "soundcloud:playlists:100",
+      title: "My Set",
+      track_count: 1,
+      permalink_url: "https://soundcloud.com/me/sets/my-set",
+    },
+  ],
+  next_href: null,
+};
+
+/** Likes view with one liked track (Alpha, id 42) and one playlist ("My Set")
+ *  whose current tracks are supplied by `playlistTracks`. */
+async function setupLikesView(
+  page: import("@playwright/test").Page,
+  playlistTracks: { id: number; urn: string }[],
+) {
+  await authInit(page);
+  await commonRoutes(page);
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [
+          {
+            id: 42,
+            urn: "soundcloud:tracks:42",
+            title: "Track Alpha",
+            user: { id: 1, username: "me" },
+            duration: 200_000,
+            permalink_url: "https://soundcloud.com/me/alpha",
+          },
+        ],
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MY_PLAYLISTS),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/playlists/**", (route) => {
+    const req = route.request();
+    if (req.method() === "GET" && req.url().includes("/tracks")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: playlistTracks, next_href: null }),
+      });
+    }
+    if (req.method() === "PUT") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          urn: "soundcloud:playlists:100",
+          title: "My Set",
+          permalink_url: "https://soundcloud.com/me/sets/my-set",
+        }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    });
+  });
+}
+
+test.describe("soundcloud playlist context-menu actions", () => {
+  test("appends a track to a playlist that doesn't contain it yet", async ({
+    page,
+  }) => {
+    await setupLikesView(page, [{ id: 1001, urn: "soundcloud:tracks:1001" }]);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(1, {
+      timeout: 5000,
+    });
+
+    await page.locator('[data-index="0"]').click({ button: "right" });
+    await page.getByTestId("playlist-add-trigger").hover();
+
+    const item = page
+      .getByTestId("playlist-add-item")
+      .filter({ hasText: "My Set" });
+    await expect(item).toBeVisible();
+    // Not a member → no check, enabled.
+    await expect(item).not.toHaveAttribute("data-member", "true");
+
+    const putPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "PUT" &&
+        req.url().includes("/playlists/") &&
+        !req.url().includes("/tracks"),
+    );
+    await item.click();
+    const put = await putPromise;
+
+    const urns = (
+      put.postDataJSON() as { playlist: { tracks: { urn: string }[] } }
+    ).playlist.tracks.map((t) => t.urn);
+    expect(urns).toEqual(["soundcloud:tracks:1001", "soundcloud:tracks:42"]);
+
+    await expect(page.getByText('Added to "My Set"')).toBeVisible();
+  });
+
+  test("adds every checkbox-selected track to a playlist", async ({ page }) => {
+    await authInit(page);
+    await commonRoutes(page);
+    await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          collection: [
+            {
+              id: 42,
+              urn: "soundcloud:tracks:42",
+              title: "Track Alpha",
+              user: { id: 1, username: "me" },
+              duration: 200_000,
+            },
+            {
+              id: 99,
+              urn: "soundcloud:tracks:99",
+              title: "Track Bravo",
+              user: { id: 1, username: "me" },
+              duration: 200_000,
+            },
+          ],
+          next_href: null,
+        }),
+      }),
+    );
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MY_PLAYLISTS),
+      }),
+    );
+    await page.route("https://api.soundcloud.com/playlists/**", (route) => {
+      const req = route.request();
+      if (req.method() === "GET" && req.url().includes("/tracks")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            collection: [{ id: 1001, urn: "soundcloud:tracks:1001" }],
+            next_href: null,
+          }),
+        });
+      }
+      if (req.method() === "PUT") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ urn: "soundcloud:playlists:100" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    await page.getByRole("checkbox", { name: /select all/i }).click();
+    await page.locator('[data-index="0"]').click({ button: "right" });
+
+    // Count is surfaced on the submenu trigger.
+    const trigger = page.getByTestId("playlist-add-trigger");
+    await expect(trigger).toHaveText(/Add to playlist \(2\)/);
+    await trigger.hover();
+
+    const putPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "PUT" &&
+        req.url().includes("/playlists/") &&
+        !req.url().includes("/tracks"),
+    );
+    await page
+      .getByTestId("playlist-add-item")
+      .filter({ hasText: "My Set" })
+      .click();
+    const put = await putPromise;
+
+    const urns = (
+      put.postDataJSON() as { playlist: { tracks: { urn: string }[] } }
+    ).playlist.tracks.map((t) => t.urn);
+    // Existing track kept + both selected tracks appended.
+    expect(urns).toEqual([
+      "soundcloud:tracks:1001",
+      "soundcloud:tracks:42",
+      "soundcloud:tracks:99",
+    ]);
+
+    await expect(page.getByText('Added 2 tracks to "My Set"')).toBeVisible();
+  });
+
+  test("marks a playlist the track is already in and disables it", async ({
+    page,
+  }) => {
+    // Playlist already contains the row's track (id 42).
+    await setupLikesView(page, [{ id: 42, urn: "soundcloud:tracks:42" }]);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(1, {
+      timeout: 5000,
+    });
+
+    await page.locator('[data-index="0"]').click({ button: "right" });
+    await page.getByTestId("playlist-add-trigger").hover();
+
+    const item = page
+      .getByTestId("playlist-add-item")
+      .filter({ hasText: "My Set" });
+    // Membership resolves asynchronously → item flips to member + disabled.
+    await expect(item).toHaveAttribute("data-member", "true");
+    await expect(item).toHaveAttribute("data-disabled", "");
+  });
+
+  test("removes a track from the playlist being viewed", async ({ page }) => {
+    await authInit(page);
+    await commonRoutes(page);
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MY_PLAYLISTS),
+      }),
+    );
+
+    const playlistTracks = [
+      {
+        id: 42,
+        urn: "soundcloud:tracks:42",
+        title: "Track Alpha",
+        user: { id: 1, username: "me" },
+        duration: 200_000,
+      },
+      {
+        id: 1001,
+        urn: "soundcloud:tracks:1001",
+        title: "Track Beta",
+        user: { id: 1, username: "me" },
+        duration: 200_000,
+      },
+    ];
+    await page.route("https://api.soundcloud.com/playlists/**", (route) => {
+      const req = route.request();
+      if (req.method() === "GET" && req.url().includes("/tracks")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ collection: playlistTracks, next_href: null }),
+        });
+      }
+      if (req.method() === "PUT") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ urn: "soundcloud:playlists:100" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    // Navigate straight into the playlist node (tab "me" is the default).
+    await page.goto(
+      "/library?source=soundcloud&node=pl:soundcloud:playlists:100",
+    );
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    await page.locator('[data-index="0"]').click({ button: "right" });
+
+    const putPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "PUT" &&
+        req.url().includes("/playlists/") &&
+        !req.url().includes("/tracks"),
+    );
+    await page.getByTestId("playlist-remove").click();
+
+    // Row disappears optimistically.
+    await expect(page.locator("[data-index]")).toHaveCount(1);
+    await expect(page.getByText("Track Beta")).toBeVisible();
+
+    const put = await putPromise;
+    const urns = (
+      put.postDataJSON() as { playlist: { tracks: { urn: string }[] } }
+    ).playlist.tracks.map((t) => t.urn);
+    // Alpha (42) dropped, Beta (1001) kept.
+    expect(urns).toEqual(["soundcloud:tracks:1001"]);
+  });
+
+  test("removes every checkbox-selected track from the playlist", async ({
+    page,
+  }) => {
+    await authInit(page);
+    await commonRoutes(page);
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MY_PLAYLISTS),
+      }),
+    );
+
+    const playlistTracks = [
+      {
+        id: 42,
+        urn: "soundcloud:tracks:42",
+        title: "Track Alpha",
+        user: { id: 1, username: "me" },
+        duration: 200_000,
+      },
+      {
+        id: 99,
+        urn: "soundcloud:tracks:99",
+        title: "Track Bravo",
+        user: { id: 1, username: "me" },
+        duration: 200_000,
+      },
+      {
+        id: 1001,
+        urn: "soundcloud:tracks:1001",
+        title: "Track Beta",
+        user: { id: 1, username: "me" },
+        duration: 200_000,
+      },
+    ];
+    await page.route("https://api.soundcloud.com/playlists/**", (route) => {
+      const req = route.request();
+      if (req.method() === "GET" && req.url().includes("/tracks")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ collection: playlistTracks, next_href: null }),
+        });
+      }
+      if (req.method() === "PUT") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ urn: "soundcloud:playlists:100" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    await page.goto(
+      "/library?source=soundcloud&node=pl:soundcloud:playlists:100",
+    );
+    await expect(page.locator("[data-index]")).toHaveCount(3, {
+      timeout: 5000,
+    });
+
+    await page.getByRole("checkbox", { name: /select all/i }).click();
+    await page.locator('[data-index="0"]').click({ button: "right" });
+
+    const removeItem = page.getByTestId("playlist-remove");
+    await expect(removeItem).toHaveText(/Remove from playlist \(3\)/);
+
+    const putPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "PUT" &&
+        req.url().includes("/playlists/") &&
+        !req.url().includes("/tracks"),
+    );
+    await removeItem.click();
+
+    // All three selected rows disappear.
+    await expect(page.locator("[data-index]")).toHaveCount(0);
+
+    const put = await putPromise;
+    const urns = (
+      put.postDataJSON() as { playlist: { tracks: { urn: string }[] } }
+    ).playlist.tracks.map((t) => t.urn);
+    expect(urns).toEqual([]);
+  });
+
+  test("creates a playlist from the selection and refreshes the sidebar", async ({
+    page,
+  }) => {
+    await authInit(page);
+    await commonRoutes(page);
+    // Pre-expand the sidebar "Playlists" group so its child nodes are visible.
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "tree-panel-expanded:library:soundcloud:me",
+        JSON.stringify(["playlists"]),
+      );
+    });
+    await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          collection: [
+            {
+              id: 42,
+              urn: "soundcloud:tracks:42",
+              title: "Track Alpha",
+              user: { id: 1, username: "me" },
+              duration: 200_000,
+            },
+            {
+              id: 99,
+              urn: "soundcloud:tracks:99",
+              title: "Track Bravo",
+              user: { id: 1, username: "me" },
+              duration: 200_000,
+            },
+          ],
+          next_href: null,
+        }),
+      }),
+    );
+    // Server keeps returning an empty list (SoundCloud's list is eventually
+    // consistent) — the sidebar must show the new playlist optimistically from
+    // the POST response, without waiting for a refetch.
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+    // POST /playlists (create). `*` matches an optional query but not a
+    // subpath, so it won't catch /playlists/{urn}.
+    await page.route("https://api.soundcloud.com/playlists*", (route) => {
+      if (route.request().method() === "POST") {
+        return route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            urn: "soundcloud:playlists:200",
+            title: "My Mix",
+            track_count: 2,
+            permalink_url: "https://soundcloud.com/me/sets/my-mix",
+          }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      });
+    });
+
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    // Select both rows.
+    await page.getByRole("checkbox", { name: /select all/i }).click();
+
+    await page.locator('[data-index="0"]').click({ button: "right" });
+    await page.getByTestId("playlist-create").click(); // label: "Create playlist (2)"
+
+    // Fill the create dialog and submit.
+    await page.getByLabel("Title").fill("My Mix");
+
+    const postPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "POST" &&
+        req.url() === "https://api.soundcloud.com/playlists",
+    );
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+    const post = await postPromise;
+
+    const urns = (
+      post.postDataJSON() as { playlist: { tracks: { urn: string }[] } }
+    ).playlist.tracks.map((t) => t.urn);
+    expect(urns).toEqual(["soundcloud:tracks:42", "soundcloud:tracks:99"]);
+
+    await expect(page.getByText('Playlist "My Mix" created')).toBeVisible();
+    // Sidebar refetched and now shows the new playlist node.
+    await expect(page.getByRole("button", { name: /My Mix/ })).toBeVisible();
+  });
+});

--- a/frontend/e2e/soundcloud-playlist-manage.spec.ts
+++ b/frontend/e2e/soundcloud-playlist-manage.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Right-click a playlist node in the sidebar (own playlists / "me" tab) to
+ * rename or delete it. Both write to SoundCloud (PUT title / DELETE) and the
+ * sidebar refreshes via the shared playlist reload.
+ */
+
+function baseRoutes(page: import("@playwright/test").Page) {
+  return Promise.all([
+    page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    ),
+    page.route("https://api.soundcloud.com/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      }),
+    ),
+    page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    ),
+    page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      }),
+    ),
+    page.route("**/api/bpm/soundcloud/bulk", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ bpms: {} }),
+      }),
+    ),
+    page.route("**/api/settings/root-folder", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ root_music_folder: "/music" }),
+      }),
+    ),
+  ]);
+}
+
+/** Auth + a pre-expanded "Playlists" sidebar group so playlist nodes show. */
+function initState(page: import("@playwright/test").Page) {
+  return page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({ id: 1, username: "me", permalink: "me" }),
+    );
+    window.localStorage.setItem(
+      "tree-panel-expanded:library:soundcloud:me",
+      JSON.stringify(["playlists"]),
+    );
+  });
+}
+
+test.describe("soundcloud playlist sidebar management", () => {
+  test("renames a playlist from its sidebar context menu", async ({ page }) => {
+    await initState(page);
+    await baseRoutes(page);
+
+    // Server keeps returning the OLD title (SoundCloud's list is eventually
+    // consistent) — the sidebar must reflect the rename optimistically.
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          collection: [
+            {
+              urn: "soundcloud:playlists:100",
+              title: "My Set",
+              track_count: 3,
+            },
+          ],
+          next_href: null,
+        }),
+      }),
+    );
+    await page.route("https://api.soundcloud.com/playlists/**", (route) => {
+      const req = route.request();
+      if (req.method() === "PUT") {
+        const body = req.postDataJSON() as { playlist: { title?: string } };
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            urn: "soundcloud:playlists:100",
+            title: body.playlist.title ?? "My Set",
+          }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    await page.goto("/library?source=soundcloud");
+    const node = page.getByRole("button", { name: /My Set/ });
+    await expect(node).toBeVisible({ timeout: 5000 });
+
+    await node.click({ button: "right" });
+    await page.getByTestId("playlist-rename").click();
+
+    await page.getByLabel("Title").fill("Renamed Set");
+    const putPromise = page.waitForRequest(
+      (req) =>
+        req.method() === "PUT" &&
+        req.url().includes("/playlists/") &&
+        !req.url().includes("/tracks"),
+    );
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    const put = await putPromise;
+
+    expect(
+      (put.postDataJSON() as { playlist: { title: string } }).playlist.title,
+    ).toBe("Renamed Set");
+
+    // Sidebar refetches and shows the new name.
+    await expect(
+      page.getByRole("button", { name: /Renamed Set/ }),
+    ).toBeVisible();
+  });
+
+  test("deletes a playlist from its sidebar context menu", async ({ page }) => {
+    await initState(page);
+    await baseRoutes(page);
+
+    // Server keeps returning the playlist even after DELETE (SoundCloud's list
+    // is eventually consistent) — the sidebar must drop it optimistically.
+    await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          collection: [
+            {
+              urn: "soundcloud:playlists:100",
+              title: "My Set",
+              track_count: 3,
+            },
+          ],
+          next_href: null,
+        }),
+      }),
+    );
+    // Delete is proxied through the backend (SoundCloud blocks DELETE via CORS).
+    await page.route("**/api/soundcloud/playlists/*", (route) => {
+      if (route.request().method() === "DELETE") {
+        return route.fulfill({ status: 204, body: "" });
+      }
+      return route.fallback();
+    });
+
+    await page.goto("/library?source=soundcloud");
+    const node = page.getByRole("button", { name: /My Set/ });
+    await expect(node).toBeVisible({ timeout: 5000 });
+
+    await node.click({ button: "right" });
+    await page.getByTestId("playlist-delete").click();
+
+    const deletePromise = page.waitForRequest(
+      (req) =>
+        req.method() === "DELETE" &&
+        req.url().includes("/api/soundcloud/playlists/"),
+    );
+    await page.getByTestId("playlist-delete-confirm").click();
+    await deletePromise;
+
+    // Sidebar refetches; the node is gone.
+    await expect(page.getByRole("button", { name: /My Set/ })).toHaveCount(0);
+  });
+});

--- a/frontend/src/app/library/likes-tree-panel.tsx
+++ b/frontend/src/app/library/likes-tree-panel.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useMemo } from "react";
 
+import { PlaylistNodeMenu } from "@/components/playlist-node-menu";
 import { TreeView } from "@/components/tree/tree-view";
 import type { SourceProfile } from "@/lib/profile-groups";
 import type { SCPlaylist } from "@/lib/soundcloud";
@@ -82,6 +83,12 @@ interface LikesTreePanelProps {
    * member's playlists. Falls through to the flat `playlists` list when
    * absent or single-member. */
   playlistsByMember?: Array<{ source: SourceProfile; playlists: SCPlaylist[] }>;
+  /** When true, right-clicking a playlist node offers rename/delete. Only pass
+   *  for the user's own playlists (the "me" tab). */
+  editable?: boolean;
+  /** Called after a playlist is deleted, so the caller can navigate away if it
+   *  was the one being viewed. */
+  onPlaylistDeleted?: (urn: string) => void;
 }
 
 export function LikesTreePanel({
@@ -98,6 +105,8 @@ export function LikesTreePanel({
   perMixFilteredCount,
   showMixes,
   playlistsByMember,
+  editable,
+  onPlaylistDeleted,
 }: LikesTreePanelProps) {
   const tree = useMemo<LikesTreeNode>(() => {
     const toPlaylistNode = (pl: SCPlaylist, idx: number): LikesTreeNode => {
@@ -203,6 +212,21 @@ export function LikesTreePanel({
       onSelect={onSelect}
       storageKey={storageKey}
       hideRoot
+      wrapNode={
+        editable
+          ? (node, row) =>
+              node.kind === "playlist" && node.playlist?.urn ? (
+                <PlaylistNodeMenu
+                  playlist={node.playlist}
+                  onDeleted={onPlaylistDeleted}
+                >
+                  {row}
+                </PlaylistNodeMenu>
+              ) : (
+                row
+              )
+          : undefined
+      }
       renderIcon={(node) => {
         if (node.kind === "likes") {
           return <Heart className="text-muted-foreground size-3.5 shrink-0" />;

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -680,6 +680,10 @@ export function SoundcloudView() {
             mixes={mixes}
             perMixFilteredCount={perMixCount}
             showMixes={tab === "me"}
+            editable={tab === "me"}
+            onPlaylistDeleted={(urn) => {
+              if (nodeId === playlistNodeId(urn)) setNodeId(LIKES_NODE_ID);
+            }}
           />
         )}
 
@@ -694,6 +698,7 @@ export function SoundcloudView() {
             mixTracks={mixTracks}
             nodeId={nodeId ?? LIKES_NODE_ID}
             isPlaylistView={isPlaylistView}
+            selectedPlaylistUrn={selectedPlaylist?.urn ?? null}
             isAllPlaylistsView={isAllPlaylistsView}
             isMixView={isMixView}
             isMixesGroupView={isMixesGroupView}
@@ -729,6 +734,9 @@ interface LikesViewProps {
   mixTracks: ReturnType<typeof useSystemPlaylistTracks>;
   nodeId: string;
   isPlaylistView: boolean;
+  /** URN of the playlist currently being viewed (null unless in a playlist
+   *  node). Non-null + tab "me" ⇒ an editable, owned playlist. */
+  selectedPlaylistUrn: string | null;
   isAllPlaylistsView: boolean;
   isMixView: boolean;
   isMixesGroupView: boolean;
@@ -761,6 +769,7 @@ function LikesView({
   mixTracks,
   nodeId,
   isPlaylistView,
+  selectedPlaylistUrn,
   isAllPlaylistsView,
   isMixView,
   isMixesGroupView,
@@ -784,7 +793,15 @@ function LikesView({
 
   const columnPrefs = useColumnPrefs("library.soundcloud", LIKES_COLUMN_DEFS);
 
-  const sourceTracks = isMixView
+  // Optimistic "removed from playlist" set — a removed row disappears at once,
+  // before the playlist re-fetch. Cleared whenever the viewed node changes.
+  const [removedUrns, setRemovedUrns] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset optimistic removals when the viewed node changes
+    setRemovedUrns(new Set());
+  }, [nodeId]);
+
+  const baseTracks = isMixView
     ? mixTracks.tracks
     : isPlaylistView
       ? playlistTracks.tracks
@@ -795,6 +812,23 @@ function LikesView({
           : isTracksView
             ? (activeTracks?.tracks ?? EMPTY_TRACKS)
             : activeLikes.tracks;
+  const sourceTracks = useMemo(
+    () =>
+      removedUrns.size === 0
+        ? baseTracks
+        : baseTracks.filter((t) => !t.urn || !removedUrns.has(t.urn)),
+    [baseTracks, removedUrns],
+  );
+
+  // Editable when viewing one of the user's OWN playlists (tab "me").
+  const removeFromPlaylist =
+    tab === "me" && isPlaylistView && selectedPlaylistUrn
+      ? {
+          playlistUrn: selectedPlaylistUrn,
+          onRemoved: (urn: string) =>
+            setRemovedUrns((prev) => new Set(prev).add(urn)),
+        }
+      : undefined;
 
   const { filteredTracks } = useLikesFilter(
     sourceTracks,
@@ -1080,6 +1114,8 @@ function LikesView({
             columnWidths={columnPrefs.prefs.widths}
             onColumnWidthChange={columnPrefs.setWidth}
             onColumnWidthReset={columnPrefs.resetWidth}
+            showAddToPlaylist
+            removeFromPlaylist={removeFromPlaylist}
           />
         )}
 

--- a/frontend/src/app/library/use-playlist-tracks.ts
+++ b/frontend/src/app/library/use-playlist-tracks.ts
@@ -16,6 +16,14 @@ function getCached(urn: string): SCTrack[] | null {
   return entry.tracks;
 }
 
+/** Drop a playlist's cached track list so the next fetch is fresh. Call after
+ *  mutating the playlist (add/remove) so membership checks and the playlist
+ *  view re-read the real contents. */
+export function invalidatePlaylistTracks(urn: string) {
+  cache.delete(urn);
+  inflight.delete(urn);
+}
+
 /**
  * Fetches all tracks for a playlist, paginating through all pages.
  * Results are cached per-urn for CACHE_TTL; concurrent callers share the

--- a/frontend/src/app/library/use-user-playlists.ts
+++ b/frontend/src/app/library/use-user-playlists.ts
@@ -17,8 +17,42 @@ interface UseUserPlaylistsResult {
 const CACHE_TTL = 5 * 60 * 1000;
 const cache = new Map<string, { playlists: SCPlaylist[]; fetchedAt: number }>();
 
+// Cross-instance reload: the sidebar tree and the tracks table each mount their
+// own useUserPlaylists. When one mutates playlists (create/add/remove), every
+// mounted instance must refetch — otherwise the sidebar goes stale. Subscribers
+// are notified to bump their reload key.
+const subscribers = new Set<() => void>();
+
 function cacheKey(userUrn: string | "me" | null) {
   return userUrn ?? "";
+}
+
+/** Invalidate the cached playlists for `userUrn` and refresh every mounted
+ *  useUserPlaylists (e.g. after creating a playlist — a refetch picks it up). */
+export function reloadUserPlaylists(userUrn: string | "me" | null) {
+  if (userUrn) cache.delete(cacheKey(userUrn));
+  subscribers.forEach((fn) => fn());
+}
+
+/**
+ * Apply an optimistic edit to the cached playlists for `userUrn` and refresh
+ * every mounted useUserPlaylists — without refetching. Use for delete/rename:
+ * SoundCloud's GET /me/playlists is eventually consistent and can still return
+ * a just-deleted (or just-renamed) playlist, so a refetch would show stale
+ * data until it propagates.
+ */
+export function mutateCachedUserPlaylists(
+  userUrn: string | "me" | null,
+  updater: (playlists: SCPlaylist[]) => SCPlaylist[],
+) {
+  const entry = cache.get(cacheKey(userUrn));
+  if (entry) {
+    cache.set(cacheKey(userUrn), {
+      playlists: updater(entry.playlists),
+      fetchedAt: entry.fetchedAt,
+    });
+  }
+  subscribers.forEach((fn) => fn());
 }
 
 export function useUserPlaylists(
@@ -30,18 +64,25 @@ export function useUserPlaylists(
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
+    const bump = () => setReloadKey((k) => k + 1);
+    subscribers.add(bump);
+    return () => {
+      subscribers.delete(bump);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!userUrn) {
       setPlaylists([]);
       return;
     }
 
+    // A reload deletes the cache entry (see reloadUserPlaylists) and bumps
+    // reloadKey to re-run this effect, so a surviving fresh entry means nothing
+    // changed for this user — reuse it rather than refetch.
     const key = cacheKey(userUrn);
     const cached = cache.get(key);
-    if (
-      cached &&
-      Date.now() - cached.fetchedAt < CACHE_TTL &&
-      reloadKey === 0
-    ) {
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
       setPlaylists(cached.playlists);
       setLoading(false);
       setError(null);
@@ -94,9 +135,6 @@ export function useUserPlaylists(
     playlists,
     loading,
     error,
-    reload: () => {
-      if (userUrn) cache.delete(cacheKey(userUrn));
-      setReloadKey((k) => k + 1);
-    },
+    reload: () => reloadUserPlaylists(userUrn),
   };
 }

--- a/frontend/src/components/create-playlist-dialog.tsx
+++ b/frontend/src/components/create-playlist-dialog.tsx
@@ -18,7 +18,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { createPlaylist, type SCTrack } from "@/lib/soundcloud";
+import {
+  createPlaylist,
+  type SCPlaylist,
+  type SCTrack,
+} from "@/lib/soundcloud";
 
 export const MAX_TRACKS = 500;
 
@@ -27,7 +31,7 @@ interface CreatePlaylistDialogProps {
   trigger?: React.ReactNode;
   defaultTitle?: string;
   defaultDescription?: string;
-  onCreated?: () => void;
+  onCreated?: (playlist: SCPlaylist) => void;
   /** Optional controlled open state — lets the dialog be opened from code
    * paths that don't render the trigger (e.g. command palette). */
   open?: boolean;
@@ -82,7 +86,7 @@ export function CreatePlaylistDialog({
       });
       const url = (playlist as Record<string, unknown>).permalink_url as
         string | undefined;
-      onCreated?.();
+      onCreated?.(playlist);
       setOpen(false);
       toast.success(`Playlist "${title.trim()}" created`, {
         action: url

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -23,25 +23,42 @@ import {
   Download,
   FolderCheck,
   GripVertical,
+  ListPlus,
+  ListX,
   Search,
   ShoppingCart,
 } from "lucide-react";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 
+import {
+  fetchAllPlaylistTracks,
+  invalidatePlaylistTracks,
+} from "@/app/library/use-playlist-tracks";
+import {
+  mutateCachedUserPlaylists,
+  useUserPlaylists,
+} from "@/app/library/use-user-playlists";
 import { CoverPlayButton } from "@/components/cover-play-button";
+import { CreatePlaylistDialog } from "@/components/create-playlist-dialog";
 import {
   SoundcloudBpmCacheContext,
   SoundcloudBpmCell,
 } from "@/components/soundcloud-bpm-cell";
 import { SoundcloudLikeButton } from "@/components/soundcloud-like-button";
 import { SourceProfileAvatar } from "@/components/source-profile-avatar";
+import {
+  TrackPlaylistSubmenu,
+  type AddToPlaylistResult,
+} from "@/components/track-playlist-submenu";
 import { TrackQueueMenu } from "@/components/track-queue-menu";
 import {
   TrackTable,
   type TrackTableColumn,
 } from "@/components/track-table/track-table";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ContextMenuItem } from "@/components/ui/context-menu";
 import {
   Popover,
   PopoverContent,
@@ -59,7 +76,12 @@ import { parseFallbackDownloadUrl } from "@/lib/parse-fallback-download";
 import { usePlayer, type PlayerTrack } from "@/lib/player-context";
 import type { SourceProfile } from "@/lib/profile-groups";
 import { useIsScUnplayable } from "@/lib/sc-unplayable";
-import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
+import {
+  addTracksToPlaylist,
+  parseSCTimestamp,
+  type SCPlaylist,
+  type SCTrack,
+} from "@/lib/soundcloud";
 import {
   getCachedSoundcloudPeaks,
   getCachedSoundcloudStreamUrl,
@@ -572,6 +594,25 @@ interface TrackRowProps {
   onAddToQueue: () => void;
   /** Insert this track right after the current one. */
   onPlayNext: () => void;
+  /** When set, the row's context menu gains "Add to playlist" (submenu of the
+   *  user's own playlists) and "Create playlist" (SoundCloud view only).
+   *  `createCount` is how many tracks the create action would use — the current
+   *  checkbox selection when this row is part of it, otherwise just this row. */
+  addToPlaylist?: {
+    trackUrns: string[];
+    playlists: SCPlaylist[];
+    loading: boolean;
+    onAdd: (playlist: SCPlaylist) => Promise<AddToPlaylistResult>;
+    createCount: number;
+    onCreatePlaylist: () => void;
+  };
+  /** When set, the row's context menu gains a "Remove from playlist" item
+   *  (shown only when viewing one of the user's own playlists). Acts on the
+   *  selection when this row is part of it; `count` is how many. */
+  removeFromPlaylist?: {
+    count: number;
+    onRemove: () => void;
+  };
   /** Columns filtered and ordered per user preferences, with resolved widths. */
   visibleColumns: ResolvedLikesCol[];
   /** When set, the row renders a drag handle and participates in SortableContext. */
@@ -594,6 +635,8 @@ function TrackRowInner({
   onStartPlay,
   onAddToQueue,
   onPlayNext,
+  addToPlaylist,
+  removeFromPlaylist,
   visibleColumns,
   dragHandle,
 }: TrackRowProps) {
@@ -632,6 +675,45 @@ function TrackRowInner({
       onPlayNext={onPlayNext}
       onAddToQueue={onAddToQueue}
       disabled={unplayable}
+      extraItems={
+        addToPlaylist || removeFromPlaylist ? (
+          <>
+            {addToPlaylist && (
+              <>
+                <TrackPlaylistSubmenu
+                  trackUrns={addToPlaylist.trackUrns}
+                  playlists={addToPlaylist.playlists}
+                  loading={addToPlaylist.loading}
+                  onAdd={addToPlaylist.onAdd}
+                />
+                <ContextMenuItem
+                  data-testid="playlist-create"
+                  onSelect={addToPlaylist.onCreatePlaylist}
+                  className="text-xs"
+                >
+                  <ListPlus className="size-3.5" />
+                  {addToPlaylist.createCount > 1
+                    ? `Create playlist (${addToPlaylist.createCount})`
+                    : "Create playlist"}
+                </ContextMenuItem>
+              </>
+            )}
+            {removeFromPlaylist && (
+              <ContextMenuItem
+                data-testid="playlist-remove"
+                variant="destructive"
+                onSelect={removeFromPlaylist.onRemove}
+                className="text-xs"
+              >
+                <ListX className="size-3.5" />
+                {removeFromPlaylist.count > 1
+                  ? `Remove from playlist (${removeFromPlaylist.count})`
+                  : "Remove from playlist"}
+              </ContextMenuItem>
+            )}
+          </>
+        ) : undefined
+      }
     >
       <div>
         <div
@@ -782,6 +864,17 @@ interface LikesTableProps {
   /** Reports the current *visible* URN order (after sort). Fires whenever
    *  the sorted display changes so callers can save whatever the user sees. */
   onVisibleOrderChange?: (orderedUrns: string[]) => void;
+  /** Opt-in: add an "Add to playlist" submenu to each row's context menu,
+   *  targeting the authenticated user's own SoundCloud playlists. */
+  showAddToPlaylist?: boolean;
+  /** When set, each row's context menu gains "Remove from playlist" acting on
+   *  this playlist. Only pass when viewing one of the user's own playlists.
+   *  `onRemoved` fires after a successful remove so the caller can drop the
+   *  row from the displayed list. */
+  removeFromPlaylist?: {
+    playlistUrn: string;
+    onRemoved: (trackUrn: string) => void;
+  };
 }
 
 export function LikesTable({
@@ -802,10 +895,123 @@ export function LikesTable({
   onColumnWidthReset,
   onReorderTracks,
   onVisibleOrderChange,
+  showAddToPlaylist,
+  removeFromPlaylist,
 }: LikesTableProps) {
   const reorderEnabled = !!onReorderTracks;
   const { playQueue, currentTrack, reconcileUpcoming, enqueue, playNext } =
     usePlayer();
+
+  // "Add to playlist" submenu (SoundCloud view only). The user's own playlists
+  // are shared with the SoundCloud view's list via a module-level cache, so
+  // this is a cache hit rather than a second fetch.
+  const {
+    playlists: myPlaylists,
+    loading: playlistsLoading,
+    reload: reloadPlaylists,
+  } = useUserPlaylists(showAddToPlaylist ? "me" : null);
+  const handleAddToPlaylist = useCallback(
+    async (
+      playlist: SCPlaylist,
+      tracksToAdd: SCTrack[],
+    ): Promise<AddToPlaylistResult> => {
+      if (!playlist.urn) return "error";
+      const targetUrns = tracksToAdd
+        .map((t) => t.urn)
+        .filter((u): u is string => u != null);
+      if (targetUrns.length === 0) return "error";
+      try {
+        // SoundCloud's playlist PUT *replaces* the track set, so read the
+        // existing tracks first (cached, shared with the playlist view) and
+        // append to them — the playlist metadata carries no tracks.
+        const existing = await fetchAllPlaylistTracks(playlist.urn);
+        const existingUrns = existing
+          .map((t) => t.urn)
+          .filter((u): u is string => u != null);
+        const existingSet = new Set(existingUrns);
+        const toAdd = targetUrns.filter((u) => !existingSet.has(u));
+        if (toAdd.length === 0) {
+          toast.info(
+            targetUrns.length === 1
+              ? `Already in "${playlist.title}"`
+              : `All ${targetUrns.length} tracks already in "${playlist.title}"`,
+          );
+          return "exists";
+        }
+        const updated = await addTracksToPlaylist(playlist.urn, [
+          ...existingUrns,
+          ...toAdd,
+        ]);
+        invalidatePlaylistTracks(playlist.urn);
+        reloadPlaylists();
+        const url = (updated as Record<string, unknown>).permalink_url as
+          string | undefined;
+        toast.success(
+          toAdd.length === 1
+            ? `Added to "${playlist.title}"`
+            : `Added ${toAdd.length} tracks to "${playlist.title}"`,
+          {
+            action: url
+              ? { label: "Open", onClick: () => window.open(url, "_blank") }
+              : undefined,
+          },
+        );
+        return "added";
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to add to playlist",
+        );
+        return "error";
+      }
+    },
+    [reloadPlaylists],
+  );
+
+  // "Remove from playlist" — only wired when the caller is viewing one of the
+  // user's own playlists (see the `removeFromPlaylist` prop). Reads the current
+  // track set, drops the target, and writes the rest back.
+  const removePlaylistUrn = removeFromPlaylist?.playlistUrn;
+  const notifyRemoved = removeFromPlaylist?.onRemoved;
+  const handleRemoveFromPlaylist = useCallback(
+    async (tracksToRemove: SCTrack[]) => {
+      if (!removePlaylistUrn) return;
+      const targetUrns = tracksToRemove
+        .map((t) => t.urn)
+        .filter((u): u is string => u != null);
+      if (targetUrns.length === 0) return;
+      const targetSet = new Set(targetUrns);
+      try {
+        const existing = await fetchAllPlaylistTracks(removePlaylistUrn);
+        const kept = existing
+          .map((t) => t.urn)
+          .filter((u): u is string => u != null && !targetSet.has(u));
+        await addTracksToPlaylist(removePlaylistUrn, kept);
+        invalidatePlaylistTracks(removePlaylistUrn);
+        targetUrns.forEach((u) => notifyRemoved?.(u));
+        reloadPlaylists();
+        toast.success(
+          targetUrns.length === 1
+            ? `Removed "${tracksToRemove[0].title ?? "track"}" from playlist`
+            : `Removed ${targetUrns.length} tracks from playlist`,
+        );
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to remove from playlist",
+        );
+      }
+    },
+    [removePlaylistUrn, notifyRemoved, reloadPlaylists],
+  );
+
+  // "Create playlist" from the row context menu. Seeded with the tracks chosen
+  // at right-click time (selection or single row) and rendered once below.
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createTracks, setCreateTracks] = useState<SCTrack[]>([]);
+  const openCreatePlaylist = useCallback((tracksForPlaylist: SCTrack[]) => {
+    setCreateTracks(tracksForPlaylist);
+    setCreateDialogOpen(true);
+  }, []);
+
   // Mirror the current track into a ref so the reconcile effect can read it
   // without making it a dependency — otherwise reconciling (which changes
   // `currentTrack`'s reference) would re-trigger the effect and loop. This
@@ -920,6 +1126,13 @@ export function LikesTable({
     });
     return sorted;
   }, [tracks, sortBy, sortOrder]);
+
+  // Tracks currently checkbox-selected — the "Create playlist" context action
+  // uses these when the right-clicked row is part of the selection.
+  const selectedTracks = useMemo(
+    () => sortedTracks.filter((t) => selectedIds.has(extractId(t))),
+    [sortedTracks, selectedIds],
+  );
 
   // Row reordering is only active when no column sort is applied — otherwise
   // the user's drag target (sorted position) wouldn't map to a meaningful
@@ -1108,6 +1321,10 @@ export function LikesTable({
             return { ...lc, width: col.width };
           })
           .filter((v): v is ResolvedLikesCol => v !== null);
+        // Tracks the playlist actions operate on: the checkbox selection when
+        // this row is part of it, otherwise just this row.
+        const rowTargets =
+          id != null && selectedIds.has(id) ? selectedTracks : [track];
         return (
           <TrackRow
             sortableId={sortableId}
@@ -1141,6 +1358,31 @@ export function LikesTable({
             onStartPlay={() => handleStartPlay(index)}
             onAddToQueue={() => enqueue(scTrackToPlayerTrack(track, bpmCache))}
             onPlayNext={() => playNext(scTrackToPlayerTrack(track, bpmCache))}
+            addToPlaylist={
+              showAddToPlaylist
+                ? {
+                    // Act on the whole checkbox selection when this row is part
+                    // of it, otherwise just this row.
+                    trackUrns: rowTargets
+                      .map((t) => t.urn)
+                      .filter((u): u is string => u != null),
+                    playlists: myPlaylists,
+                    loading: playlistsLoading,
+                    onAdd: (playlist) =>
+                      handleAddToPlaylist(playlist, rowTargets),
+                    createCount: rowTargets.length,
+                    onCreatePlaylist: () => openCreatePlaylist(rowTargets),
+                  }
+                : undefined
+            }
+            removeFromPlaylist={
+              removeFromPlaylist
+                ? {
+                    count: rowTargets.length,
+                    onRemove: () => handleRemoveFromPlaylist(rowTargets),
+                  }
+                : undefined
+            }
             visibleColumns={rowCols}
           />
         );
@@ -1192,6 +1434,16 @@ export function LikesTable({
         </DndContext>
       ) : (
         table
+      )}
+      {showAddToPlaylist && (
+        <CreatePlaylistDialog
+          tracks={createTracks}
+          open={createDialogOpen}
+          onOpenChange={setCreateDialogOpen}
+          onCreated={(playlist) =>
+            mutateCachedUserPlaylists("me", (pls) => [playlist, ...pls])
+          }
+        />
       )}
     </SoundcloudBpmCacheContext.Provider>
   );

--- a/frontend/src/components/playlist-node-menu.tsx
+++ b/frontend/src/components/playlist-node-menu.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { mutateCachedUserPlaylists } from "@/app/library/use-user-playlists";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  deletePlaylist,
+  renamePlaylist,
+  type SCPlaylist,
+} from "@/lib/soundcloud";
+
+/**
+ * Right-click wrapper for one of the user's own playlist nodes in the sidebar:
+ * "Rename" (inline dialog) and "Delete" (confirm). Both write to SoundCloud,
+ * then refresh every mounted playlist list via reloadUserPlaylists. `onDeleted`
+ * lets the caller navigate away if the deleted playlist was being viewed.
+ */
+export function PlaylistNodeMenu({
+  playlist,
+  onDeleted,
+  children,
+}: {
+  playlist: SCPlaylist;
+  onDeleted?: (urn: string) => void;
+  children: React.ReactNode;
+}) {
+  const urn = playlist.urn;
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [title, setTitle] = useState(playlist.title ?? "");
+  const [busy, setBusy] = useState(false);
+
+  async function handleRename() {
+    const next = title.trim();
+    if (!urn || !next) return;
+    if (next === (playlist.title ?? "")) {
+      setRenameOpen(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      await renamePlaylist(urn, next);
+      mutateCachedUserPlaylists("me", (pls) =>
+        pls.map((p) => (p.urn === urn ? { ...p, title: next } : p)),
+      );
+      setRenameOpen(false);
+      toast.success(`Renamed to "${next}"`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to rename playlist",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!urn) return;
+    setBusy(true);
+    try {
+      await deletePlaylist(urn);
+      mutateCachedUserPlaylists("me", (pls) =>
+        pls.filter((p) => p.urn !== urn),
+      );
+      setDeleteOpen(false);
+      onDeleted?.(urn);
+      toast.success(`Deleted "${playlist.title ?? "playlist"}"`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to delete playlist",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+        <ContextMenuContent className="w-40">
+          <ContextMenuItem
+            data-testid="playlist-rename"
+            className="text-xs"
+            onSelect={() => {
+              setTitle(playlist.title ?? "");
+              setRenameOpen(true);
+            }}
+          >
+            <Pencil className="size-3.5" />
+            Rename
+          </ContextMenuItem>
+          <ContextMenuItem
+            data-testid="playlist-delete"
+            variant="destructive"
+            className="text-xs"
+            onSelect={() => setDeleteOpen(true)}
+          >
+            <Trash2 className="size-3.5" />
+            Delete
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename playlist</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="rename-playlist-title">Title</Label>
+            <Input
+              id="rename-playlist-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRename();
+              }}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button onClick={handleRename} disabled={busy || !title.trim()}>
+              {busy ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete “{playlist.title ?? "playlist"}”?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the playlist on SoundCloud. The tracks
+              themselves are not affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="playlist-delete-confirm"
+              onClick={(e) => {
+                e.preventDefault();
+                handleDelete();
+              }}
+              disabled={busy}
+            >
+              {busy ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/components/track-playlist-submenu.tsx
+++ b/frontend/src/components/track-playlist-submenu.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { Check, ListMusic, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { fetchAllPlaylistTracks } from "@/app/library/use-playlist-tracks";
+import {
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+} from "@/components/ui/context-menu";
+import type { SCPlaylist } from "@/lib/soundcloud";
+
+export type AddToPlaylistResult = "added" | "exists" | "error";
+
+/**
+ * Resolve which of `playlists` already contain *every* target track. Only runs
+ * while `active` (the submenu is open) to avoid fetching every playlist's
+ * tracks for every rendered row. SoundCloud has no reverse "playlists
+ * containing track X" endpoint, so this reads each playlist's track list
+ * (cached per-urn, shared with the playlist navigation view).
+ */
+function usePlaylistMembership(
+  trackUrns: string[],
+  playlists: SCPlaylist[],
+  active: boolean,
+) {
+  const [memberUrns, setMemberUrns] = useState<Set<string>>(new Set());
+  const key = trackUrns.join("|");
+
+  useEffect(() => {
+    if (!active || trackUrns.length === 0 || playlists.length === 0) return;
+    let cancelled = false;
+    Promise.all(
+      playlists.map(async (pl) => {
+        if (!pl.urn) return null;
+        try {
+          const tracks = await fetchAllPlaylistTracks(pl.urn);
+          const has = new Set(tracks.map((t) => t.urn));
+          return trackUrns.every((u) => has.has(u)) ? pl.urn : null;
+        } catch {
+          return null;
+        }
+      }),
+    ).then((results) => {
+      if (cancelled) return;
+      setMemberUrns(new Set(results.filter((u): u is string => u != null)));
+    });
+    return () => {
+      cancelled = true;
+    };
+    // trackUrns is captured via its joined `key`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, key, playlists]);
+
+  return memberUrns;
+}
+
+/**
+ * "Add to playlist ▸" context-menu submenu listing the user's own SoundCloud
+ * playlists. Acts on `trackUrns` — the current checkbox selection when the
+ * right-clicked row is part of it, otherwise just that row; the trigger shows
+ * the count. Playlists already containing every target track show a check and
+ * are disabled; selecting an eligible one calls `onAdd` (which owns the network
+ * write and toast). The submenu stays open on select so the spinner and the
+ * flip-to-checked feedback are visible.
+ */
+export function TrackPlaylistSubmenu({
+  trackUrns,
+  playlists,
+  loading,
+  onAdd,
+}: {
+  trackUrns: string[];
+  playlists: SCPlaylist[];
+  loading: boolean;
+  onAdd: (playlist: SCPlaylist) => Promise<AddToPlaylistResult>;
+}) {
+  const [open, setOpen] = useState(false);
+  const memberUrns = usePlaylistMembership(trackUrns, playlists, open);
+  // Playlists this selection was just added to — reflected immediately without
+  // waiting for a re-fetch. Reset when the target set changes.
+  const [optimistic, setOptimistic] = useState<Set<string>>(new Set());
+  const [pendingUrn, setPendingUrn] = useState<string | null>(null);
+  const key = trackUrns.join("|");
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset optimistic adds when the target set changes
+    setOptimistic(new Set());
+  }, [key]);
+
+  const count = trackUrns.length;
+  const isMember = (urn?: string) =>
+    !!urn && (memberUrns.has(urn) || optimistic.has(urn));
+
+  async function handleSelect(playlist: SCPlaylist) {
+    const urn = playlist.urn;
+    if (!urn || pendingUrn || isMember(urn)) return;
+    setPendingUrn(urn);
+    const result = await onAdd(playlist);
+    if (result === "added" || result === "exists") {
+      setOptimistic((prev) => new Set(prev).add(urn));
+    }
+    setPendingUrn(null);
+  }
+
+  return (
+    <ContextMenuSub onOpenChange={setOpen}>
+      <ContextMenuSubTrigger
+        data-testid="playlist-add-trigger"
+        className="gap-2 text-xs"
+      >
+        <ListMusic className="size-3.5" />
+        {count > 1 ? `Add to playlist (${count})` : "Add to playlist"}
+      </ContextMenuSubTrigger>
+      <ContextMenuSubContent className="max-h-72 w-56 overflow-y-auto">
+        {loading ? (
+          <ContextMenuItem disabled className="text-xs">
+            Loading playlists…
+          </ContextMenuItem>
+        ) : playlists.length === 0 ? (
+          <ContextMenuItem disabled className="text-xs">
+            No playlists
+          </ContextMenuItem>
+        ) : (
+          playlists.map((playlist) => {
+            const member = isMember(playlist.urn);
+            return (
+              <ContextMenuItem
+                key={playlist.urn}
+                data-testid="playlist-add-item"
+                data-member={member ? "true" : undefined}
+                disabled={member || pendingUrn != null}
+                onSelect={(e) => {
+                  // Keep the menu open for spinner + checked feedback.
+                  e.preventDefault();
+                  handleSelect(playlist);
+                }}
+                className="text-xs"
+              >
+                {pendingUrn === playlist.urn ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : member ? (
+                  <Check className="size-3.5 text-[var(--brand)]" />
+                ) : (
+                  <ListMusic className="size-3.5" />
+                )}
+                <span className="truncate">{playlist.title}</span>
+              </ContextMenuItem>
+            );
+          })
+        )}
+      </ContextMenuSubContent>
+    </ContextMenuSub>
+  );
+}

--- a/frontend/src/components/track-queue-menu.tsx
+++ b/frontend/src/components/track-queue-menu.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 
@@ -14,23 +15,26 @@ import {
  * The parent supplies the actions (each view builds its own PlayerTrack and
  * calls the player context), so this component stays presentation-only.
  * `disabled` greys the items out for rows that can't be played (e.g. an
- * unresolved Rekordbox track).
+ * unresolved Rekordbox track). `extraItems`, when given, renders below a
+ * separator (the SoundCloud playlist actions).
  */
 export function TrackQueueMenu({
   onPlayNext,
   onAddToQueue,
   disabled = false,
+  extraItems,
   children,
 }: {
   onPlayNext: () => void;
   onAddToQueue: () => void;
   disabled?: boolean;
+  extraItems?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="w-40">
+      <ContextMenuContent className="w-44">
         <ContextMenuItem
           data-testid="queue-play-next"
           disabled={disabled}
@@ -49,6 +53,12 @@ export function TrackQueueMenu({
           <ListPlus className="size-3.5" />
           Add to queue
         </ContextMenuItem>
+        {extraItems && (
+          <>
+            <ContextMenuSeparator />
+            {extraItems}
+          </>
+        )}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/frontend/src/lib/soundcloud.ts
+++ b/frontend/src/lib/soundcloud.ts
@@ -165,6 +165,40 @@ export async function addTracksToPlaylist(
   return data as SCPlaylist;
 }
 
+export async function renamePlaylist(
+  playlistUrn: string,
+  title: string,
+): Promise<SCPlaylist> {
+  const client = await getClient();
+  const { data, error } = await client.PUT("/playlists/{playlist_urn}", {
+    params: { path: { playlist_urn: playlistUrn } },
+    body: { playlist: { title } },
+  });
+  if (error)
+    throw new Error(`Failed to rename playlist: ${JSON.stringify(error)}`);
+  return data as SCPlaylist;
+}
+
+// Delete goes through the backend: SoundCloud's public API doesn't expose
+// DELETE on /playlists in its CORS policy, so the browser can't call it
+// directly (it fails with a network "Load failed"). The backend forwards the
+// request with the user's token — same pattern as like/unlike.
+export async function deletePlaylist(playlistUrn: string): Promise<void> {
+  const token = await ensureValidToken();
+  const parts = playlistUrn.split(":");
+  const playlistId = parseInt(parts[parts.length - 1], 10);
+  if (!playlistId) throw new Error(`Invalid playlist urn: ${playlistUrn}`);
+  const base = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const resp = await fetch(`${base}/api/soundcloud/playlists/${playlistId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`Failed to delete playlist: ${resp.status} ${body}`);
+  }
+}
+
 export type SCTracks = components["schemas"]["Tracks"];
 
 export async function getMyLikedTracks(

--- a/tests/api/test_soundcloud_playlist_delete.py
+++ b/tests/api/test_soundcloud_playlist_delete.py
@@ -1,0 +1,86 @@
+"""Tests for the SoundCloud playlist-delete proxy endpoint.
+
+The browser can't DELETE a playlist directly (SoundCloud blocks the method in
+its CORS policy), so the backend forwards the request with the user's token.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api import soundcloud as soundcloud_api
+
+
+class _MockAsyncClient:
+    """Minimal async-context-manager stand-in for httpx.AsyncClient."""
+
+    def __init__(self, resp, recorder: list):
+        self._resp = resp
+        self._recorder = recorder
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def request(self, method, url, headers=None):
+        self._recorder.append((method, url, headers))
+        return self._resp
+
+
+def _resp(status_code: int):
+    return SimpleNamespace(
+        status_code=status_code,
+        is_success=200 <= status_code < 300,
+    )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(soundcloud_api.router)
+    return TestClient(app)
+
+
+def test_delete_playlist_forwards_to_soundcloud(client: TestClient) -> None:
+    calls: list = []
+    with patch.object(
+        soundcloud_api.httpx,
+        "AsyncClient",
+        lambda *a, **k: _MockAsyncClient(_resp(200), calls),
+    ):
+        resp = client.delete(
+            "/api/soundcloud/playlists/100",
+            headers={"Authorization": "Bearer tok"},
+        )
+
+    assert resp.status_code == 204
+    assert len(calls) == 1
+    method, url, headers = calls[0]
+    assert method == "DELETE"
+    assert url == "https://api.soundcloud.com/playlists/soundcloud:playlists:100"
+    assert headers["Authorization"] == "OAuth tok"
+
+
+def test_delete_playlist_requires_auth(client: TestClient) -> None:
+    resp = client.delete("/api/soundcloud/playlists/100")
+    assert resp.status_code == 401
+
+
+def test_delete_playlist_propagates_upstream_failure(client: TestClient) -> None:
+    with patch.object(
+        soundcloud_api.httpx,
+        "AsyncClient",
+        lambda *a, **k: _MockAsyncClient(_resp(404), []),
+    ):
+        resp = client.delete(
+            "/api/soundcloud/playlists/100",
+            headers={"Authorization": "Bearer tok"},
+        )
+    assert resp.status_code == 502


### PR DESCRIPTION
Right-click a track row to add the selection to a playlist, create a new one, or remove it from the current playlist; right-click a sidebar playlist to rename or delete it. Playlist mutations update the cached list optimistically so the sidebar stays in sync (SoundCloud's list GET is eventually consistent), and delete is proxied through the backend since SoundCloud blocks DELETE via CORS.

Test plan: `npm run test:e2e:fast` (playlist specs) + `uv run pytest tests/api/test_soundcloud_playlist_delete.py`