### PR TITLE
fix(library): stop Fetch from Downloads dialog overflowing on narrow windows

### DIFF
--- a/frontend/e2e/fetch-from-downloads.spec.ts
+++ b/frontend/e2e/fetch-from-downloads.spec.ts
@@ -163,6 +163,47 @@ test.describe("Fetch from Downloads", () => {
     await expect.poll(() => posted?.file_names).toEqual(["keep.mp3"]);
   });
 
+  test("narrow window: long filenames truncate without overflowing the dialog", async ({
+    page,
+  }) => {
+    // Below Tailwind's `sm` breakpoint the dialog spans the window, so the
+    // preview list must stay within its box (regression: flex-1 truncation
+    // needs min-w-0, and the grid content wrapper must not force the track).
+    await page.setViewportSize({ width: 500, height: 900 });
+    await setupBrowse(page);
+    await setupPreview(page, {
+      candidates: [
+        {
+          name: "Some Artist - A Very Long Track Title That Exceeds The Dialog Width By A Lot (Extended Remaster).aiff",
+          size: 1,
+          mtime: 0,
+        },
+      ],
+      skipped: [],
+    });
+
+    await page.goto("/library");
+    await page.getByTestId("fetch-from-downloads-trigger").first().click();
+    const dialog = page.getByRole("dialog");
+    const item = dialog.getByTestId("fetch-preview-item");
+    await expect(item).toHaveCount(1);
+
+    const contentWidth = await dialog.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const listScroll = await dialog
+      .getByTestId("fetch-preview-list")
+      .evaluate((el) => (el as HTMLElement).scrollWidth);
+    expect(listScroll).toBeLessThanOrEqual(contentWidth);
+
+    // The name span clips (ellipsis) rather than pushing the row wide.
+    const span = item.locator("span").first();
+    const truncated = await span.evaluate(
+      (el) => el.scrollWidth > el.clientWidth,
+    );
+    expect(truncated).toBe(true);
+  });
+
   test("custom window posts the typed number of days", async ({ page }) => {
     await setupBrowse(page);
     await setupPreview(page, {

--- a/frontend/src/components/fetch-from-downloads-button.tsx
+++ b/frontend/src/components/fetch-from-downloads-button.tsx
@@ -172,7 +172,7 @@ export function FetchFromDownloadsButton({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-3 py-2">
+          <div className="min-w-0 space-y-3 py-2">
             <Label className="text-muted-foreground text-xs">Time window</Label>
             <ToggleGroup
               type="single"
@@ -245,7 +245,10 @@ export function FetchFromDownloadsButton({
                         data-testid="fetch-preview-item"
                         data-excluded={isExcluded ? "true" : "false"}
                       >
-                        <span className="flex-1 truncate" title={c.name}>
+                        <span
+                          className="min-w-0 flex-1 truncate"
+                          title={c.name}
+                        >
                           {c.name}
                         </span>
                         <button
@@ -258,7 +261,7 @@ export function FetchFromDownloadsButton({
                               return next;
                             })
                           }
-                          className="text-muted-foreground hover:text-foreground rounded p-0.5"
+                          className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5"
                           aria-label={
                             isExcluded
                               ? `Include ${c.name}`


### PR DESCRIPTION
## Problem

On windows narrower than Tailwind's \`sm\` breakpoint (640px) the *Fetch from Downloads* dialog spans nearly the full window (\`sm:max-w-md\` doesn't apply, so the primitive falls back to \`max-w-[calc(100%-2rem)]\`), and the preview list overflowed:

- Long filenames didn't truncate — they ran past the × button.
- The list's max-content pushed the \`DialogContent\` grid track wider than its own box, so the preview + header bled outside the dialog.

## Fix

`frontend/src/components/fetch-from-downloads-button.tsx`:
- `min-w-0` on the filename span so `flex-1 truncate` can actually shrink (classic flexbox truncation gotcha).
- `shrink-0` on the remove button.
- `min-w-0` on the content wrapper so the grid `auto` column stays bounded by the dialog width instead of the list's max-content.

The shared `ui/dialog.tsx` primitive is untouched.

## Verification

At a 500px viewport: list `scrollWidth ≤ dialog width`, and long names ellipsis-truncate. Added a narrow-viewport regression test to `e2e/fetch-from-downloads.spec.ts`. All 4 specs + typecheck pass.