### PR TITLE
feat(soundcloud): BPM range filter

### DIFF
--- a/frontend/e2e/soundcloud-bpm-filter.spec.ts
+++ b/frontend/e2e/soundcloud-bpm-filter.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * SoundCloud library BPM range filter.
+ *
+ * BPM for SoundCloud tracks lives in the backend cache (analysed / manually
+ * set), not on the track object — so the filter reads the bulk BPM prefill.
+ * Tracks with no known BPM are dropped by default and kept only when the
+ * "Include unknown BPM" toggle is on.
+ */
+
+const TRACKS = [
+  { id: 42, title: "Track A120", bpm: 120 },
+  { id: 99, title: "Track B124", bpm: 124 },
+  { id: 7, title: "Track C130", bpm: 130 },
+  { id: 5, title: "Track D-unknown", bpm: null }, // never analysed
+];
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: TRACKS.map((t) => ({
+          id: t.id,
+          urn: `soundcloud:tracks:${t.id}`,
+          title: t.title,
+          user: { id: 1, username: "me" },
+          duration: 200_000,
+          permalink_url: `https://soundcloud.com/me/${t.id}`,
+        })),
+        next_href: null,
+      }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/tracks*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("https://api.soundcloud.com/me/playlists*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("https://api.soundcloud.com/me/feed/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ collection: [], next_href: null }),
+    }),
+  );
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  // Cached BPMs for the three analysed tracks; id 5 is absent (unknown).
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        bpms: Object.fromEntries(
+          TRACKS.filter((t) => t.bpm != null).map((t) => [
+            String(t.id),
+            t.bpm,
+          ]),
+        ),
+      }),
+    }),
+  );
+}
+
+test.describe("soundcloud BPM filter", () => {
+  test("BPM control and unknown toggle render once BPMs are known", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(4, {
+      timeout: 5000,
+    });
+
+    await page.getByRole("button", { name: /^filters$/i }).click();
+    // The "Include unknown BPM" toggle only renders once the source tracks
+    // yield a real BPM range, so its presence proves the BPM filter surface.
+    await expect(
+      page.getByRole("checkbox", { name: "Include unknown BPM" }),
+    ).toBeVisible();
+  });
+
+  test("range excludes tracks outside it and unknown BPM by default", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud&bpmMin=123&bpmMax=127");
+
+    // Only the 124 BPM track survives: 120 and 130 are out of range, and the
+    // unknown-BPM track is dropped because the include toggle is off.
+    await expect(page.locator("[data-index]")).toHaveCount(1, {
+      timeout: 5000,
+    });
+    await expect(page.getByText("Track B124")).toBeVisible();
+    await expect(page.getByText("Track A120")).toHaveCount(0);
+    await expect(page.getByText("Track C130")).toHaveCount(0);
+    await expect(page.getByText("Track D-unknown")).toHaveCount(0);
+  });
+
+  test("include-unknown toggle keeps un-analysed tracks in range", async ({
+    page,
+  }) => {
+    await setup(page);
+    await page.goto(
+      "/library?source=soundcloud&bpmMin=123&bpmMax=127&bpm_include_unknown=true",
+    );
+
+    // The 124 track plus the unknown-BPM track; 120 and 130 stay excluded.
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+    await expect(page.getByText("Track B124")).toBeVisible();
+    await expect(page.getByText("Track D-unknown")).toBeVisible();
+    await expect(page.getByText("Track A120")).toHaveCount(0);
+    await expect(page.getByText("Track C130")).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/soundcloud-bpm-filter.spec.ts
+++ b/frontend/e2e/soundcloud-bpm-filter.spec.ts
@@ -78,10 +78,7 @@ async function setup(page: import("@playwright/test").Page) {
       contentType: "application/json",
       body: JSON.stringify({
         bpms: Object.fromEntries(
-          TRACKS.filter((t) => t.bpm != null).map((t) => [
-            String(t.id),
-            t.bpm,
-          ]),
+          TRACKS.filter((t) => t.bpm != null).map((t) => [String(t.id), t.bpm]),
         ),
       }),
     }),

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -51,6 +51,7 @@ import {
   type ProfileGroupMember,
 } from "@/lib/profile-groups";
 import { parseSCTimestamp, type SCTrack } from "@/lib/soundcloud";
+import { useScBpmMap } from "@/lib/sources/use-sc-bpm-map";
 import { cn } from "@/lib/utils";
 
 import { useFollowingsTracks } from "../weekly/use-followings-tracks";
@@ -97,11 +98,17 @@ function filterSchemaForTab(
   // your own likes from that list would always empty it. Everywhere else
   // (Mixes, Playlists, Discover, Search) the filter is useful.
   const onLikesNode = tab === "me" && nodeId === LIKES_NODE_ID;
+  // The "include unknown BPM" toggle is only meaningful once a BPM range is
+  // available — hide it until the source tracks yield real BPM values.
+  const bpmAttr = schema.attributes.find((a) => a.id === "bpm");
+  const hasBpmRange =
+    bpmAttr?.kind === "range" && (bpmAttr.max ?? 0) > (bpmAttr.min ?? 0);
   return {
     ...schema,
     attributes: schema.attributes.filter((a) => {
       if (a.id === "exclude_my_likes") return !onLikesNode;
       if (a.id === "in_collection") return hasCollection;
+      if (a.id === "bpm_include_unknown") return hasBpmRange;
       return true;
     }),
   };
@@ -413,6 +420,44 @@ export function SoundcloudView() {
       .catch(() => {});
   }, []);
 
+  // Cached BPMs for every list that feeds a count or the visible table, in one
+  // bulk request. Lifted above the filter so the BPM range predicate and the
+  // schema's BPM range see real (analysed/manual) BPMs — `track.bpm` metadata
+  // is null for most SoundCloud uploads. Deduped so the same id isn't sent
+  // twice across, e.g., Likes and a playlist.
+  const bpmSourceTracks = useMemo(() => {
+    const seen = new Set<number>();
+    const out: SCTrack[] = [];
+    const push = (list: SCTrack[] | undefined) => {
+      for (const t of list ?? []) {
+        const id = extractId(t);
+        if (id != null && !seen.has(id)) {
+          seen.add(id);
+          out.push(t);
+        }
+      }
+    };
+    push(activeLikes.tracks);
+    push(activeReposts?.tracks);
+    push(activeTracks?.tracks);
+    push(newTodayTracks);
+    push(newWeekTracks);
+    push(combinedPlaylistTracks.tracks);
+    push(playlistTracks.tracks);
+    push(mixTracks.tracks);
+    return out;
+  }, [
+    activeLikes.tracks,
+    activeReposts?.tracks,
+    activeTracks?.tracks,
+    newTodayTracks,
+    newWeekTracks,
+    combinedPlaylistTracks.tracks,
+    playlistTracks.tracks,
+    mixTracks.tracks,
+  ]);
+  const bpmMap = useScBpmMap(bpmSourceTracks);
+
   // Reset selection to Likes when the user switches tab or active group.
   // Skip the initial mount so a `?node=` URL param survives — otherwise
   // this effect would clobber it back to Likes before the page rendered.
@@ -442,6 +487,16 @@ export function SoundcloudView() {
           step: 15,
           formatHint: "duration",
         },
+        {
+          id: "bpm",
+          label: "BPM",
+          kind: "range",
+          min: 0,
+          max: 0,
+          step: 1,
+          formatHint: "bpm",
+        },
+        { id: "bpm_include_unknown", label: "Include unknown BPM", kind: "bool" },
         {
           id: "track_type",
           label: "Type",
@@ -478,8 +533,14 @@ export function SoundcloudView() {
   // and Playlists as well. Scoping the Set by tab silently no-op'd the
   // filter on those views.
   const filterPredicate = useMemo(
-    () => makeLikesFilterPredicate(filterOptions, myLikedIds, collectionIds),
-    [filterOptions, myLikedIds, collectionIds],
+    () =>
+      makeLikesFilterPredicate(
+        filterOptions,
+        myLikedIds,
+        collectionIds,
+        bpmMap,
+      ),
+    [filterOptions, myLikedIds, collectionIds, bpmMap],
   );
 
   // Filtered counts for tree nodes
@@ -786,6 +847,7 @@ export function SoundcloudView() {
             onFilterChange={setFilter}
             onClearFilters={clearFilters}
             filterOptions={filterOptions}
+            bpmMap={bpmMap}
           />
         </div>
       </div>
@@ -830,6 +892,7 @@ interface LikesViewProps {
   ) => void;
   onClearFilters: () => void;
   filterOptions: import("./use-likes-filter").LikesFilterOptions;
+  bpmMap: Map<number, number>;
 }
 
 function LikesView({
@@ -863,6 +926,7 @@ function LikesView({
   onFilterChange,
   onClearFilters,
   filterOptions,
+  bpmMap,
 }: LikesViewProps) {
   // Selection state stays local — filters live at the page level.
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -916,13 +980,15 @@ function LikesView({
     filterOptions,
     myLikedIds,
     collectionIds,
+    bpmMap,
   );
 
   // Data-derived schema: enriches the seed with genre options/counts and a
-  // real duration range computed from the current sourceTracks.
+  // real duration + BPM range computed from the current sourceTracks.
   const { schema: enrichedSchema } = useFilterSchema({
     source: "soundcloud",
     tracks: sourceTracks,
+    bpmByTrack: bpmMap,
   });
   const schema = useMemo<FilterSchemaResponse>(() => {
     if (!enrichedSchema) return seedSchema;
@@ -1199,6 +1265,7 @@ function LikesView({
         ) : (
           <LikesTable
             tracks={filteredTracks}
+            bpmCache={bpmMap}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
             onRangeSelect={selectRange}

--- a/frontend/src/app/library/soundcloud-view.tsx
+++ b/frontend/src/app/library/soundcloud-view.tsx
@@ -496,7 +496,11 @@ export function SoundcloudView() {
           step: 1,
           formatHint: "bpm",
         },
-        { id: "bpm_include_unknown", label: "Include unknown BPM", kind: "bool" },
+        {
+          id: "bpm_include_unknown",
+          label: "Include unknown BPM",
+          kind: "bool",
+        },
         {
           id: "track_type",
           label: "Type",

--- a/frontend/src/app/library/use-likes-filter.ts
+++ b/frontend/src/app/library/use-likes-filter.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 
 import type { FilterState } from "@/lib/filters/schema";
-import { scTrackId } from "@/lib/sources/use-sc-bpm-map";
 import type { SCTrack } from "@/lib/soundcloud";
+import { scTrackId } from "@/lib/sources/use-sc-bpm-map";
 
 export interface LikesFilterOptions {
   search: string;

--- a/frontend/src/app/library/use-likes-filter.ts
+++ b/frontend/src/app/library/use-likes-filter.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import type { FilterState } from "@/lib/filters/schema";
+import { scTrackId } from "@/lib/sources/use-sc-bpm-map";
 import type { SCTrack } from "@/lib/soundcloud";
 
 export interface LikesFilterOptions {
@@ -8,6 +9,10 @@ export interface LikesFilterOptions {
   genres: string[];
   minDuration: number | null;
   maxDuration: number | null;
+  minBpm: number | null;
+  maxBpm: number | null;
+  /** When a BPM range is set, whether tracks with no known BPM still pass. */
+  includeUnknownBpm: boolean;
   excludeMyLikes: boolean;
   inCollection: boolean | null; // null = any, true = in collection, false = not in collection
   /** null = any; "track" = shorter than SET_THRESHOLD_SECONDS; "set" = at or above. */
@@ -28,6 +33,10 @@ export function filterStateToLikesOptions(
 ): LikesFilterOptions {
   const duration = (state.duration as
     [number | null, number | null] | undefined) ?? [null, null];
+  const bpm = (state.bpm as [number | null, number | null] | undefined) ?? [
+    null,
+    null,
+  ];
   // track_type is modelled as a multi-select enum with options ["track",
   // "set"]. A single-item selection means "only this type"; picking both
   // (or neither) is equivalent to no filter and collapses to null.
@@ -42,6 +51,9 @@ export function filterStateToLikesOptions(
     genres: (state.genre as string[] | undefined) ?? [],
     minDuration: duration[0],
     maxDuration: duration[1],
+    minBpm: bpm[0],
+    maxBpm: bpm[1],
+    includeUnknownBpm: state.bpm_include_unknown === true,
     excludeMyLikes: state.exclude_my_likes === true,
     inCollection:
       state.in_collection === true
@@ -66,13 +78,18 @@ function extractId(track: SCTrack): number | undefined {
   return parseInt(parts[parts.length - 1], 10) || undefined;
 }
 
-/** Pure predicate for filtering a single track — use outside of the hook. */
+/** Pure predicate for filtering a single track — use outside of the hook.
+ *
+ * `bpmByTrack` supplies cached (analysed/manual) BPMs; the predicate falls
+ * back to the track's metadata `bpm` when a track isn't in the map. */
 export function makeLikesFilterPredicate(
   options: LikesFilterOptions,
   myLikedIds?: Set<number>,
   collectionIds?: Set<number>,
+  bpmByTrack?: Map<number, number>,
 ): (track: SCTrack) => boolean {
   const searchLower = options.search.toLowerCase().trim();
+  const bpmActive = options.minBpm != null || options.maxBpm != null;
   return (track) => {
     if (searchLower) {
       const title = (track.title ?? "").toLowerCase();
@@ -105,6 +122,16 @@ export function makeLikesFilterPredicate(
       if (options.trackType === "set" && !isSet) return false;
       if (options.trackType === "track" && isSet) return false;
     }
+    if (bpmActive) {
+      const id = scTrackId(track);
+      const bpm = (id != null ? bpmByTrack?.get(id) : undefined) ?? track.bpm;
+      if (bpm == null) {
+        if (!options.includeUnknownBpm) return false;
+      } else {
+        if (options.minBpm != null && bpm < options.minBpm) return false;
+        if (options.maxBpm != null && bpm > options.maxBpm) return false;
+      }
+    }
     return true;
   };
 }
@@ -114,6 +141,7 @@ export function useLikesFilter(
   options: UseLikesFilterOptions,
   myLikedIds?: Set<number>,
   collectionIds?: Set<number>,
+  bpmByTrack?: Map<number, number>,
 ): UseLikesFilterResult {
   const availableGenres = useMemo(() => {
     const genreSet = new Set<string>();
@@ -128,9 +156,10 @@ export function useLikesFilter(
       options,
       myLikedIds,
       collectionIds,
+      bpmByTrack,
     );
     return tracks.filter(predicate);
-  }, [tracks, options, myLikedIds, collectionIds]);
+  }, [tracks, options, myLikedIds, collectionIds, bpmByTrack]);
 
   return { filteredTracks, availableGenres };
 }

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -841,6 +841,10 @@ interface LikesTableProps {
   onSelectAll: () => void;
   onDeselectAll: () => void;
   collectionIds?: Set<number>;
+  /** Pre-fetched cached BPMs (track id → bpm). When provided, the table uses
+   *  it instead of making its own bulk request — pass it when a parent already
+   *  fetched BPMs (e.g. to drive a BPM filter) so there's a single source. */
+  bpmCache?: Map<number, number>;
   /** IDs of tracks the authenticated user has liked. When a track's id is in
    *  this set, the like button renders as active. */
   likedIds?: Set<number>;
@@ -885,6 +889,7 @@ export function LikesTable({
   onSelectAll,
   onDeselectAll,
   collectionIds,
+  bpmCache: externalBpmCache,
   likedIds,
   newTrackUrns,
   isColumnVisible,
@@ -1024,9 +1029,15 @@ export function LikesTable({
 
   // Pre-fill cached BPMs for all tracks in this table in a single bulk
   // request, rather than making one GET per visible row. The map survives
-  // re-renders; cells read it via SoundcloudBpmCacheContext.
-  const [bpmCache, setBpmCache] = useState<Map<number, number>>(new Map());
+  // re-renders; cells read it via SoundcloudBpmCacheContext. A parent can
+  // instead supply `externalBpmCache` (e.g. the SoundCloud library, which
+  // fetches BPMs once to drive its BPM filter) — then we skip our own fetch.
+  const [internalBpmCache, setInternalBpmCache] = useState<Map<number, number>>(
+    new Map(),
+  );
+  const bpmCache = externalBpmCache ?? internalBpmCache;
   useEffect(() => {
+    if (externalBpmCache) return;
     const ids: number[] = [];
     for (const t of tracks) {
       if (t.urn) {
@@ -1043,7 +1054,7 @@ export function LikesTable({
         if (cancelled) return;
         const next = new Map<number, number>();
         for (const [k, v] of Object.entries(resp.bpms)) next.set(Number(k), v);
-        setBpmCache(next);
+        setInternalBpmCache(next);
       })
       .catch(() => {
         /* Prefill is best-effort; cells fall back to metadata + Detect button. */
@@ -1051,7 +1062,7 @@ export function LikesTable({
     return () => {
       cancelled = true;
     };
-  }, [tracks]);
+  }, [tracks, externalBpmCache]);
 
   const colVisible = React.useCallback(
     (id: string) => {

--- a/frontend/src/lib/filters/soundcloud-adapter.ts
+++ b/frontend/src/lib/filters/soundcloud-adapter.ts
@@ -1,8 +1,12 @@
 import type { FilterSchemaResponse } from "@/lib/filters/schema";
 import type { SCTrack } from "@/lib/soundcloud";
+import { scTrackId } from "@/lib/sources/use-sc-bpm-map";
 
 export interface SoundcloudSchemaInputs {
   tracks: SCTrack[];
+  /** Cached BPMs (track id → bpm) so the range covers analysed tracks, not
+   * just the rare uploads that carry a metadata `bpm`. */
+  bpmByTrack?: Map<number, number>;
 }
 
 /**
@@ -17,12 +21,15 @@ export interface SoundcloudSchemaInputs {
 export function buildSoundcloudSchema(
   inputs: SoundcloudSchemaInputs,
 ): FilterSchemaResponse {
-  const { tracks } = inputs;
+  const { tracks, bpmByTrack } = inputs;
 
   const genreCounts: Record<string, number> = {};
   let durationMin = Infinity;
   let durationMax = -Infinity;
   let hasDuration = false;
+  let bpmMin = Infinity;
+  let bpmMax = -Infinity;
+  let hasBpm = false;
   // Same 12-minute heuristic as the weekly view — keeps the track/set
   // split consistent wherever users toggle it.
   const trackTypeCounts: Record<string, number> = { track: 0, set: 0 };
@@ -36,6 +43,13 @@ export function buildSoundcloudSchema(
       hasDuration = true;
       if (s < 720) trackTypeCounts.track += 1;
       else trackTypeCounts.set += 1;
+    }
+    const id = scTrackId(t);
+    const bpm = (id != null ? bpmByTrack?.get(id) : undefined) ?? t.bpm;
+    if (bpm != null && bpm > 0) {
+      if (bpm < bpmMin) bpmMin = bpm;
+      if (bpm > bpmMax) bpmMax = bpm;
+      hasBpm = true;
     }
   }
 
@@ -62,6 +76,19 @@ export function buildSoundcloudSchema(
               max: Math.ceil(durationMax),
               step: 15,
               formatHint: "duration" as const,
+            },
+          ]
+        : []),
+      ...(hasBpm
+        ? [
+            {
+              id: "bpm",
+              label: "BPM",
+              kind: "range" as const,
+              min: Math.floor(bpmMin),
+              max: Math.ceil(bpmMax),
+              step: 1,
+              formatHint: "bpm" as const,
             },
           ]
         : []),

--- a/frontend/src/lib/filters/use-filter-schema.ts
+++ b/frontend/src/lib/filters/use-filter-schema.ts
@@ -17,6 +17,7 @@ export type FilterSchemaSource =
   | {
       source: "soundcloud";
       tracks: SCTrack[];
+      bpmByTrack?: Map<number, number>;
     };
 
 export interface UseFilterSchemaResult {
@@ -41,12 +42,13 @@ export function useFilterSchema(
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<Error | null>(null);
 
-  // SoundCloud: synchronous compute; memoize on tracks reference.
+  // SoundCloud: synchronous compute; memoize on tracks + bpm-map reference.
   const scTracks = input.source === "soundcloud" ? input.tracks : null;
+  const scBpm = input.source === "soundcloud" ? input.bpmByTrack : undefined;
   const scSchema = React.useMemo(() => {
     if (!scTracks) return null;
-    return buildSoundcloudSchema({ tracks: scTracks });
-  }, [scTracks]);
+    return buildSoundcloudSchema({ tracks: scTracks, bpmByTrack: scBpm });
+  }, [scTracks, scBpm]);
 
   // Filesystem: async fetch; re-run on state/folder changes.
   const fsKey =

--- a/frontend/src/lib/sources/use-sc-bpm-map.ts
+++ b/frontend/src/lib/sources/use-sc-bpm-map.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { api } from "@/lib/api";
+import type { SCTrack } from "@/lib/soundcloud";
+
+/** Numeric SoundCloud track id parsed from a `soundcloud:tracks:<id>` urn. */
+export function scTrackId(track: SCTrack): number | null {
+  if (!track.urn) return null;
+  const id = parseInt(track.urn.split(":").pop() ?? "", 10);
+  return id > 0 ? id : null;
+}
+
+/**
+ * Bulk-fetch cached SoundCloud BPMs (analysed or manually-set, from the
+ * backend `soundcloud_track_bpm` table) for `tracks`, keyed by numeric track
+ * id. This is the same one-request-per-list prefill the likes table does for
+ * its BPM column, lifted so the filter layer can see real BPM values too —
+ * `track.bpm` (SoundCloud metadata) is null for most user uploads.
+ *
+ * Best-effort: a failed request leaves the previous map in place; consumers
+ * fall back to metadata BPM.
+ */
+export function useScBpmMap(tracks: SCTrack[]): Map<number, number> {
+  const [map, setMap] = useState<Map<number, number>>(new Map());
+  useEffect(() => {
+    const ids: number[] = [];
+    for (const t of tracks) {
+      const id = scTrackId(t);
+      if (id != null) ids.push(id);
+    }
+    if (ids.length === 0) return;
+    let cancelled = false;
+    api
+      .getSoundcloudBpmsBulk(ids)
+      .then((resp) => {
+        if (cancelled) return;
+        const next = new Map<number, number>();
+        for (const [k, v] of Object.entries(resp.bpms)) next.set(Number(k), v);
+        setMap(next);
+      })
+      .catch(() => {
+        /* Prefill is best-effort; predicate falls back to metadata BPM. */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tracks]);
+  return map;
+}


### PR DESCRIPTION
Adds a BPM range filter to the SoundCloud library toolbar, with an "Include unknown BPM" toggle to keep un-analysed tracks. Reads effective BPM (backend cache from analyze/manual-set, falling back to metadata), lifted to the page level so the predicate, schema range, and tree counts stay consistent.

Test plan: `npx playwright test soundcloud-bpm-filter` (+ typecheck, lint, unit).