### PR TITLE
feat(palette): queue actions in track search context menu

### DIFF
--- a/frontend/e2e/command-palette.spec.ts
+++ b/frontend/e2e/command-palette.spec.ts
@@ -200,6 +200,49 @@ test.describe("Command palette", () => {
     await expect(page).toHaveURL(/play=%2Fmusic%2Fcollection%2Fx\.aif/);
   });
 
+  test("right-click adds a SoundCloud track result to the play queue", async ({
+    page,
+  }) => {
+    await page.goto("/library");
+    await page.getByRole("button", { name: /open command palette/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByPlaceholder(/search or type a command/i).fill("track");
+    const trackRow = dialog.getByRole("option", { name: /Remote Track A/ });
+    await expect(trackRow).toBeVisible();
+
+    // Right-click opens the queue context menu; the palette stays open so the
+    // user can queue several tracks in a row.
+    await trackRow.click({ button: "right" });
+    await page.getByTestId("queue-add").click();
+    await expect(
+      page.getByText(/added to queue: remote track a/i),
+    ).toBeVisible();
+
+    // Enqueue onto an empty queue starts playback, so the track lands as the
+    // now-playing entry in the player bar.
+    await expect(page.getByTestId("waveform-player")).toContainText(
+      "Remote Track A",
+    );
+  });
+
+  test("right-click can play a SoundCloud track result next", async ({
+    page,
+  }) => {
+    await page.goto("/library");
+    await page.getByRole("button", { name: /open command palette/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByPlaceholder(/search or type a command/i).fill("track");
+    const trackRow = dialog.getByRole("option", { name: /Remote Track B/ });
+    await expect(trackRow).toBeVisible();
+
+    await trackRow.click({ button: "right" });
+    await page.getByTestId("queue-play-next").click();
+    await expect(page.getByText(/playing next: remote track b/i)).toBeVisible();
+    await expect(page.getByTestId("waveform-player")).toContainText(
+      "Remote Track B",
+    );
+  });
+
   test("nav command navigates to the destination", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: /open command palette/i }).click();

--- a/frontend/src/components/command-palette/index.tsx
+++ b/frontend/src/components/command-palette/index.tsx
@@ -2,8 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import { Spinner } from "@/components/spinner";
+import { TrackQueueMenu } from "@/components/track-queue-menu";
 import {
   CommandDialog,
   CommandEmpty,
@@ -13,6 +15,9 @@ import {
   CommandList,
   CommandShortcut,
 } from "@/components/ui/command";
+import { usePlayer } from "@/lib/player-context";
+import { scTrackToPlayerTrack } from "@/lib/sc-player-track";
+import type { SCTrack } from "@/lib/soundcloud";
 
 import { useCommandPalette } from "./provider";
 import { LocalTracksProvider } from "./providers/local-tracks";
@@ -37,6 +42,7 @@ function groupBy(items: CommandItem[]): Map<string, CommandItem[]> {
 export function CommandPalette() {
   const { open, setOpen, providers, dynamicCommands } = useCommandPalette();
   const router = useRouter();
+  const { enqueue, playNext } = usePlayer();
 
   const [query, setQuery] = useState("");
   const [asyncResults, setAsyncResults] = useState<CommandItem[]>([]);
@@ -67,6 +73,23 @@ export function CommandPalette() {
       router.push(`/library?${params.toString()}`);
     },
     [router],
+  );
+  // Right-click queue actions on SoundCloud track results. These don't close
+  // the palette, so the user can queue several tracks in a row; a toast
+  // confirms since the list itself doesn't change.
+  const onAddTrackToQueue = useCallback(
+    (track: SCTrack) => {
+      enqueue(scTrackToPlayerTrack(track));
+      toast(`Added to queue: ${track.title ?? "track"}`);
+    },
+    [enqueue],
+  );
+  const onPlayTrackNext = useCallback(
+    (track: SCTrack) => {
+      playNext(scTrackToPlayerTrack(track));
+      toast(`Playing next: ${track.title ?? "track"}`);
+    },
+    [playNext],
   );
   const onSelectUser = useCallback(
     (user: { permalink?: string | null } | null | undefined) => {
@@ -259,7 +282,11 @@ export function CommandPalette() {
       <NavProvider onNavigate={onNavigate} />
       <PinnedFoldersProvider onSelect={onSelectPinnedFolder} />
       <LocalTracksProvider onSelect={onSelectLocalTrack} />
-      <SoundcloudTracksProvider onSelect={onSelectTrack} />
+      <SoundcloudTracksProvider
+        onSelect={onSelectTrack}
+        onAddToQueue={onAddTrackToQueue}
+        onPlayNext={onPlayTrackNext}
+      />
       <SoundcloudUsersProvider onSelect={onSelectUser} />
 
       <CommandDialog open={open} onOpenChange={setOpen} shouldFilter={false}>
@@ -294,7 +321,7 @@ export function CommandPalette() {
                   ]
                     .filter(Boolean)
                     .join(" ");
-                  return (
+                  const node = (
                     <CommandItemUI
                       key={item.id}
                       data-command-id={item.id}
@@ -326,6 +353,18 @@ export function CommandPalette() {
                       )}
                     </CommandItemUI>
                   );
+                  if (item.onAddToQueue && item.onPlayNext) {
+                    return (
+                      <TrackQueueMenu
+                        key={item.id}
+                        onAddToQueue={item.onAddToQueue}
+                        onPlayNext={item.onPlayNext}
+                      >
+                        {node}
+                      </TrackQueueMenu>
+                    );
+                  }
+                  return node;
                 })}
               </CommandGroup>
             );

--- a/frontend/src/components/command-palette/providers/soundcloud-tracks.tsx
+++ b/frontend/src/components/command-palette/providers/soundcloud-tracks.tsx
@@ -13,8 +13,12 @@ const TRACK_URL_RE = /^https?:\/\/(www\.)?soundcloud\.com\//i;
 
 export function SoundcloudTracksProvider({
   onSelect,
+  onAddToQueue,
+  onPlayNext,
 }: {
   onSelect: (track: SCTrack) => void;
+  onAddToQueue: (track: SCTrack) => void;
+  onPlayNext: (track: SCTrack) => void;
 }) {
   const provider = useMemo<CommandProvider>(
     () => ({
@@ -48,10 +52,12 @@ export function SoundcloudTracksProvider({
             onSelect(t);
             close();
           },
+          onAddToQueue: () => onAddToQueue(t),
+          onPlayNext: () => onPlayNext(t),
         }));
       },
     }),
-    [onSelect],
+    [onSelect, onAddToQueue, onPlayNext],
   );
 
   useRegisterProvider(provider);

--- a/frontend/src/components/command-palette/types.ts
+++ b/frontend/src/components/command-palette/types.ts
@@ -20,6 +20,10 @@ export interface CommandItem {
   keywords?: string[];
   shortcut?: string[];
   run: (ctx: CommandRunContext) => void | Promise<void>;
+  /** When set, the item gains a right-click "Play next" / "Add to queue" menu.
+   * Both callbacks must be provided together. */
+  onPlayNext?: () => void;
+  onAddToQueue?: () => void;
 }
 
 export type CommandProvideResult = CommandItem[];

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -73,8 +73,9 @@ import {
 import { api } from "@/lib/api";
 import type { ColumnDef } from "@/lib/columns/types";
 import { parseFallbackDownloadUrl } from "@/lib/parse-fallback-download";
-import { usePlayer, type PlayerTrack } from "@/lib/player-context";
+import { usePlayer } from "@/lib/player-context";
 import type { SourceProfile } from "@/lib/profile-groups";
+import { scTrackToPlayerTrack } from "@/lib/sc-player-track";
 import { useIsScUnplayable } from "@/lib/sc-unplayable";
 import {
   addTracksToPlaylist,
@@ -348,27 +349,6 @@ function artworkUrl(track: SCTrack): string | null {
   const url = track.artwork_url;
   if (!url) return null;
   return api.proxyImageUrl(url);
-}
-
-// Build a PlayerTrack skeleton from an SC track. Every entry is a skeleton —
-// the player resolves streamUrl on demand via the shared TTL cache. Shared by
-// the play-to-start path and the mid-playback queue reconcile.
-function scTrackToPlayerTrack(
-  track: SCTrack,
-  bpmCache: Map<number, number>,
-): PlayerTrack {
-  const id = extractId(track);
-  return {
-    filePath: `soundcloud:${id}`,
-    fileName: track.title ?? String(id),
-    title: track.title ?? undefined,
-    artist: track.user?.username ?? undefined,
-    waveformUrl: track.waveform_url ?? undefined,
-    streamRefreshKey: id,
-    permalinkUrl: track.permalink_url ?? undefined,
-    artworkUrl: artworkUrl(track) ?? undefined,
-    bpm: bpmCache.get(id) ?? track.bpm ?? null,
-  };
 }
 
 function searchQuery(track: SCTrack): string {

--- a/frontend/src/lib/sc-player-track.ts
+++ b/frontend/src/lib/sc-player-track.ts
@@ -1,0 +1,36 @@
+import { api } from "@/lib/api";
+import type { PlayerTrack } from "@/lib/player-context";
+import type { SCTrack } from "@/lib/soundcloud";
+
+/** Numeric SoundCloud track id parsed from its `urn`. Returns 0 when missing. */
+function scTrackId(track: SCTrack): number {
+  if (!track.urn) return 0;
+  const parts = track.urn.split(":");
+  return parseInt(parts[parts.length - 1], 10) || 0;
+}
+
+/**
+ * Build a `PlayerTrack` skeleton from a SoundCloud track. The player resolves
+ * `streamUrl` on demand via the shared TTL cache, so only hints are filled in.
+ * Pass `bpmCache` to enrich BPM from an analysis cache; otherwise the track's
+ * own `bpm` (if any) is used.
+ */
+export function scTrackToPlayerTrack(
+  track: SCTrack,
+  bpmCache?: Map<number, number>,
+): PlayerTrack {
+  const id = scTrackId(track);
+  return {
+    filePath: `soundcloud:${id}`,
+    fileName: track.title ?? String(id),
+    title: track.title ?? undefined,
+    artist: track.user?.username ?? undefined,
+    waveformUrl: track.waveform_url ?? undefined,
+    streamRefreshKey: id,
+    permalinkUrl: track.permalink_url ?? undefined,
+    artworkUrl: track.artwork_url
+      ? api.proxyImageUrl(track.artwork_url)
+      : undefined,
+    bpm: bpmCache?.get(id) ?? track.bpm ?? null,
+  };
+}


### PR DESCRIPTION
## What

Right-click a SoundCloud track result in the command palette to **Play next** or **Add to queue** — no navigation, no leaving the palette. Reuses the existing `TrackQueueMenu` (same menu as the likes/collection track rows). The palette stays open so several tracks can be queued in a row; a toast confirms each action.

## Why

Previously the only thing you could do with a palette track result was jump to the search tab and autoplay it. Queuing meant navigating away first. This lets you build up the listening queue straight from search.

## Changes

- **`src/lib/sc-player-track.ts`** (new) — extracted `scTrackToPlayerTrack(track, bpmCache?)` so the palette and `likes-table` share one converter (it was previously private to `likes-table`).
- **`likes-table.tsx`** — uses the shared converter; behavior unchanged.
- **`command-palette/types.ts`** — optional `onPlayNext` / `onAddToQueue` on `CommandItem`.
- **`providers/soundcloud-tracks.tsx`** — attaches the two callbacks per track.
- **`command-palette/index.tsx`** — wires `usePlayer().enqueue/playNext`, wraps track items in `TrackQueueMenu`, toasts confirmation.
- **`e2e/command-palette.spec.ts`** — two new tests: right-click → add to queue, and right-click → play next.

## Notes

- No new palette command ids or providers — these are context-menu actions (`data-testid`), not commands — so the command-palette catalog/docs are unaffected (catalog spec still green).
- Minor Radix quirk: because the context menu is nested inside the palette's dialog, closing the palette by **keyboard** Escape after using the menu takes two presses (Radix's nested-layer stack absorbs the first). Clicking outside still closes it in one. Left as-is; happy to auto-close the palette on a queue action instead if preferred.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx playwright test command-palette.spec.ts command-palette-catalog.spec.ts` (10 passed)