### PR TITLE
fix: stop silent backend-sidecar failures

### DIFF
--- a/desktop/scripts/setup-dev-sidecar.sh
+++ b/desktop/scripts/setup-dev-sidecar.sh
@@ -6,6 +6,24 @@
 #        Or automatically via: npm run desktop:dev
 set -e
 
+# ── Refuse to start if something already owns the backend port ────────────
+# Tauri spawns the sidecar unconditionally; if the port is taken the new
+# backend exits on bind and /health still answers from the orphan, so the app
+# silently runs against stale code. Fail here instead.
+BACKEND_PORT=8000
+EXISTING_PID=$(lsof -nP -tiTCP:"${BACKEND_PORT}" -sTCP:LISTEN 2>/dev/null | head -1 || true)
+if [[ -n "$EXISTING_PID" ]]; then
+  echo "Error: port ${BACKEND_PORT} is already in use by PID ${EXISTING_PID}:" >&2
+  ps -o pid,lstart,command -p "$EXISTING_PID" >&2
+  echo "" >&2
+  echo "The sidecar cannot bind, and the app would talk to that process instead." >&2
+  echo "Kill it with:" >&2
+  echo "" >&2
+  echo "  kill ${EXISTING_PID}" >&2
+  echo "" >&2
+  exit 1
+fi
+
 ARCH=$(rustc -vV | grep 'host:' | awk '{print $2}')
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DESKTOP_DIR="${SCRIPT_DIR}/.."

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -25,6 +25,22 @@ const HEALTH_RETRY_INTERVAL_MS: u64 = 500;
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 const RESTART_DELAY_MS: u64 = 2000;
 
+/// Managed handle to the running sidecar. `None` means "no live backend" —
+/// the watchdog's restart trigger.
+type BackendChild = std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>;
+
+/// Store (or clear, with `None`) the managed sidecar handle.
+fn set_backend_child(
+    handle: &tauri::AppHandle,
+    child: Option<tauri_plugin_shell::process::CommandChild>,
+) {
+    if let Some(mutex) = handle.try_state::<BackendChild>() {
+        if let Ok(mut guard) = mutex.lock() {
+            *guard = child;
+        }
+    }
+}
+
 /// Poll the backend /health endpoint until it responds or retries are exhausted.
 async fn wait_for_backend_ready() -> bool {
     let client = reqwest::Client::new();
@@ -49,16 +65,18 @@ async fn wait_for_backend_ready() -> bool {
     false
 }
 
-/// Spawn the sidecar and forward its output. Returns the child handle.
-fn spawn_sidecar(
-    app: &tauri::AppHandle,
-) -> Result<tauri_plugin_shell::process::CommandChild, String> {
+/// Spawn the sidecar, store its handle, and forward its output.
+fn spawn_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
     let shell = app.shell();
     let (mut rx, child) = shell
         .sidecar("starlib-backend")
         .expect("starlib-backend sidecar not found in bundle")
         .spawn()
         .map_err(|e| format!("Failed to spawn sidecar: {e}"))?;
+
+    // Store before the output task starts, so a Terminated event can never
+    // clear the slot ahead of us filling it.
+    set_backend_child(app, Some(child));
 
     let handle = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -73,6 +91,8 @@ fn spawn_sidecar(
                 }
                 CommandEvent::Terminated(status) => {
                     log::info!("[backend] process exited: {:?}", status);
+                    // Clear the handle so the watchdog sees the exit and respawns.
+                    set_backend_child(&handle, None);
                     let _ = handle.emit("backend-disconnected", "Backend process exited");
                     break;
                 }
@@ -81,15 +101,18 @@ fn spawn_sidecar(
         }
     });
 
-    Ok(child)
+    Ok(())
 }
 
 /// Start the Python backend sidecar with automatic restart on crash.
 /// Keeps a reference to the child process so it can be killed on app close.
 fn start_backend(app: &tauri::AppHandle) {
+    // Register the slot before spawning: a sidecar that dies immediately (e.g.
+    // the port is already taken) emits Terminated before we could store it,
+    // and that event must find the state in place to clear it.
+    app.manage(BackendChild::new(None));
     match spawn_sidecar(app) {
-        Ok(child) => {
-            app.manage(std::sync::Mutex::new(Some(child)));
+        Ok(()) => {
             // Spawn a watchdog that monitors and restarts on crash.
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
@@ -104,7 +127,7 @@ fn start_backend(app: &tauri::AppHandle) {
                     }
 
                     let needs_restart = {
-                        if let Some(mutex) = handle.try_state::<std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>>() {
+                        if let Some(mutex) = handle.try_state::<BackendChild>() {
                             if let Ok(guard) = mutex.lock() {
                                 guard.is_none()
                             } else {
@@ -134,17 +157,8 @@ fn start_backend(app: &tauri::AppHandle) {
                     }
 
                     log::warn!("[backend] restarting sidecar (attempt {attempts}/{MAX_RESTART_ATTEMPTS})");
-                    match spawn_sidecar(&handle) {
-                        Ok(child) => {
-                            if let Some(mutex) = handle.try_state::<std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>>() {
-                                if let Ok(mut guard) = mutex.lock() {
-                                    *guard = Some(child);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("[backend] restart failed: {e}");
-                        }
+                    if let Err(e) = spawn_sidecar(&handle) {
+                        log::error!("[backend] restart failed: {e}");
                     }
                 }
             });
@@ -237,7 +251,7 @@ pub fn run() {
                 // Dropping the child handle closes the stdin pipe; the Python
                 // sidecar detects stdin EOF and exits. We also send SIGTERM as
                 // a backup (PyInstaller's bootloader forwards it to the child).
-                if let Some(mutex) = window.app_handle().try_state::<std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>>() {
+                if let Some(mutex) = window.app_handle().try_state::<BackendChild>() {
                     if let Ok(mut guard) = mutex.lock() {
                         if let Some(child) = guard.take() {
                             let pid = child.pid();

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { BackendGate } from "@/components/backend-gate";
+import { BackendStatusListener } from "@/components/backend-status-listener";
 import {
   CommandPalette,
   CommandPaletteProvider,
@@ -55,6 +56,10 @@ export default function RootLayout({
         <LogInit />
         <DeepLinkListener />
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          {/* Above BackendGate: sidecar failures must be visible while the
+              gate is still waiting for /health. */}
+          <Toaster />
+          <BackendStatusListener />
           <TooltipProvider>
             <BackendGate>
               <NuqsAdapter>
@@ -68,7 +73,6 @@ export default function RootLayout({
                         <SetupGate>{children}</SetupGate>
                       </LayoutShell>
                       <WaveformPlayer />
-                      <Toaster />
                       <CommandPalette />
                     </CommandPaletteProvider>
                   </TopBarProvider>

--- a/frontend/src/components/backend-status-listener.tsx
+++ b/frontend/src/components/backend-status-listener.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+import { isTauri } from "@/lib/tauri";
+
+/**
+ * Surfaces the sidecar lifecycle events emitted by the Rust layer.
+ *
+ * `backend-disconnected` fires on every sidecar exit (the watchdog then
+ * retries), `backend-error` when it gave up or never became healthy.
+ */
+export function BackendStatusListener() {
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    const unlisteners: (() => void)[] = [];
+    let cancelled = false;
+
+    import("@tauri-apps/api/event").then(async (mod) => {
+      const disconnected = await mod.listen<string>(
+        "backend-disconnected",
+        () => {
+          toast.warning("Backend stopped — restarting…", {
+            id: "backend-status",
+          });
+        },
+      );
+      const failed = await mod.listen<string>("backend-error", (event) => {
+        toast.error(event.payload || "Backend unavailable", {
+          id: "backend-status",
+          duration: Infinity,
+        });
+      });
+      if (cancelled) {
+        disconnected();
+        failed();
+        return;
+      }
+      unlisteners.push(disconnected, failed);
+    });
+
+    return () => {
+      cancelled = true;
+      unlisteners.forEach((fn) => fn());
+    };
+  }, []);
+
+  return null;
+}

--- a/soundcloud_tools/handler/track.py
+++ b/soundcloud_tools/handler/track.py
@@ -45,6 +45,25 @@ def _find_binary(name: str) -> str:
     return name
 
 
+def _run_ffmpeg(command: list[Any]) -> None:
+    """Run an ffmpeg command with its stdio detached from the parent's.
+
+    ffmpeg inherits the parent's stdout/stderr by default. When the backend runs
+    without a reader on those pipes, ffmpeg's progress output triggers SIGPIPE and
+    the conversion dies mid-encode. Capturing the output keeps it alive and lets us
+    surface ffmpeg's own error message instead of a bare signal.
+
+    Raises
+    ------
+    RuntimeError
+        If ffmpeg exits with a non-zero status.
+    """
+    result = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise RuntimeError(f"ffmpeg failed (exit {result.returncode}): {stderr[-2000:] or '(no stderr)'}")
+
+
 FILETYPE_MAP = {
     ".mp3": MP3,
     ".aif": AIFF,
@@ -425,7 +444,7 @@ class TrackHandler(BaseModel):
             "-y",
             self.mp3_file,
         ]
-        subprocess.run(command, check=True)
+        _run_ffmpeg(command)
         return self.mp3_file
 
     def convert_to_aiff(self):
@@ -501,7 +520,7 @@ class TrackHandler(BaseModel):
             "-y",
             self.aiff_file,
         ]
-        subprocess.run(command, check=True)
+        _run_ffmpeg(command)
         return self.aiff_file
 
     def move_to_cleaned(self):
@@ -671,7 +690,7 @@ class TrackHandler(BaseModel):
                 "-y",
                 str(output_path),
             ]
-            subprocess.run(command, check=True)
+            _run_ffmpeg(command)
             return output_path
 
         if target_format == "aiff":
@@ -689,7 +708,7 @@ class TrackHandler(BaseModel):
                 "-y",
                 str(output_path),
             ]
-            subprocess.run(command, check=True)
+            _run_ffmpeg(command)
             return output_path
 
         return None


### PR DESCRIPTION
## Why

"Apply rules failed: … ffmpeg … died with `<Signals.SIGPIPE: 13>`" on any conversion — while the app was, unknowingly, talking to a backend process from six days earlier.

Four separate gaps lined up:

1. **ffmpeg inherited the parent's stdio.** With no reader on the backend's stderr, ffmpeg's progress output raised `SIGPIPE` and killed the conversion mid-encode. `subprocess.run(check=True)` reported only the bare signal — no ffmpeg message.
2. **No port preflight in dev.** Tauri spawns the sidecar unconditionally; with `:8000` already held by an orphan, uvicorn exits on bind while `wait_for_backend_ready()` gets a healthy 200 **from the orphan**. The app runs against stale code, silently.
3. **The watchdog never restarted anything.** `guard.is_none()` is its only "backend died" signal, but the `Terminated` handler never cleared the managed child handle — so the auto-restart advertised in the doc comment was dead code.
4. **Nothing listened to the failure events.** `backend-error` / `backend-disconnected` were emitted into the void; zero subscribers in `frontend/src`.

## What changed

- `soundcloud_tools/handler/track.py` — new `_run_ffmpeg()` runs with `stdin=DEVNULL` + captured output and raises with ffmpeg's own stderr. All four call sites use it.
- `desktop/scripts/setup-dev-sidecar.sh` — refuses to continue when `:8000` is taken; prints the offending process and the `kill <pid>` command.
- `desktop/src-tauri/src/lib.rs` — `Terminated` clears the child slot so the watchdog respawns. The slot is registered *before* the first spawn and written inside `spawn_sidecar` before the output task starts, so a sidecar that dies instantly can't race the store. Adds a `BackendChild` type alias for the thrice-repeated state type.
- `frontend/src/components/backend-status-listener.tsx` (new) — toasts both events. `<Toaster />` moves above `BackendGate` so a startup failure is visible while the gate is still polling `/health`.

## Testing

- Reproduced the original failure's fix: converted the offending 98 MB WAV to AIFF successfully.
- `bash desktop/scripts/setup-dev-sidecar.sh` against a live backend → exits 1 with the kill command; passes through when the port is free.
- `cargo check`, `npm run typecheck`, `npm run lint`, `pytest tests/test_track_handler.py` (13 passed), `npm run test:e2e:fast` (143 passed).

**Playwright coverage:** the status listener is gated on `isTauri()` and driven by Rust-emitted events, so it isn't reachable from the browser — no e2e test is possible per AGENTS.md's escape hatch. The closest achievable check is the existing toast suite, which still passes after the `<Toaster />` move.