### PR TITLE
ci: build release notes from changelog + link docs for install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,35 @@ jobs:
               working-directory: desktop
               run: npm install
 
+            # ── Assemble the release body: release-please's changelog (what
+            # changed, pulled from the tagged CHANGELOG.md so both matrix jobs
+            # produce identical text) followed by a link to the docs.
+            - name: Assemble release notes
+              id: notes
+              shell: bash
+              run: |
+                  # Top-most version section of CHANGELOG.md, minus its own heading.
+                  CHANGES=$(awk '
+                      /^## / { blocks++ }
+                      blocks == 1 && !/^## / { print }
+                      blocks == 2 { exit }
+                  ' CHANGELOG.md)
+
+                  {
+                      echo "body<<RELEASE_NOTES_EOF"
+                      if [ -n "$CHANGES" ]; then
+                          echo "## What's changed"
+                          echo "$CHANGES"
+                          echo
+                      fi
+                      cat <<'INSTALL'
+                  ## Install
+
+                  See the [installation guide](https://fstermann.github.io/starlib/guide/installation/) to download and install Starlib, then the [setup guide](https://fstermann.github.io/starlib/guide/setup/) to connect your SoundCloud account.
+                  INSTALL
+                      echo "RELEASE_NOTES_EOF"
+                  } >> "$GITHUB_OUTPUT"
+
             # ── tauri-action: build, upload artifacts + latest.json to the release
             - name: Build and release
               uses: tauri-apps/tauri-action@v1
@@ -194,24 +223,7 @@ jobs:
                   projectPath: desktop
                   tagName: ${{ inputs.tag }}
                   releaseName: "Starlib ${{ inputs.tag }}"
-                  releaseBody: |
-                      ## Starlib ${{ inputs.tag }}
-
-                      ### Installation (macOS)
-
-                      1. Download the `.dmg` file for your Mac:
-                         - **Apple Silicon (M1/M2/M3):** `*-aarch64.dmg`
-                         - **Intel:** `*-x86_64.dmg`
-                      2. Open the `.dmg` and drag **Starlib** to your Applications folder.
-                      3. Remove the macOS quarantine flag (required for unsigned builds):
-                         ```bash
-                         xattr -cr /Applications/Starlib.app
-                         ```
-                      4. Follow the setup wizard to enter your SoundCloud API credentials.
-
-                      ### Getting SoundCloud API credentials
-                      Register a free app at https://soundcloud.com/you/apps, then copy your Client ID and Client Secret.
+                  releaseBody: ${{ steps.notes.outputs.body }}
                   releaseDraft: false
                   prerelease: false
-                  generateReleaseNotes: true
                   args: --target ${{ matrix.tauri-target }}


### PR DESCRIPTION
Follow-up to #553.

## What
- The release body is now assembled from the top section of release-please's `CHANGELOG.md` (**What's changed**), derived from the tagged file so both matrix arch jobs produce identical text.
- Dropped the inline **Installation (macOS)** and **Getting SoundCloud API credentials** blocks — they duplicated the docs. The body now links the [installation guide](https://fstermann.github.io/starlib/guide/installation/) and [setup guide](https://fstermann.github.io/starlib/guide/setup/).
- Removed `generateReleaseNotes: true` since we supply curated notes.

## Note
The equivalent changelog-in-body commit from #553 didn't make it into the squash merge, so this PR reintroduces it (with the docs-link install instead of inline steps). The **v0.6.0** release body has already been updated to this format by hand.