### PR TITLE
fix(library): don't block Apply Rules when toggling the SoundCloud chip

### DIFF
--- a/frontend/e2e/apply-rules-sc-toggle.spec.ts
+++ b/frontend/e2e/apply-rules-sc-toggle.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "./fixtures";
+
+// Toggling the per-track SoundCloud chip on a track with no linked SC id used
+// to register as an "unsaved change", which tripped the unsaved-changes gate
+// and disabled Apply Rules ("Save your changes before applying rules") even
+// though nothing about the saved starlib_meta actually changed. The chip
+// toggle must only count as an edit when it alters what handleSave writes.
+test("toggling the SoundCloud chip on an unlinked track keeps Apply Rules enabled", async ({
+  page,
+}) => {
+  const filePath = "/music/test - track.mp3";
+
+  const browseBody = {
+    items: [
+      {
+        file_path: filePath,
+        file_name: "test - track.mp3",
+        file_size: 1000,
+        file_format: "mp3",
+        has_artwork: false,
+        title: "track",
+        artist: "test",
+        bpm: 120,
+        key: "Am",
+        genre: "techno",
+        comment: null,
+        release_date: "2024-01-01",
+        remixers: null,
+        soundcloud_id: null,
+        duration: 200,
+        mtime: Date.now() / 1000,
+      },
+    ],
+    total: 1,
+    page: 1,
+    size: 50,
+    pages: 1,
+  };
+  await page.route("**/api/metadata/folders/*/browse*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(browseBody),
+    }),
+  );
+  await page.route(/\/api\/metadata\/folders\/browse-path\?/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(browseBody),
+    }),
+  );
+  await page.route(/\/api\/metadata\/files\/.+\/info/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        file_path: filePath,
+        file_name: "test - track.mp3",
+        title: "track",
+        artist: "test",
+        bpm: 120,
+        key: "Am",
+        genre: "techno",
+        comment: null,
+        release_date: "2024-01-01",
+        remixers: null,
+        has_artwork: false,
+        is_ready: true,
+        missing_fields: [],
+        issues: [],
+      }),
+    }),
+  );
+
+  const ruleset = {
+    id: "rs-1",
+    name: "Test",
+    is_builtin: false,
+    rules: [
+      {
+        id: "copy",
+        type: "copy",
+        input: "source",
+        requires: [],
+        params: { folder: "archive" },
+      },
+    ],
+    required_attributes: [],
+  };
+  await page.route("**/api/rulesets", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rulesets: [ruleset],
+        active_ruleset_id: ruleset.id,
+      }),
+    }),
+  );
+  await page.route("**/api/folders/rulesets-by-path", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        folder_rulesets: { "/music": { ruleset_id: "rs-1", recursive: true } },
+      }),
+    }),
+  );
+
+  await page.goto("/library");
+  await page.waitForLoadState("networkidle");
+  const dataRow = page.locator('[data-index="0"]');
+  await dataRow.waitFor({ state: "visible" });
+  await dataRow.locator("[data-file-path]").first().click();
+  await page
+    .locator('input[data-slot="input"][placeholder="Title"]')
+    .waitFor({ state: "visible" });
+
+  const applyBtn = page.locator('[data-testid="apply-rules-button"]');
+  await applyBtn.waitFor({ state: "visible" });
+  await expect(applyBtn).toBeEnabled();
+
+  // Toggle the SoundCloud chip — no linked id exists, so saved metadata is
+  // unchanged and Apply Rules must remain enabled (regression: it used to
+  // disable with "Save your changes before applying rules").
+  await page.getByTestId("sc-link-toggle").click();
+  await expect(applyBtn).toBeEnabled();
+});

--- a/frontend/src/app/library/track-editor.tsx
+++ b/frontend/src/app/library/track-editor.tsx
@@ -565,16 +565,26 @@ export function TrackEditor({
     (scSearching || scQueryPending) &&
     !commentData.soundcloud_id &&
     !commentData.soundcloud_permalink;
+  // Toggling the SoundCloud chip only counts as an edit when it changes the
+  // serialized starlib_meta that handleSave actually writes. Enabling the chip
+  // on a track with no linked SC id writes nothing new, so it must not trip the
+  // unsaved-changes gate — which would otherwise block Apply rules (see #371).
+  const scMetaChanged =
+    serializeComment(
+      scLinkEnabled ? commentData.soundcloud_id : "",
+      scLinkEnabled ? commentData.soundcloud_permalink : "",
+    ) !==
+    serializeComment(
+      originalScLinkEnabled ? originalCommentData.soundcloud_id : "",
+      originalScLinkEnabled ? originalCommentData.soundcloud_permalink : "",
+    );
   const hasChanges =
     scBusy ||
     pendingArtworkData !== null ||
     (Object.keys(formData) as FormFieldKey[]).some(
       (k) => formData[k] !== originalFormData[k],
     ) ||
-    scLinkEnabled !== originalScLinkEnabled ||
-    commentData.soundcloud_id !== originalCommentData.soundcloud_id ||
-    commentData.soundcloud_permalink !==
-      originalCommentData.soundcloud_permalink;
+    scMetaChanged;
 
   // Show a hint when release_year and the year part of release_date disagree.
   const releaseDateYear =
@@ -1841,12 +1851,13 @@ export function TrackEditor({
               >
                 {/* Left chip: SC link toggle */}
                 <button
+                  data-testid="sc-link-toggle"
                   onClick={() => setScLinkEnabled(!scLinkEnabled)}
                   className={`text-2xs absolute -top-2.75 left-3 inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-0.5 font-semibold tracking-wider uppercase transition-all duration-150 ${
                     scLinkEnabled
                       ? "bg-card text-primary border shadow-sm"
                       : "bg-card text-muted-foreground hover:text-foreground border border-dashed"
-                  } ${scLinkEnabled !== originalScLinkEnabled ? "border-warning/70" : scLinkEnabled ? "border-border" : "border-border hover:border-border"}`}
+                  } ${scMetaChanged ? "border-warning/70" : scLinkEnabled ? "border-border" : "border-border hover:border-border"}`}
                 >
                   <activeSource.Icon className="size-2.5" />
                   SoundCloud


### PR DESCRIPTION
## Problem

Reported: on a track with **no** SoundCloud association, touching the per-track **SoundCloud** chip made *Apply Rules* impossible.

Cause is an accidental coupling — not an intentional "needs SoundCloud" gate. Toggling the chip flips `scLinkEnabled`, and `hasChanges` counted `scLinkEnabled !== originalScLinkEnabled` as an edit. But on an unlinked track, saving writes no new `starlib_meta`, so there's nothing to save — yet the unsaved-changes gate fired and disabled Apply Rules with *"Save your changes before applying rules."*

## Fix

`frontend/src/app/library/track-editor.tsx`: derive the SoundCloud portion of `hasChanges` from the serialized `starlib_meta` that `handleSave` actually writes (`serializeComment(...)`), instead of the raw toggle/field comparisons. Enabling the chip with no linked id produces identical serialized meta → not a change. The chip's pending-change border uses the same `scMetaChanged` signal so it stays honest.

The intentional gates are unchanged: unsaved *real* edits still block rules (#371), and classic's `artwork` requirement still applies.

## Verification

Added `e2e/apply-rules-sc-toggle.spec.ts`: opens an unlinked track with a folder ruleset, toggles the SoundCloud chip, asserts Apply Rules stays enabled. Verified it fails against the old behavior and passes with the fix. Related specs (apply-rules-busy, sc-link-switch, sc-link-button, track-editor-suggestions) + typecheck pass.