### PR TITLE
feat(soundcloud): New Today / New This Week smart lists

### DIFF
--- a/frontend/e2e/soundcloud-new-releases.spec.ts
+++ b/frontend/e2e/soundcloud-new-releases.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SoundCloud "New Today" / "New This Week" smart lists — flat nodes at the top
+ * of the library tree on the "me" tab. Both are fed by the personal followings
+ * feed (`/me/feed/tracks`, posts + reposts by people you follow) and narrowed
+ * to tracks whose own *release date* falls inside today / the current week.
+ *
+ * A track reposted today but released earlier must NOT appear — the window is
+ * on the track's release date, not when it surfaced on the feed.
+ */
+
+// Frozen "now": Wednesday 2025-06-18. Week starts the prior Sunday (2025-06-15).
+const NOW = "2025-06-18T15:00:00Z";
+
+const FEED = {
+  collection: [
+    {
+      type: "track",
+      created_at: "2025-06-18T09:00:00Z", // surfaced today
+      origin: {
+        id: 301,
+        urn: "soundcloud:tracks:301",
+        title: "Released Today Track",
+        created_at: "2025-06-18T09:00:00Z", // released today
+        user: { id: 30, username: "artist-a" },
+        duration: 200_000,
+        permalink_url: "https://soundcloud.com/a/today",
+        artwork_url: null,
+        genre: "House",
+      },
+    },
+    {
+      type: "track",
+      created_at: "2025-06-16T10:00:00Z", // surfaced Monday
+      origin: {
+        id: 302,
+        urn: "soundcloud:tracks:302",
+        title: "Released Monday Track",
+        created_at: "2025-06-16T10:00:00Z", // released Monday (this week, not today)
+        user: { id: 31, username: "artist-b" },
+        duration: 210_000,
+        permalink_url: "https://soundcloud.com/b/monday",
+        artwork_url: null,
+        genre: "Techno",
+      },
+    },
+    {
+      type: "track:repost",
+      created_at: "2025-06-18T08:00:00Z", // reposted today...
+      origin: {
+        id: 303,
+        urn: "soundcloud:tracks:303",
+        title: "Old Reposted Track",
+        created_at: "2025-06-05T10:00:00Z", // ...but released 13 days ago
+        user: { id: 32, username: "artist-c" },
+        duration: 220_000,
+        permalink_url: "https://soundcloud.com/c/old",
+        artwork_url: null,
+        genre: "House",
+      },
+    },
+  ],
+  next_href: null,
+};
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.clock.setFixedTime(new Date(NOW));
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route(/api\.soundcloud\.com\/me\/feed\/tracks/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(FEED),
+    }),
+  );
+
+  // Other "me"-tab sources fetched on load — keep them empty so only the feed
+  // drives the assertions.
+  for (const path of [
+    "https://api.soundcloud.com/me/likes/tracks*",
+    "https://api.soundcloud.com/me/reposts/tracks*",
+    "https://api.soundcloud.com/me/tracks*",
+    "https://api.soundcloud.com/me/playlists*",
+  ]) {
+    await page.route(path, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+  }
+  await page.route("**/api/soundcloud/system-playlists", (route) =>
+    route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "unavailable" }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/settings/root-folder", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ root_music_folder: "/music" }),
+    }),
+  );
+}
+
+test.describe("SoundCloud New Today / New This Week", () => {
+  test("filters feed releases by their own release date", async ({ page }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+
+    // Both smart nodes appear at the top of the tree on the "me" tab.
+    const newTodayRow = page.getByRole("button", { name: /^New Today/ });
+    const newWeekRow = page.getByRole("button", { name: /^New This Week/ });
+    await expect(newTodayRow).toBeVisible();
+    await expect(newWeekRow).toBeVisible();
+
+    // New Today → only the track released today.
+    await newTodayRow.click();
+    await expect(page.getByText("Released Today Track")).toBeVisible();
+    await expect(page.getByText("Released Monday Track")).toHaveCount(0);
+    await expect(page.getByText("Old Reposted Track")).toHaveCount(0);
+
+    // New This Week → today's + Monday's release, but not the 13-day-old track
+    // that only got reposted today.
+    await newWeekRow.click();
+    await expect(page.getByText("Released Today Track")).toBeVisible();
+    await expect(page.getByText("Released Monday Track")).toBeVisible();
+    await expect(page.getByText("Old Reposted Track")).toHaveCount(0);
+  });
+
+  test("smart nodes are absent on the Discover tab", async ({ page }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud&tab=discover");
+
+    await expect(page.getByRole("button", { name: /^New Today/ })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/frontend/src/app/library/likes-tree-panel.tsx
+++ b/frontend/src/app/library/likes-tree-panel.tsx
@@ -2,6 +2,8 @@
 
 import {
   AudioLines,
+  CalendarDays,
+  CalendarRange,
   Heart,
   ListMusic,
   Repeat2,
@@ -17,6 +19,8 @@ import type { SCPlaylist } from "@/lib/soundcloud";
 
 import type { SystemPlaylistSummary } from "./use-system-playlists";
 
+export const NEW_TODAY_NODE_ID = "new-today";
+export const NEW_WEEK_NODE_ID = "new-week";
 export const LIKES_NODE_ID = "likes";
 export const REPOSTS_NODE_ID = "reposts";
 export const TRACKS_NODE_ID = "tracks";
@@ -28,6 +32,8 @@ export const memberNodeId = (userUrn: string) => `member:${userUrn}`;
 
 export type LikesTreeNodeKind =
   | "root"
+  | "new-today"
+  | "new-week"
   | "likes"
   | "reposts"
   | "tracks"
@@ -51,6 +57,16 @@ interface LikesTreePanelProps {
   selectedId: string;
   onSelect: (id: string) => void;
   storageKey: string;
+  /** Filtered count for the "New Today" smart node (feed releases from today). */
+  newTodayCount: number;
+  /** Filtered count for the "New This Week" smart node. */
+  newWeekCount: number;
+  /**
+   * Whether the "New Today"/"New This Week" smart nodes should render. They
+   * are fed by the personal followings feed, so pass `true` on the "me" tab
+   * only.
+   */
+  showNew?: boolean;
   /** Filtered count for the Likes node. */
   likesCount: number;
   /** Filtered count for the Reposts node. */
@@ -96,6 +112,9 @@ export function LikesTreePanel({
   selectedId,
   onSelect,
   storageKey,
+  newTodayCount,
+  newWeekCount,
+  showNew,
   likesCount,
   repostsCount,
   tracksCount,
@@ -143,7 +162,28 @@ export function LikesTreePanel({
       mix: m,
     }));
 
-    const children: LikesTreeNode[] = [
+    const children: LikesTreeNode[] = [];
+    // Auto-filled smart lists sourced from the followings feed. Only on the
+    // "me" tab — the feed is personal, so they don't apply to Discover groups.
+    if (showNew) {
+      children.push(
+        {
+          id: NEW_TODAY_NODE_ID,
+          name: "New Today",
+          children: [],
+          kind: "new-today",
+          trackCount: newTodayCount,
+        },
+        {
+          id: NEW_WEEK_NODE_ID,
+          name: "New This Week",
+          children: [],
+          kind: "new-week",
+          trackCount: newWeekCount,
+        },
+      );
+    }
+    children.push(
       {
         id: LIKES_NODE_ID,
         name: "Likes",
@@ -165,7 +205,7 @@ export function LikesTreePanel({
         kind: "tracks",
         trackCount: tracksCount,
       },
-    ];
+    );
     // Always surface Mixes on tabs where it applies. When the user hasn't
     // connected yet we still render the group (empty) so the CTA in the
     // right-hand pane is reachable — hiding it would leave users who
@@ -194,6 +234,9 @@ export function LikesTreePanel({
     };
   }, [
     playlists,
+    newTodayCount,
+    newWeekCount,
+    showNew,
     likesCount,
     repostsCount,
     tracksCount,
@@ -228,6 +271,16 @@ export function LikesTreePanel({
           : undefined
       }
       renderIcon={(node) => {
+        if (node.kind === "new-today") {
+          return (
+            <CalendarDays className="text-muted-foreground size-3.5 shrink-0" />
+          );
+        }
+        if (node.kind === "new-week") {
+          return (
+            <CalendarRange className="text-muted-foreground size-3.5 shrink-0" />
+          );
+        }
         if (node.kind === "likes") {
           return <Heart className="text-muted-foreground size-3.5 shrink-0" />;
         }

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -50,15 +50,18 @@ import {
   type ProfileGroup,
   type ProfileGroupMember,
 } from "@/lib/profile-groups";
-import type { SCTrack } from "@/lib/soundcloud";
+import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
 import { cn } from "@/lib/utils";
 
+import { useFollowingsTracks } from "../weekly/use-followings-tracks";
 import { LibraryTitle } from "./library-title";
 import {
   LIKES_NODE_ID,
   LikesTreePanel,
   MIXES_GROUP_ID,
   mixNodeId,
+  NEW_TODAY_NODE_ID,
+  NEW_WEEK_NODE_ID,
   playlistNodeId,
   PLAYLISTS_GROUP_ID,
   REPOSTS_NODE_ID,
@@ -181,6 +184,55 @@ export function SoundcloudView() {
   const myLikes = useLikes("me");
   const myReposts = useReposts("me");
   const myTracks = useTracks("me");
+
+  // "New Today" / "New This Week" smart lists: tracks from the personal
+  // followings feed (posts + reposts by people you follow), narrowed to those
+  // whose own release date falls inside today / the current week. The feed is
+  // personal, so only fetch it on the "me" tab. A repost can't predate the
+  // track's release, so the feed hook's ~2-week activity window fully contains
+  // anything released this week — we just filter that set by release date.
+  const feed = useFollowingsTracks(tab === "me");
+  const { newTodayTracks, newWeekTracks } = useMemo(() => {
+    // Window anchored to "now" (UTC), matching the /weekly view's day math.
+    const now = new Date();
+    const startToday = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    );
+    const startWeek = startToday - now.getUTCDay() * 86_400_000; // prev Sunday
+    const today: SCTrack[] = [];
+    const week: SCTrack[] = [];
+    for (const track of feed.tracks) {
+      const released = parseSCTimestamp(track.created_at);
+      if (released == null) continue;
+      if (released >= startWeek) week.push(track);
+      if (released >= startToday) today.push(track);
+    }
+    return { newTodayTracks: today, newWeekTracks: week };
+  }, [feed.tracks]);
+  const newToday = useMemo(
+    () => ({
+      tracks: newTodayTracks,
+      loading: feed.loading,
+      hasMore: false,
+      loaded: newTodayTracks.length,
+      error: feed.error,
+      reload: feed.reload,
+    }),
+    [newTodayTracks, feed.loading, feed.error, feed.reload],
+  );
+  const newWeek = useMemo(
+    () => ({
+      tracks: newWeekTracks,
+      loading: feed.loading,
+      hasMore: false,
+      loaded: newWeekTracks.length,
+      error: feed.error,
+      reload: feed.reload,
+    }),
+    [newWeekTracks, feed.loading, feed.error, feed.reload],
+  );
   const groupLikes = useGroupLikes(tab === "discover" ? activeGroup : null);
   const groupReposts = useGroupReposts(tab === "discover" ? activeGroup : null);
   const groupTracks = useGroupTracks(tab === "discover" ? activeGroup : null);
@@ -309,6 +361,8 @@ export function SoundcloudView() {
   const isMixesGroupView = nodeId === MIXES_GROUP_ID;
   const isRepostsView = nodeId === REPOSTS_NODE_ID;
   const isTracksView = nodeId === TRACKS_NODE_ID;
+  const isNewTodayView = nodeId === NEW_TODAY_NODE_ID;
+  const isNewWeekView = nodeId === NEW_WEEK_NODE_ID;
 
   const selectedPlaylist = useMemo(() => {
     if (!isPlaylistView) return null;
@@ -436,6 +490,14 @@ export function SoundcloudView() {
   const repostsCount = useMemo(
     () => (activeReposts?.tracks ?? []).filter(filterPredicate).length,
     [activeReposts, filterPredicate],
+  );
+  const newTodayCount = useMemo(
+    () => newTodayTracks.filter(filterPredicate).length,
+    [newTodayTracks, filterPredicate],
+  );
+  const newWeekCount = useMemo(
+    () => newWeekTracks.filter(filterPredicate).length,
+    [newWeekTracks, filterPredicate],
   );
   const tracksCount = useMemo(
     () => (activeTracks?.tracks ?? []).filter(filterPredicate).length,
@@ -672,6 +734,9 @@ export function SoundcloudView() {
             selectedId={nodeId ?? LIKES_NODE_ID}
             onSelect={setNodeId}
             storageKey={storageKey}
+            newTodayCount={newTodayCount}
+            newWeekCount={newWeekCount}
+            showNew={tab === "me"}
             likesCount={likesCount}
             repostsCount={repostsCount}
             tracksCount={tracksCount}
@@ -693,6 +758,10 @@ export function SoundcloudView() {
             activeLikes={activeLikes}
             activeReposts={activeReposts}
             activeTracks={activeTracks}
+            newToday={newToday}
+            newWeek={newWeek}
+            isNewTodayView={isNewTodayView}
+            isNewWeekView={isNewWeekView}
             playlistTracks={playlistTracks}
             combinedPlaylistTracks={combinedPlaylistTracks}
             mixTracks={mixTracks}
@@ -729,6 +798,10 @@ interface LikesViewProps {
   activeLikes: ReturnType<typeof useLikes>;
   activeReposts: ReturnType<typeof useLikes> | null;
   activeTracks: ReturnType<typeof useLikes> | null;
+  newToday: ReturnType<typeof useLikes>;
+  newWeek: ReturnType<typeof useLikes>;
+  isNewTodayView: boolean;
+  isNewWeekView: boolean;
   playlistTracks: ReturnType<typeof usePlaylistTracks>;
   combinedPlaylistTracks: ReturnType<typeof useCombinedPlaylistsTracks>;
   mixTracks: ReturnType<typeof useSystemPlaylistTracks>;
@@ -764,6 +837,10 @@ function LikesView({
   activeLikes,
   activeReposts,
   activeTracks,
+  newToday,
+  newWeek,
+  isNewTodayView,
+  isNewWeekView,
   playlistTracks,
   combinedPlaylistTracks,
   mixTracks,
@@ -801,17 +878,21 @@ function LikesView({
     setRemovedUrns(new Set());
   }, [nodeId]);
 
-  const baseTracks = isMixView
-    ? mixTracks.tracks
-    : isPlaylistView
-      ? playlistTracks.tracks
-      : isAllPlaylistsView
-        ? combinedPlaylistTracks.tracks
-        : isRepostsView
-          ? (activeReposts?.tracks ?? EMPTY_TRACKS)
-          : isTracksView
-            ? (activeTracks?.tracks ?? EMPTY_TRACKS)
-            : activeLikes.tracks;
+  const baseTracks = isNewTodayView
+    ? newToday.tracks
+    : isNewWeekView
+      ? newWeek.tracks
+      : isMixView
+        ? mixTracks.tracks
+        : isPlaylistView
+          ? playlistTracks.tracks
+          : isAllPlaylistsView
+            ? combinedPlaylistTracks.tracks
+            : isRepostsView
+              ? (activeReposts?.tracks ?? EMPTY_TRACKS)
+              : isTracksView
+                ? (activeTracks?.tracks ?? EMPTY_TRACKS)
+                : activeLikes.tracks;
   const sourceTracks = useMemo(
     () =>
       removedUrns.size === 0
@@ -891,39 +972,51 @@ function LikesView({
     [sourceTracks, selectedIds],
   );
 
-  const loading = isMixView
-    ? mixTracks.loading
-    : isPlaylistView
-      ? playlistTracks.loading
-      : isAllPlaylistsView
-        ? combinedPlaylistTracks.loading
-        : isRepostsView
-          ? (activeReposts?.loading ?? false)
-          : isTracksView
-            ? (activeTracks?.loading ?? false)
-            : activeLikes.loading;
-  const error = isMixView
-    ? mixTracks.error
-    : isPlaylistView
-      ? playlistTracks.error
-      : isAllPlaylistsView
-        ? combinedPlaylistTracks.error
-        : isRepostsView
-          ? (activeReposts?.error ?? null)
-          : isTracksView
-            ? (activeTracks?.error ?? null)
-            : activeLikes.error;
-  const loadedCount = isMixView
-    ? mixTracks.tracks.length
-    : isPlaylistView
-      ? playlistTracks.tracks.length
-      : isAllPlaylistsView
-        ? combinedPlaylistTracks.tracks.length
-        : isRepostsView
-          ? (activeReposts?.loaded ?? 0)
-          : isTracksView
-            ? (activeTracks?.loaded ?? 0)
-            : activeLikes.loaded;
+  const loading = isNewTodayView
+    ? newToday.loading
+    : isNewWeekView
+      ? newWeek.loading
+      : isMixView
+        ? mixTracks.loading
+        : isPlaylistView
+          ? playlistTracks.loading
+          : isAllPlaylistsView
+            ? combinedPlaylistTracks.loading
+            : isRepostsView
+              ? (activeReposts?.loading ?? false)
+              : isTracksView
+                ? (activeTracks?.loading ?? false)
+                : activeLikes.loading;
+  const error = isNewTodayView
+    ? newToday.error
+    : isNewWeekView
+      ? newWeek.error
+      : isMixView
+        ? mixTracks.error
+        : isPlaylistView
+          ? playlistTracks.error
+          : isAllPlaylistsView
+            ? combinedPlaylistTracks.error
+            : isRepostsView
+              ? (activeReposts?.error ?? null)
+              : isTracksView
+                ? (activeTracks?.error ?? null)
+                : activeLikes.error;
+  const loadedCount = isNewTodayView
+    ? newToday.loaded
+    : isNewWeekView
+      ? newWeek.loaded
+      : isMixView
+        ? mixTracks.tracks.length
+        : isPlaylistView
+          ? playlistTracks.tracks.length
+          : isAllPlaylistsView
+            ? combinedPlaylistTracks.tracks.length
+            : isRepostsView
+              ? (activeReposts?.loaded ?? 0)
+              : isTracksView
+                ? (activeTracks?.loaded ?? 0)
+                : activeLikes.loaded;
 
   // Contextual palette commands — registered only while this view is mounted
   // and a selection/filter context applies.
@@ -943,12 +1036,15 @@ function LikesView({
     ),
   });
 
-  const reloadActiveLikes =
-    isRepostsView && activeReposts
-      ? activeReposts.reload
-      : isTracksView && activeTracks
-        ? activeTracks.reload
-        : activeLikes.reload;
+  const reloadActiveLikes = isNewTodayView
+    ? newToday.reload
+    : isNewWeekView
+      ? newWeek.reload
+      : isRepostsView && activeReposts
+        ? activeReposts.reload
+        : isTracksView && activeTracks
+          ? activeTracks.reload
+          : activeLikes.reload;
   useReloadHandler(reloadActiveLikes);
   useCommand({
     id: "sc:reload",
@@ -1081,19 +1177,23 @@ function LikesView({
         ) : sourceTracks.length === 0 && !loading ? (
           <div className="flex h-full items-center justify-center">
             <p className="text-muted-foreground text-sm">
-              {isMixView
-                ? "This mix is empty"
-                : isPlaylistView
-                  ? "This playlist is empty"
-                  : isAllPlaylistsView
-                    ? "No playlists"
-                    : tab === "search"
-                      ? "No tracks matched your search"
-                      : isRepostsView
-                        ? "No reposted tracks found"
-                        : isTracksView
-                          ? "No tracks found"
-                          : "No liked tracks found"}
+              {isNewTodayView
+                ? "Nothing released today on your feed yet"
+                : isNewWeekView
+                  ? "Nothing released this week on your feed yet"
+                  : isMixView
+                    ? "This mix is empty"
+                    : isPlaylistView
+                      ? "This playlist is empty"
+                      : isAllPlaylistsView
+                        ? "No playlists"
+                        : tab === "search"
+                          ? "No tracks matched your search"
+                          : isRepostsView
+                            ? "No reposted tracks found"
+                            : isTracksView
+                              ? "No tracks found"
+                              : "No liked tracks found"}
             </p>
           </div>
         ) : (

--- a/frontend/src/app/weekly/use-followings-tracks.ts
+++ b/frontend/src/app/weekly/use-followings-tracks.ts
@@ -84,7 +84,7 @@ async function fetchRecentPages(
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
-export function useFollowingsTracks(): UseFollowingsTracksResult {
+export function useFollowingsTracks(enabled = true): UseFollowingsTracksResult {
   const [tracks, setTracks] = useState<SCTrack[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -128,11 +128,12 @@ export function useFollowingsTracks(): UseFollowingsTracksResult {
   );
 
   useEffect(() => {
+    if (!enabled) return;
     const controller = new AbortController();
     abortRef.current = controller;
     fetchAll(controller.signal);
     return () => controller.abort();
-  }, [fetchAll]);
+  }, [fetchAll, enabled]);
 
   const reload = useCallback(() => {
     abortRef.current?.abort();


### PR DESCRIPTION
Adds two auto-filled nodes at the top of the SoundCloud library tree (My Library tab), fed by the followings feed and filtered to tracks whose own release date falls in today / the current week. A track reposted today but released earlier is excluded. Reuses the `/weekly` feed hook (gated by an `enabled` flag) so no new backend route is needed.

**Test plan:** `npx playwright test soundcloud-new-releases` — covers both windows and the reposted-old-track exclusion via a frozen clock.