### PR TITLE
feat(soundcloud): add 16 metadata columns to the library table

### DIFF
--- a/frontend/e2e/sc-metadata-columns.spec.ts
+++ b/frontend/e2e/sc-metadata-columns.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * The SoundCloud table exposes the full set of API metadata fields as
+ * opt-in columns. They are hidden by default; enabling one via the Columns
+ * menu renders its values and (where sortable) sorts by them.
+ */
+
+const TRACK_A = {
+  id: 1,
+  urn: "soundcloud:tracks:1",
+  title: "Alpha track",
+  user: { id: 1, username: "me" },
+  duration: 200_000,
+  created_at: "2023-01-15T00:00:00Z",
+  permalink_url: "https://soundcloud.com/me/alpha",
+  key_signature: "Amin",
+  label_name: "Alpha Records",
+  tag_list: 'techno "deep house" 909',
+  release_year: 2021,
+  release_month: 3,
+  release_day: 7,
+  favoritings_count: 4200,
+  reposts_count: 12,
+  comment_count: 3,
+  download_count: 55,
+  user_playback_count: 9,
+  isrc: "USAB12300001",
+  license: "cc-by-nc",
+  access: "playable",
+  sharing: "public",
+  metadata_artist: "Alpha Feat. Beta",
+  downloadable: true,
+  description: "First line\nSecond line",
+};
+
+const TRACK_B = {
+  id: 2,
+  urn: "soundcloud:tracks:2",
+  title: "Bravo track",
+  user: { id: 1, username: "me" },
+  duration: 200_000,
+  created_at: "2024-06-01T00:00:00Z",
+  permalink_url: "https://soundcloud.com/me/bravo",
+  key_signature: "Cmaj",
+  label_name: "Bravo Tapes",
+  release_year: 2019,
+  favoritings_count: 7,
+  sharing: "public",
+};
+
+async function setup(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("access_token", "fake-token");
+    window.localStorage.setItem(
+      "token_expires_at",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+    window.localStorage.setItem(
+      "sc_user",
+      JSON.stringify({
+        id: 1,
+        username: "me",
+        permalink: "me",
+        avatar_url: null,
+      }),
+    );
+  });
+
+  await page.route("https://api.soundcloud.com/me/likes/tracks*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        collection: [TRACK_A, TRACK_B],
+        next_href: null,
+      }),
+    }),
+  );
+  for (const url of [
+    "https://api.soundcloud.com/me/playlists*",
+    "https://api.soundcloud.com/me/feed/tracks*",
+  ]) {
+    await page.route(url, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ collection: [], next_href: null }),
+      }),
+    );
+  }
+  await page.route("**/api/metadata/collection/soundcloud-ids", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.route("**/api/bpm/soundcloud/bulk", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ bpms: {} }),
+    }),
+  );
+}
+
+/** Enable columns by label via the Columns dropdown. */
+async function showColumns(
+  page: import("@playwright/test").Page,
+  ...labels: string[]
+) {
+  await page.getByRole("button", { name: "Columns" }).click();
+  for (const label of labels) {
+    await page
+      .getByRole("menuitemcheckbox", { name: label, exact: true })
+      .click();
+  }
+  await page.keyboard.press("Escape");
+}
+
+function cell(
+  page: import("@playwright/test").Page,
+  row: number,
+  columnId: string,
+) {
+  return page.locator(`[data-index="${row}"] [data-column-id="${columnId}"]`);
+}
+
+test.describe("SoundCloud metadata columns", () => {
+  test("extended columns are hidden by default", async ({ page }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    for (const id of ["key_signature", "label_name", "isrc", "description"]) {
+      await expect(page.locator(`[data-column-id="${id}"]`)).toHaveCount(0);
+    }
+  });
+
+  test("enabling columns renders their API values", async ({ page }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    await showColumns(
+      page,
+      "Key",
+      "Label",
+      "Tags",
+      "Released",
+      "Likes",
+      "ISRC",
+      "License",
+      "Metadata artist",
+      "Description",
+    );
+
+    await expect(cell(page, 0, "key_signature")).toHaveText("Amin");
+    await expect(cell(page, 0, "label_name")).toHaveText("Alpha Records");
+    // tag_list is space-separated with quotes around multi-word tags.
+    await expect(cell(page, 0, "tag_list")).toHaveText(
+      "techno, deep house, 909",
+    );
+    // release_year/month/day → DD.MM.YYYY.
+    await expect(cell(page, 0, "released")).toHaveText("07.03.2021");
+    await expect(cell(page, 0, "favoritings_count")).toHaveText("4.2K");
+    await expect(cell(page, 0, "isrc")).toHaveText("USAB12300001");
+    await expect(cell(page, 0, "license")).toHaveText("cc-by-nc");
+    await expect(cell(page, 0, "metadata_artist")).toHaveText(
+      "Alpha Feat. Beta",
+    );
+    // Newlines collapse so the row stays single-line.
+    await expect(cell(page, 0, "description")).toHaveText(
+      "First line Second line",
+    );
+
+    // Missing fields fall back to an em-dash rather than rendering empty.
+    await expect(cell(page, 1, "isrc")).toHaveText("—");
+    await expect(cell(page, 1, "metadata_artist")).toHaveText("—");
+    // Year-only release date renders just the year.
+    await expect(cell(page, 1, "released")).toHaveText("2019");
+  });
+
+  test("Likes column sorts by favoritings_count", async ({ page }) => {
+    await setup(page);
+    await page.goto("/library?source=soundcloud");
+    await expect(page.locator("[data-index]")).toHaveCount(2, {
+      timeout: 5000,
+    });
+
+    await showColumns(page, "Likes");
+
+    const header = page.getByRole("row").first();
+    // Ascending → Bravo (7) before Alpha (4200).
+    await header.locator("button", { hasText: "Likes" }).click();
+    await expect(page.locator('[data-index="0"]')).toContainText("Bravo track");
+
+    // Descending → Alpha first.
+    await header.locator("button", { hasText: "Likes" }).click();
+    await expect(page.locator('[data-index="0"]')).toContainText("Alpha track");
+  });
+});

--- a/frontend/src/components/columns/column-visibility-menu.tsx
+++ b/frontend/src/components/columns/column-visibility-menu.tsx
@@ -18,7 +18,7 @@ export interface ColumnVisibilityMenuProps {
   columns: ColumnDef[];
   isVisible: (id: string) => boolean;
   setHidden: (id: string, hidden: boolean) => void;
-  /** Restore all columns to visible. */
+  /** Restore every column to its default visibility. */
   onResetVisibility: () => void;
   /** Optional: reset the column order. Only shown when drag-reorder is wired. */
   onResetOrder?: () => void;

--- a/frontend/src/components/likes-table.tsx
+++ b/frontend/src/components/likes-table.tsx
@@ -19,6 +19,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
   Ban,
+  Check,
   ChevronDown,
   Download,
   FolderCheck,
@@ -99,7 +100,20 @@ type SortKey =
   | "duration"
   | "playback_count"
   | "uploaded"
-  | "added";
+  | "added"
+  | "key_signature"
+  | "label_name"
+  | "released"
+  | "favoritings_count"
+  | "reposts_count"
+  | "comment_count"
+  | "download_count"
+  | "user_playback_count"
+  | "isrc"
+  | "license"
+  | "access"
+  | "sharing"
+  | "metadata_artist";
 type SortOrder = "asc" | "desc";
 
 /** A single source of truth for likes-table columns. Drives both the header
@@ -110,6 +124,9 @@ interface LikesCol {
   header: string;
   sortKey?: SortKey;
   required?: boolean;
+  /** Columns default to visible; the extended metadata columns opt out so the
+   *  table stays readable until the user enables them. */
+  defaultVisible?: boolean;
   defaultWidth: number;
   /** Style classes applied to the cell (no width — that's inline). */
   cellClassName: string;
@@ -243,6 +260,168 @@ const LIKES_COLUMNS: LikesCol[] = [
     renderBody: ({ track }) => <>{formatDate(track.addedAt)}</>,
   },
   {
+    id: "key_signature",
+    header: "Key",
+    sortKey: "key_signature",
+    defaultVisible: false,
+    defaultWidth: 64,
+    cellClassName: "text-muted-foreground shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.key_signature || "—"}</>,
+  },
+  {
+    id: "label_name",
+    header: "Label",
+    sortKey: "label_name",
+    defaultVisible: false,
+    defaultWidth: 140,
+    cellClassName: "text-muted-foreground min-w-0 shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.label_name || "—"}</>,
+  },
+  {
+    id: "metadata_artist",
+    header: "Metadata artist",
+    sortKey: "metadata_artist",
+    defaultVisible: false,
+    defaultWidth: 160,
+    cellClassName: "text-muted-foreground min-w-0 shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.metadata_artist || "—"}</>,
+  },
+  {
+    id: "tag_list",
+    header: "Tags",
+    defaultVisible: false,
+    defaultWidth: 200,
+    cellClassName: "text-muted-foreground min-w-0 shrink-0 truncate text-xs",
+    renderBody: ({ track }) => {
+      const tags = parseTagList(track.tag_list);
+      if (!tags.length) return <>—</>;
+      return <span title={tags.join(", ")}>{tags.join(", ")}</span>;
+    },
+  },
+  {
+    id: "released",
+    header: "Released",
+    sortKey: "released",
+    defaultVisible: false,
+    defaultWidth: 96,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatRelease(track)}</>,
+  },
+  {
+    id: "favoritings_count",
+    header: "Likes",
+    sortKey: "favoritings_count",
+    defaultVisible: false,
+    defaultWidth: 64,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatPlays(track.favoritings_count)}</>,
+  },
+  {
+    id: "reposts_count",
+    header: "Reposts",
+    sortKey: "reposts_count",
+    defaultVisible: false,
+    defaultWidth: 72,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatPlays(track.reposts_count)}</>,
+  },
+  {
+    id: "comment_count",
+    header: "Comments",
+    sortKey: "comment_count",
+    defaultVisible: false,
+    defaultWidth: 80,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatPlays(track.comment_count)}</>,
+  },
+  {
+    id: "download_count",
+    header: "Downloads",
+    sortKey: "download_count",
+    defaultVisible: false,
+    defaultWidth: 84,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatPlays(track.download_count)}</>,
+  },
+  {
+    id: "user_playback_count",
+    header: "My plays",
+    sortKey: "user_playback_count",
+    defaultVisible: false,
+    defaultWidth: 72,
+    cellClassName:
+      "text-muted-foreground shrink-0 text-right text-xs tabular-nums",
+    renderBody: ({ track }) => <>{formatPlays(track.user_playback_count)}</>,
+  },
+  {
+    id: "downloadable",
+    header: "DL",
+    defaultVisible: false,
+    defaultWidth: 40,
+    cellClassName: "text-muted-foreground shrink-0 flex justify-center",
+    renderBody: ({ track }) =>
+      track.downloadable || track.download_url ? (
+        <Check className="text-primary size-3.5" aria-label="Downloadable" />
+      ) : (
+        <>—</>
+      ),
+  },
+  {
+    id: "access",
+    header: "Access",
+    sortKey: "access",
+    defaultVisible: false,
+    defaultWidth: 80,
+    cellClassName: "text-muted-foreground shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.access || "—"}</>,
+  },
+  {
+    id: "sharing",
+    header: "Sharing",
+    sortKey: "sharing",
+    defaultVisible: false,
+    defaultWidth: 72,
+    cellClassName: "text-muted-foreground shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.sharing || "—"}</>,
+  },
+  {
+    id: "license",
+    header: "License",
+    sortKey: "license",
+    defaultVisible: false,
+    defaultWidth: 110,
+    cellClassName: "text-muted-foreground min-w-0 shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.license || "—"}</>,
+  },
+  {
+    id: "isrc",
+    header: "ISRC",
+    sortKey: "isrc",
+    defaultVisible: false,
+    defaultWidth: 120,
+    cellClassName: "text-muted-foreground shrink-0 truncate text-xs",
+    renderBody: ({ track }) => <>{track.isrc || "—"}</>,
+  },
+  {
+    id: "description",
+    header: "Description",
+    defaultVisible: false,
+    defaultWidth: 240,
+    cellClassName: "text-muted-foreground min-w-0 shrink-0 truncate text-xs",
+    renderBody: ({ track }) => {
+      // Collapse newlines — SC descriptions are multi-line and a raw value
+      // would blow out the single-line row.
+      const text = track.description?.replace(/\s+/g, " ").trim();
+      if (!text) return <>—</>;
+      return <span title={track.description}>{text}</span>;
+    },
+  },
+  {
     id: "links",
     header: "Links",
     defaultWidth: 84,
@@ -293,6 +472,7 @@ export const LIKES_COLUMN_DEFS: ColumnDef[] = LIKES_COLUMNS.filter(
   id: c.id,
   header: c.header,
   required: c.required,
+  defaultVisible: c.defaultVisible,
 }));
 
 const LIKES_COLUMNS_BY_ID = new Map(LIKES_COLUMNS.map((c) => [c.id, c]));
@@ -330,6 +510,57 @@ function formatDate(value: string | undefined): string {
 
 function dateValue(value: string | undefined): number {
   return parseSCTimestamp(value) ?? 0;
+}
+
+/** Sort value per key. String accessors sort alphabetically, numeric ones
+ *  numerically; missing values collapse to `""`/`0` so they group together. */
+const SORT_ACCESSORS: Record<SortKey, (t: SCTrack) => string | number> = {
+  title: (t) => t.title ?? "",
+  artist: (t) => t.user?.username ?? "",
+  genre: (t) => t.genre ?? "",
+  duration: (t) => t.duration ?? 0,
+  playback_count: (t) => t.playback_count ?? 0,
+  uploaded: (t) => dateValue(t.created_at),
+  added: (t) => dateValue(t.addedAt),
+  key_signature: (t) => t.key_signature ?? "",
+  label_name: (t) => t.label_name ?? "",
+  released: releaseValue,
+  favoritings_count: (t) => t.favoritings_count ?? 0,
+  reposts_count: (t) => t.reposts_count ?? 0,
+  comment_count: (t) => t.comment_count ?? 0,
+  download_count: (t) => t.download_count ?? 0,
+  user_playback_count: (t) => t.user_playback_count ?? 0,
+  isrc: (t) => t.isrc ?? "",
+  license: (t) => t.license ?? "",
+  access: (t) => t.access ?? "",
+  sharing: (t) => t.sharing ?? "",
+  metadata_artist: (t) => t.metadata_artist ?? "",
+};
+
+/** Split SoundCloud's `tag_list` (space-separated, quotes around multi-word
+ *  tags) into individual tags. */
+function parseTagList(value: string | undefined): string[] {
+  if (!value) return [];
+  return Array.from(value.matchAll(/"([^"]*)"|(\S+)/g))
+    .map((m) => (m[1] ?? m[2] ?? "").trim())
+    .filter(Boolean);
+}
+
+/** Release date from SC's split `release_year`/`release_month`/`release_day`
+ *  fields. Falls back to just the year when month/day are missing. */
+function formatRelease(track: SCTrack): string {
+  const { release_year: y, release_month: m, release_day: d } = track;
+  if (!y) return "—";
+  if (!m) return String(y);
+  const mm = String(m).padStart(2, "0");
+  if (!d) return `${mm}.${y}`;
+  return `${String(d).padStart(2, "0")}.${mm}.${y}`;
+}
+
+function releaseValue(track: SCTrack): number {
+  const { release_year: y, release_month: m, release_day: d } = track;
+  if (!y) return 0;
+  return y * 10000 + (m ?? 0) * 100 + (d ?? 0);
 }
 
 function formatPlays(count: number | undefined): string {
@@ -755,6 +986,7 @@ function TrackRowInner({
           {visibleColumns.map((col) => (
             <div
               key={col.id}
+              data-column-id={col.id}
               className={col.cellClassName}
               style={{ width: col.width }}
             >
@@ -1050,7 +1282,10 @@ export function LikesTable({
       // true from isColumnVisible. Without this guard, callers that don't
       // pass a predicate would see an empty 32px column on every row.
       if (id === "source") return isColumnVisible?.(id) === true;
-      return isColumnVisible ? isColumnVisible(id) : true;
+      if (isColumnVisible) return isColumnVisible(id);
+      // No predicate (e.g. the weekly view): fall back to the column's own
+      // default so the extended metadata columns stay hidden.
+      return LIKES_COLUMNS_BY_ID.get(id)?.defaultVisible !== false;
     },
     [isColumnVisible],
   );
@@ -1088,31 +1323,14 @@ export function LikesTable({
 
   const sortedTracks = useMemo(() => {
     if (!sortBy) return tracks;
+    const accessor = SORT_ACCESSORS[sortBy];
     const sorted = [...tracks].sort((a, b) => {
-      let cmp = 0;
-      switch (sortBy) {
-        case "title":
-          cmp = (a.title ?? "").localeCompare(b.title ?? "");
-          break;
-        case "artist":
-          cmp = (a.user?.username ?? "").localeCompare(b.user?.username ?? "");
-          break;
-        case "genre":
-          cmp = (a.genre ?? "").localeCompare(b.genre ?? "");
-          break;
-        case "duration":
-          cmp = (a.duration ?? 0) - (b.duration ?? 0);
-          break;
-        case "playback_count":
-          cmp = (a.playback_count ?? 0) - (b.playback_count ?? 0);
-          break;
-        case "uploaded":
-          cmp = dateValue(a.created_at) - dateValue(b.created_at);
-          break;
-        case "added":
-          cmp = dateValue(a.addedAt) - dateValue(b.addedAt);
-          break;
-      }
+      const va = accessor(a);
+      const vb = accessor(b);
+      const cmp =
+        typeof va === "string"
+          ? va.localeCompare(vb as string)
+          : va - (vb as number);
       return sortOrder === "asc" ? cmp : -cmp;
     });
     return sorted;

--- a/frontend/src/lib/columns/types.ts
+++ b/frontend/src/lib/columns/types.ts
@@ -18,13 +18,21 @@ export interface ColumnDef {
 export interface ColumnPrefs {
   /** IDs of columns the user has explicitly hidden. */
   hidden: string[];
+  /** IDs of columns the user has explicitly shown. Only meaningful for
+   *  columns with `defaultVisible: false`. */
+  shown: string[];
   /** User-chosen column order by id. Empty means "use the defs' natural order". */
   order: string[];
   /** User-resized column widths by id (pixels). Missing = use default. */
   widths: Record<string, number>;
 }
 
-export const emptyPrefs: ColumnPrefs = { hidden: [], order: [], widths: {} };
+export const emptyPrefs: ColumnPrefs = {
+  hidden: [],
+  shown: [],
+  order: [],
+  widths: {},
+};
 
 /**
  * Applies a user order to a column list. Unknown ids in `order` are ignored;
@@ -55,5 +63,6 @@ export function applyOrder<T extends { id: string }>(
 export function isColumnVisible(col: ColumnDef, prefs: ColumnPrefs): boolean {
   if (col.required) return true;
   if (prefs.hidden.includes(col.id)) return false;
+  if (prefs.shown.includes(col.id)) return true;
   return col.defaultVisible !== false;
 }

--- a/frontend/src/lib/columns/use-column-prefs.ts
+++ b/frontend/src/lib/columns/use-column-prefs.ts
@@ -45,6 +45,7 @@ export function useColumnPrefs(
         // Normalize older stored shapes that may lack fields added later.
         setPrefs({
           hidden: Array.isArray(loaded.hidden) ? loaded.hidden : [],
+          shown: Array.isArray(loaded.shown) ? loaded.shown : [],
           order: Array.isArray(loaded.order) ? loaded.order : [],
           widths:
             loaded.widths && typeof loaded.widths === "object"
@@ -70,11 +71,16 @@ export function useColumnPrefs(
     (id: string, hidden: boolean) => {
       const col = columns.find((c) => c.id === id);
       if (col?.required) return;
+      // Both lists are maintained so the choice survives a change to the
+      // column's own default: an explicit toggle always wins.
       persist({
         ...prefs,
         hidden: hidden
           ? Array.from(new Set([...prefs.hidden, id]))
           : prefs.hidden.filter((h) => h !== id),
+        shown: hidden
+          ? prefs.shown.filter((s) => s !== id)
+          : Array.from(new Set([...prefs.shown, id])),
       });
     },
     [columns, prefs, persist],
@@ -103,7 +109,7 @@ export function useColumnPrefs(
   );
 
   const resetVisibility = React.useCallback(
-    () => persist({ ...prefs, hidden: [] }),
+    () => persist({ ...prefs, hidden: [], shown: [] }),
     [prefs, persist],
   );
 


### PR DESCRIPTION
## What

The SoundCloud table showed 9 columns while the v1 `Track` response carries far more. This adds the rest as opt-in columns:

Key · Label · Metadata artist · Tags · Released · Likes · Reposts · Comments · Downloads · My plays · DL · Access · Sharing · License · ISRC · Description

All default to hidden — the table looks unchanged until you enable them in the Columns menu. Everything is sortable except Tags, DL, and Description.

Non-obvious ones:

- **Tags** — `tag_list` is a space-separated string with quotes around multi-word tags; parsed into `techno, deep house, 909`.
- **Released** — assembled from `release_year/month/day`, degrading to `MM.YYYY` or `YYYY` when parts are missing. Distinct from Uploaded (`created_at`).
- **DL** — checkmark when `downloadable` or `download_url` is set.
- **Description** — newlines collapsed so rows stay single-line; full text in the tooltip.

The sort `switch` became a `SORT_ACCESSORS` map rather than growing by 13 cases.

## Bug this surfaced

`ColumnPrefs` only tracked `hidden[]`, so a `defaultVisible: false` column could never be turned on — checking it in the menu removed an id that was never there. Added a `shown[]` list, consulted by `isColumnVisible` before falling back to the column's default; "Reset visibility" clears both. Stored prefs without the field normalize to `[]` on load.

Relatedly, the weekly view renders `LikesTable` without a visibility predicate, which previously meant "show everything". It now falls back to each column's own default, so the new columns stay off there too.

## Tests

`frontend/e2e/sc-metadata-columns.spec.ts` — hidden by default; enabling nine columns renders the right values (tag parsing, both release-date shapes, em-dash fallbacks); Likes sorts by `favoritings_count`. Added `data-column-id` to body cells so the spec can target columns directly.

Typecheck, lint, format, 124 unit tests, and the 15 related e2e specs pass.

## Caveat

`key_signature`, `label_name`, and `isrc` are in the schema but empty for most SC uploads — those columns will often be all em-dashes in practice.