### PR TITLE
perf(backend): cut redundant work out of scanning, browsing and upstream calls

### DIFF
--- a/backend/api/metadata/artwork.py
+++ b/backend/api/metadata/artwork.py
@@ -122,7 +122,9 @@ async def update_file_artwork(
             detail="Failed to embed artwork",
         ) from e
 
-    indexing.invalidate_cache()
+    # Only this file changed — a bare invalidate_cache() would drop the
+    # whole session index and force a full re-scan of every folder.
+    indexing.reindex_file(root_folder, resolved_path)
 
     return OperationResponse(
         success=True,
@@ -165,7 +167,7 @@ def delete_file_artwork(
             detail="Failed to remove artwork",
         ) from e
 
-    indexing.invalidate_cache()
+    indexing.reindex_file(root_folder, resolved_path)
 
     return OperationResponse(
         success=True,

--- a/backend/api/metadata/browse.py
+++ b/backend/api/metadata/browse.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi_pagination import Page, paginate
+from fastapi_pagination.api import create_page, resolve_params
 
 from backend.api.deps import get_root_folder, validate_folder_mode
 from backend.api.metadata._helpers import _row_to_browse_dict, _row_value, resolve_folder
@@ -170,7 +171,28 @@ def browse_by_path(
 
     indexing.ensure_folder_indexed(folder_path, root_folder=resolved_root)
 
+    # Page in SQL. Materialising the whole folder and slicing it in Python
+    # costs the full row set on every page request.
+    params = resolve_params()
+    raw = params.to_raw_params().as_limit_offset()
+
     try:
+        total = query.count_filtered_tracks(
+            folder=folder_path,
+            search_query=search,
+            genres=genres,
+            artists=artists,
+            keys=keys,
+            bpm_min=bpm_min,
+            bpm_max=bpm_max,
+            start_date=date_from,
+            end_date=date_to,
+            has_soundcloud_id=has_soundcloud_id,
+            file_formats=file_formats,
+            size_min=size_min,
+            size_max=size_max,
+            recursive=recursive,
+        )
         pairs = query.list_and_filter_tracks(
             folder=folder_path,
             search_query=search,
@@ -185,9 +207,11 @@ def browse_by_path(
             file_formats=file_formats,
             size_min=size_min,
             size_max=size_max,
+            recursive=recursive,
             sort_by=sort_by,
             sort_order=sort_order,
-            recursive=recursive,
+            limit=raw.limit,
+            offset=raw.offset,
         )
     except Exception as e:
         logger.exception("Failed to list tracks")
@@ -213,7 +237,7 @@ def browse_by_path(
     if indexing.is_indexing(folder_path):
         response.headers["X-Cache-Loading"] = "true"
 
-    return paginate(pairs, transformer=lambda items: [to_browse_response(p) for p in items])
+    return create_page([to_browse_response(row) for row in pairs], total=total, params=params)
 
 
 @router.get("/folders/browse-path/filter-values", response_model=FilterValuesResponse)
@@ -359,7 +383,27 @@ def browse_folder_files(
     """
     folder_path = resolve_folder(mode, root_folder)
 
+    # Page in SQL. Materialising the whole folder and slicing it in Python
+    # costs the full row set on every page request.
+    params = resolve_params()
+    raw = params.to_raw_params().as_limit_offset()
+
     try:
+        total = query.count_filtered_tracks(
+            folder=folder_path,
+            search_query=search,
+            genres=genres,
+            artists=artists,
+            keys=keys,
+            bpm_min=bpm_min,
+            bpm_max=bpm_max,
+            start_date=date_from,
+            end_date=date_to,
+            has_soundcloud_id=has_soundcloud_id,
+            file_formats=file_formats,
+            size_min=size_min,
+            size_max=size_max,
+        )
         pairs = query.list_and_filter_tracks(
             folder=folder_path,
             search_query=search,
@@ -376,6 +420,8 @@ def browse_folder_files(
             size_max=size_max,
             sort_by=sort_by,
             sort_order=sort_order,
+            limit=raw.limit,
+            offset=raw.offset,
         )
     except Exception as e:
         logger.exception("Failed to list tracks")
@@ -401,7 +447,7 @@ def browse_folder_files(
     if indexing.is_indexing(folder_path):
         response.headers["X-Cache-Loading"] = "true"
 
-    return paginate(pairs, transformer=lambda items: [to_browse_response(p) for p in items])
+    return create_page([to_browse_response(row) for row in pairs], total=total, params=params)
 
 
 @router.get("/folders/{mode}/filter-values", response_model=FilterValuesResponse)

--- a/backend/infra/ai/ollama.py
+++ b/backend/infra/ai/ollama.py
@@ -24,6 +24,27 @@ logger = logging.getLogger(__name__)
 
 _TIMEOUT = 5.0  # seconds for health/model requests
 
+# One client for the process — a fresh AsyncClient per call discards the
+# connection pool and re-handshakes against the local Ollama server.
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return the shared client, creating it on first use."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=_TIMEOUT)
+    return _client
+
+
+async def close_client() -> None:
+    """Close the shared client. Called on application shutdown."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
 # Process lifecycle — only set when *we* spawned Ollama.
 _process: subprocess.Popen | None = None
 
@@ -50,9 +71,8 @@ def is_installed() -> bool:
 async def is_available() -> bool:
     """Return True if the Ollama server is reachable."""
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.get(f"{_base_url()}/api/tags")
-            return resp.status_code == 200
+        resp = await get_client().get(f"{_base_url()}/api/tags")
+        return resp.status_code == 200
     except (httpx.HTTPError, OSError):
         return False
 
@@ -152,18 +172,17 @@ for _sig in (signal.SIGTERM, signal.SIGINT):
 async def list_models() -> list[OllamaModel]:
     """Return models installed on the Ollama server."""
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.get(f"{_base_url()}/api/tags")
-            resp.raise_for_status()
-            data = resp.json()
-            return [
-                OllamaModel(
-                    name=m["name"],
-                    size=m.get("size", 0),
-                    digest=m.get("digest", ""),
-                )
-                for m in data.get("models", [])
-            ]
+        resp = await get_client().get(f"{_base_url()}/api/tags")
+        resp.raise_for_status()
+        data = resp.json()
+        return [
+            OllamaModel(
+                name=m["name"],
+                size=m.get("size", 0),
+                digest=m.get("digest", ""),
+            )
+            for m in data.get("models", [])
+        ]
     except (httpx.HTTPError, OSError) as exc:
         logger.warning("Failed to list Ollama models: %s", exc)
         return []
@@ -199,8 +218,9 @@ async def chat(
     if format:
         body["format"] = format
 
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.post(url, json=body)
-        resp.raise_for_status()
-        data = resp.json()
-        return data["message"]["content"]
+    # Generation is far slower than the metadata calls, so this one call
+    # overrides the client-wide timeout.
+    resp = await get_client().post(url, json=body, timeout=120.0)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["message"]["content"]

--- a/backend/infra/ai/ollama.py
+++ b/backend/infra/ai/ollama.py
@@ -26,23 +26,31 @@ _TIMEOUT = 5.0  # seconds for health/model requests
 
 # One client for the process — a fresh AsyncClient per call discards the
 # connection pool and re-handshakes against the local Ollama server.
+#
+# Keyed on the running loop, not merely cached: pooled connections belong to
+# the loop that opened them, so reusing a client across loops raises
+# "Event loop is closed".
 _client: httpx.AsyncClient | None = None
+_client_loop: asyncio.AbstractEventLoop | None = None
 
 
 def get_client() -> httpx.AsyncClient:
-    """Return the shared client, creating it on first use."""
-    global _client
-    if _client is None or _client.is_closed:
+    """Return the shared client for the running loop, creating it on first use."""
+    global _client, _client_loop
+    loop = asyncio.get_running_loop()
+    if _client is None or _client.is_closed or _client_loop is not loop:
         _client = httpx.AsyncClient(timeout=_TIMEOUT)
+        _client_loop = loop
     return _client
 
 
 async def close_client() -> None:
     """Close the shared client. Called on application shutdown."""
-    global _client
+    global _client, _client_loop
     if _client is not None and not _client.is_closed:
         await _client.aclose()
     _client = None
+    _client_loop = None
 
 
 # Process lifecycle — only set when *we* spawned Ollama.

--- a/backend/infra/audio/track_handler.py
+++ b/backend/infra/audio/track_handler.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterable
+from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal, Self
 
@@ -118,8 +119,15 @@ class TrackHandler(BaseModel):
         lossless_extensions = {".aif", ".aiff", ".wav", ".flac", ".alac"}
         return self.file.suffix.lower() in lossless_extensions
 
-    @property
+    @cached_property
     def track(self):
+        """The parsed mutagen object for this file.
+
+        Cached: opening the file re-reads and re-parses every ID3 frame,
+        embedded artwork included.  A handler is always short-lived (one per
+        file, per operation), and the write helpers mutate this object before
+        calling ``save()``, so the cached copy never drifts from disk.
+        """
         class_ = FILETYPE_MAP.get(Path(self.file).suffix, EasyID3)
         obj = class_(self.file)
         if not hasattr(obj, "tags") or obj.tags is None:
@@ -181,11 +189,12 @@ class TrackHandler(BaseModel):
         return self.track.tags.getall("APIC")
 
     def get_single_cover(self, raise_error: bool = True):
-        if len(self.covers) != 1:
+        covers = self.covers
+        if len(covers) != 1:
             if raise_error:
                 raise ValueError("Track has more than one cover")
-            return self.covers[0].data if self.covers else None
-        return self.covers[0].data
+            return covers[0].data if covers else None
+        return covers[0].data
 
     def convert_to_mp3(self):
         if not self.cleaned_folder.exists():

--- a/backend/infra/cache.py
+++ b/backend/infra/cache.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable, Sequence
 from datetime import date
 from pathlib import Path
 
@@ -85,7 +86,7 @@ def init_db(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def upsert_track(
+def track_row(
     *,
     file_path: Path,
     folder: Path,
@@ -108,10 +109,13 @@ def upsert_track(
     mix_name: str | None = None,
     release_year: int | None = None,
     user_comment: str | None = None,
-) -> None:
-    """Insert or replace a track row."""
-    engine = get_engine()
-    row = {
+) -> dict:
+    """Build the column dict for one track row.
+
+    Split out from :func:`upsert_track` so the indexer can assemble many rows
+    off-thread and write them in one batched transaction.
+    """
+    return {
         "file_path": str(file_path),
         "file_name": file_path.name,
         "folder": str(folder),
@@ -135,15 +139,36 @@ def upsert_track(
         "mtime": mtime,
         "soundcloud_id": soundcloud_id,
     }
+
+
+def _upsert_stmt(row_keys: Iterable[str]):
+    """Build the INSERT ... ON CONFLICT DO UPDATE statement for track rows."""
     # Use raw SQLite "INSERT OR REPLACE" semantics via SQLAlchemy Core to keep
     # the single-round-trip behaviour the caller relied on previously.
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-    stmt = sqlite_insert(Track.__table__).values(row)
-    update_cols = {c: stmt.excluded[c] for c in row if c != "file_path"}
-    stmt = stmt.on_conflict_do_update(index_elements=[Track.__table__.c.file_path], set_=update_cols)
-    with engine.begin() as conn:
-        conn.execute(stmt)
+    stmt = sqlite_insert(Track.__table__)
+    update_cols = {c: stmt.excluded[c] for c in row_keys if c != "file_path"}
+    return stmt.on_conflict_do_update(index_elements=[Track.__table__.c.file_path], set_=update_cols)
+
+
+def upsert_track(**kwargs) -> None:
+    """Insert or replace a single track row."""
+    row = track_row(**kwargs)
+    with get_engine().begin() as conn:
+        conn.execute(_upsert_stmt(row), [row])
+
+
+def upsert_tracks(rows: Sequence[dict]) -> None:
+    """Insert or replace many track rows in one transaction.
+
+    Every row must carry the same columns — they all come from
+    :func:`track_row`, so that holds by construction.
+    """
+    if not rows:
+        return
+    with get_engine().begin() as conn:
+        conn.execute(_upsert_stmt(rows[0]), list(rows))
 
 
 def update_track_bpm(file_path: Path, bpm: int) -> bool:
@@ -201,6 +226,18 @@ def get_track_mtime(file_path: Path) -> float | None:
     with get_engine().connect() as conn:
         row = conn.execute(select(Track.mtime).where(Track.file_path == str(file_path))).first()
     return float(row[0]) if row else None
+
+
+def get_track_mtimes(folder: Path, *, recursive: bool = False) -> dict[str, float]:
+    """Return ``{file_path: mtime}`` for every indexed track under *folder*.
+
+    One query instead of a ``get_track_mtime`` per file — a folder scan
+    otherwise issues a round trip for each file on disk just to decide it has
+    nothing to do.
+    """
+    with get_engine().connect() as conn:
+        rows = conn.execute(select(Track.file_path, Track.mtime).where(_folder_clause(folder, recursive))).all()
+    return {str(r[0]): float(r[1]) for r in rows}
 
 
 def get_tracks_missing_bpm(folder: Path, recursive: bool = False) -> list[str]:
@@ -352,8 +389,14 @@ def get_tracks(
     size_max: int | None = None,
     sort_by: str = "file_name",
     sort_order: str = "asc",
+    limit: int | None = None,
+    offset: int | None = None,
 ):
-    """Return filtered and sorted track rows as mapping-style objects."""
+    """Return filtered and sorted track rows as mapping-style objects.
+
+    When *limit* is given the slice is taken in SQL.  Callers that page must
+    pass it — otherwise every page request materialises the entire folder.
+    """
     stmt = _apply_filters(
         select(Track),
         folder=folder,
@@ -385,8 +428,57 @@ def get_tracks(
     else:
         stmt = stmt.order_by(order_expr)
 
+    # file_path is the primary key, so this makes the ordering total — without
+    # it two rows tying on the sort column can swap between pages and a row is
+    # shown twice (or skipped) as the user scrolls.
+    stmt = stmt.order_by(Track.file_path.asc())
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    if offset:
+        stmt = stmt.offset(offset)
+
     with get_engine().connect() as conn:
         return conn.execute(stmt).mappings().all()
+
+
+def count_tracks(
+    folder: Path,
+    *,
+    recursive: bool = False,
+    search_query: str | None = None,
+    genres: list[str] | None = None,
+    artists: list[str] | None = None,
+    keys: list[str] | None = None,
+    bpm_min: int | None = None,
+    bpm_max: int | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    has_soundcloud_id: bool | None = None,
+    file_formats: list[str] | None = None,
+    size_min: int | None = None,
+    size_max: int | None = None,
+) -> int:
+    """Count rows matching the same filters :func:`get_tracks` applies."""
+    stmt = _apply_filters(
+        select(func.count()).select_from(Track),
+        folder=folder,
+        recursive=recursive,
+        search_query=search_query,
+        genres=genres,
+        artists=artists,
+        keys=keys,
+        bpm_min=bpm_min,
+        bpm_max=bpm_max,
+        start_date=start_date,
+        end_date=end_date,
+        has_soundcloud_id=has_soundcloud_id,
+        file_formats=file_formats,
+        size_min=size_min,
+        size_max=size_max,
+    )
+    with get_engine().connect() as conn:
+        return int(conn.execute(stmt).scalar_one())
 
 
 # ---------------------------------------------------------------------------

--- a/backend/infra/db/engine.py
+++ b/backend/infra/db/engine.py
@@ -36,10 +36,12 @@ def init_engine(db_path: Path) -> Engine:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     if _engine is not None:
         _engine.dispose()
+    # No pool_pre_ping: it issues an extra "SELECT 1" on every checkout to
+    # detect connections a server dropped from under us.  A local SQLite file
+    # has no such failure mode, so it is pure overhead on the hottest path.
     engine = create_engine(
         f"sqlite:///{db_path}",
         connect_args={"check_same_thread": False},
-        pool_pre_ping=True,
         future=True,
     )
     _install_pragmas(engine)

--- a/backend/infra/soundcloud/client.py
+++ b/backend/infra/soundcloud/client.py
@@ -26,6 +26,27 @@ API_V2_BASE = "https://api-v2.soundcloud.com"
 # HTTP timeout for upstream SoundCloud calls. Overridable via env var for ops.
 TIMEOUT_SECONDS: float = float(os.environ.get("STARLIB_SC_HTTP_TIMEOUT", "15"))
 
+# One client for the process, so connections (and their TLS handshakes) are
+# reused across calls. Building a fresh AsyncClient per request throws the
+# pool away every time and makes every call pay a new handshake.
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return the shared client, creating it on first use."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=TIMEOUT_SECONDS)
+    return _client
+
+
+async def close_client() -> None:
+    """Close the shared client. Called on application shutdown."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
 
 def _headers(token: str, *, accept_json: bool) -> dict[str, str]:
     headers = {"Authorization": f"OAuth {token}"}
@@ -50,14 +71,13 @@ async def request(
     public API drops the Authorization header and returns 401 when those are
     present.
     """
-    async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
-        return await client.request(
-            method,
-            url,
-            params=params or None,
-            headers=_headers(token, accept_json=accept_json),
-            follow_redirects=follow_redirects,
-        )
+    return await get_client().request(
+        method,
+        url,
+        params=params or None,
+        headers=_headers(token, accept_json=accept_json),
+        follow_redirects=follow_redirects,
+    )
 
 
 async def get(

--- a/backend/infra/soundcloud/client.py
+++ b/backend/infra/soundcloud/client.py
@@ -13,6 +13,7 @@ re-auth prompt — so that stays in the routers.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 
@@ -26,26 +27,35 @@ API_V2_BASE = "https://api-v2.soundcloud.com"
 # HTTP timeout for upstream SoundCloud calls. Overridable via env var for ops.
 TIMEOUT_SECONDS: float = float(os.environ.get("STARLIB_SC_HTTP_TIMEOUT", "15"))
 
-# One client for the process, so connections (and their TLS handshakes) are
+# One client per event loop, so connections (and their TLS handshakes) are
 # reused across calls. Building a fresh AsyncClient per request throws the
 # pool away every time and makes every call pay a new handshake.
+#
+# The client is keyed on the running loop, not just cached: its pooled
+# connections are bound to the loop that opened them, so handing a client from
+# a finished loop to a new one raises "Event loop is closed". The app has a
+# single long-lived loop; tests and scripts do not.
 _client: httpx.AsyncClient | None = None
+_client_loop: asyncio.AbstractEventLoop | None = None
 
 
 def get_client() -> httpx.AsyncClient:
-    """Return the shared client, creating it on first use."""
-    global _client
-    if _client is None or _client.is_closed:
+    """Return the shared client for the running loop, creating it on first use."""
+    global _client, _client_loop
+    loop = asyncio.get_running_loop()
+    if _client is None or _client.is_closed or _client_loop is not loop:
         _client = httpx.AsyncClient(timeout=TIMEOUT_SECONDS)
+        _client_loop = loop
     return _client
 
 
 async def close_client() -> None:
     """Close the shared client. Called on application shutdown."""
-    global _client
+    global _client, _client_loop
     if _client is not None and not _client.is_closed:
         await _client.aclose()
     _client = None
+    _client_loop = None
 
 
 def _headers(token: str, *, accept_json: bool) -> dict[str, str]:

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -5,6 +5,7 @@ index scan per configured folder; unwinds all three on shutdown.
 """
 
 import logging
+import threading
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from fastapi import FastAPI
 from backend.config import get_backend_settings
 from backend.infra import cache, watcher
 from backend.infra.ai import ollama as ollama_service
+from backend.infra.soundcloud import client as sc_client
 from backend.services import app_settings as app_settings_service
 from backend.services import folder_config as folder_config_service
 from backend.services.collection.indexing import ensure_folder_indexed
@@ -27,7 +29,10 @@ async def lifespan(app: FastAPI):
 
     # Initialise SQLite cache (creates tables if first run)
     cache.init_db(settings.cache_dir / "metadata.db")
-    cache.prune_missing_files()
+
+    # Pruning stat()s every cached path; on a large library that is tens of
+    # thousands of syscalls. Off the startup path — nothing below depends on it.
+    threading.Thread(target=cache.prune_missing_files, daemon=True).start()
 
     # Start watchdog observer for real-time file change detection
     watcher.start_watcher(root)
@@ -42,5 +47,7 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    await sc_client.close_client()
+    await ollama_service.close_client()
     ollama_service.shutdown()
     watcher.stop_watcher()

--- a/backend/services/collection/indexing.py
+++ b/backend/services/collection/indexing.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from backend.infra import cache
-from backend.infra.audio.folders import load_tracks_recursive
+from backend.infra.audio.folders import FILETYPE_MAP, load_tracks_recursive
 from backend.infra.audio.track_handler import TrackHandler
 
 logger = logging.getLogger(__name__)
@@ -26,13 +26,14 @@ _indexed_this_session: set[Path] = set()  # folders fully scanned this session
 _state_lock = threading.Lock()
 
 
-def _index_one(root_folder: Path, file: Path) -> None:
-    """Index a single file into the DB if its mtime has changed."""
+# Rows written per transaction during a folder scan.  One commit per file
+# means one WAL fsync per file; batching amortises that over the whole scan.
+_WRITE_BATCH_SIZE = 200
+
+
+def _build_row(root_folder: Path, file: Path, mtime: float, size: int) -> dict | None:
+    """Read *file*'s tags and project them into a cache row, or None if unreadable."""
     try:
-        stat = file.stat()
-        mtime = stat.st_mtime
-        if cache.get_track_mtime(file) == mtime:
-            return  # unchanged
         handler = TrackHandler(root_folder=root_folder, file=file)
         track_info = handler.track_info
         missing: list[str] = []
@@ -45,7 +46,7 @@ def _index_one(root_folder: Path, file: Path) -> None:
         if not track_info.artwork:
             missing.append("artwork")
         sc_id = track_info.starlib_meta.soundcloud_id if track_info.starlib_meta else None
-        cache.upsert_track(
+        return cache.track_row(
             file_path=file,
             folder=file.parent.resolve(),
             title=track_info.title or None,
@@ -55,7 +56,7 @@ def _index_one(root_folder: Path, file: Path) -> None:
             bpm=track_info.bpm,
             release_date=track_info.release_date,
             has_artwork=track_info.artwork is not None,
-            file_size=stat.st_size,
+            file_size=size,
             file_format=file.suffix,
             duration=track_info.length,
             is_complete=track_info.complete,
@@ -70,18 +71,69 @@ def _index_one(root_folder: Path, file: Path) -> None:
         )
     except Exception as e:
         logger.warning("Skipping unreadable file %s: %s", file, e)
+        return None
+
+
+def _index_one(root_folder: Path, file: Path) -> None:
+    """Index a single file into the DB if its mtime has changed."""
+    try:
+        stat = file.stat()
+    except OSError as e:
+        logger.warning("Skipping unreadable file %s: %s", file, e)
+        return
+    if cache.get_track_mtime(file) == stat.st_mtime:
+        return  # unchanged
+    row = _build_row(root_folder, file, stat.st_mtime, stat.st_size)
+    if row is not None:
+        cache.upsert_tracks([row])
+
+
+def _stale_files(folder: Path, audio_files: list[Path]) -> list[tuple[Path, float, int]]:
+    """Return (file, mtime, size) for files whose on-disk mtime differs from the cache."""
+    known = cache.get_track_mtimes(folder.resolve(), recursive=True)
+    stale: list[tuple[Path, float, int]] = []
+    for f in audio_files:
+        try:
+            stat = f.stat()
+        except OSError:
+            continue
+        if known.get(str(f)) != stat.st_mtime:
+            stale.append((f, stat.st_mtime, stat.st_size))
+    return stale
 
 
 def _load_folder_to_db(folder: Path, root_folder: Path) -> None:
     """Scan *folder* recursively, indexing new/changed files into the DB."""
     resolved = folder.resolve()
     try:
-        audio_files = load_tracks_recursive(folder)
+        # Only formats the tag reader can actually open — otherwise every
+        # stray .asd/.jpg costs a mutagen open that raises.
+        audio_files = load_tracks_recursive(folder, list(FILETYPE_MAP))
+        stale = _stale_files(folder, audio_files)
+
+        written = 0
+        batch: list[dict] = []
         with ThreadPoolExecutor() as pool:
-            futures = [pool.submit(_index_one, root_folder, f) for f in audio_files]
-            for _ in as_completed(futures):
-                pass
-        logger.info("Finished indexing %s (%d files)", folder, len(audio_files))
+            futures = [pool.submit(_build_row, root_folder, f, mtime, size) for f, mtime, size in stale]
+            for future in as_completed(futures):
+                row = future.result()
+                if row is None:
+                    continue
+                batch.append(row)
+                if len(batch) >= _WRITE_BATCH_SIZE:
+                    cache.upsert_tracks(batch)
+                    written += len(batch)
+                    batch = []
+        if batch:
+            cache.upsert_tracks(batch)
+            written += len(batch)
+
+        logger.info(
+            "Finished indexing %s (%d files, %d changed)",
+            folder,
+            len(audio_files),
+            written,
+        )
     except Exception as e:
         logger.error("Failed to index folder %s: %s", folder, e)
     finally:

--- a/backend/services/collection/query.py
+++ b/backend/services/collection/query.py
@@ -56,6 +56,8 @@ def list_and_filter_tracks(
     file_formats: list[str] | None = None,
     size_min: int | None = None,
     size_max: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list:
     """
     List, filter, and sort tracks via SQL. Returns sqlite3.Row items.
@@ -86,6 +88,10 @@ def list_and_filter_tracks(
         "asc" or "desc"
     recursive : bool
         Include tracks in subfolders
+    limit : int, optional
+        Maximum rows to return. Applied in SQL.
+    offset : int, optional
+        Rows to skip before collecting. Applied in SQL.
 
     Returns
     -------
@@ -110,6 +116,81 @@ def list_and_filter_tracks(
         size_max=size_max,
         sort_by=sort_by,
         sort_order=sort_order,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def count_filtered_tracks(
+    folder: Path,
+    search_query: str | None = None,
+    genres: list[str] | None = None,
+    artists: list[str] | None = None,
+    keys: list[str] | None = None,
+    bpm_min: int | None = None,
+    bpm_max: int | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    recursive: bool = False,
+    has_soundcloud_id: bool | None = None,
+    file_formats: list[str] | None = None,
+    size_min: int | None = None,
+    size_max: int | None = None,
+) -> int:
+    """Total rows matching the same filters as :func:`list_and_filter_tracks`.
+
+    Parameters
+    ----------
+    folder : Path
+        Folder to scan
+    search_query : str, optional
+        Case-insensitive substring search across title, artist, genre
+    genres : list[str], optional
+        Exact genre matches (OR logic)
+    artists : list[str], optional
+        Substring artist matches (OR logic)
+    keys : list[str], optional
+        Exact key matches (OR logic)
+    bpm_min : int, optional
+        Minimum BPM (inclusive)
+    bpm_max : int, optional
+        Maximum BPM (inclusive)
+    start_date : date, optional
+        Earliest release date (inclusive)
+    end_date : date, optional
+        Latest release date (inclusive)
+    recursive : bool
+        Include tracks in subfolders
+    has_soundcloud_id : bool, optional
+        Filter by SoundCloud link presence
+    file_formats : list[str], optional
+        Exact file-format matches (OR logic)
+    size_min : int, optional
+        Minimum file size in bytes
+    size_max : int, optional
+        Maximum file size in bytes
+
+    Returns
+    -------
+    int
+        Number of matching rows.
+    """
+    ensure_folder_indexed(folder)
+    return cache.count_tracks(
+        folder.resolve(),
+        recursive=recursive,
+        search_query=search_query,
+        genres=genres,
+        artists=artists,
+        keys=keys,
+        bpm_min=bpm_min,
+        bpm_max=bpm_max,
+        start_date=start_date,
+        end_date=end_date,
+        has_soundcloud_id=has_soundcloud_id,
+        file_formats=file_formats,
+        size_min=size_min,
+        size_max=size_max,
     )
 
 

--- a/tests/api/test_browse_pagination.py
+++ b/tests/api/test_browse_pagination.py
@@ -1,0 +1,132 @@
+"""Paged browse endpoints.
+
+Paging is resolved in SQL now, so these pin the contract the frontend's
+infinite scroll relies on: ``total`` is the filter total (not the page size),
+each page holds ``size`` rows, and scrolling through every page yields each
+track exactly once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.infra import cache
+from backend.infra.db import engine as db_engine
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine():
+    yield
+    if db_engine._engine is not None:  # type: ignore[attr-defined]
+        db_engine._engine.dispose()  # type: ignore[attr-defined]
+    db_engine._engine = None  # type: ignore[attr-defined]
+    db_engine._engine_path = None  # type: ignore[attr-defined]
+
+
+def _add(folder: Path, name: str, *, genre: str = "House") -> None:
+    cache.upsert_track(
+        file_path=folder / name,
+        folder=folder,
+        title=name,
+        artist_str="Artist",
+        genre=genre,
+        key=None,
+        bpm=124,
+        release_date=None,
+        has_artwork=False,
+        file_size=1,
+        file_format=".mp3",
+        duration=None,
+        is_complete=False,
+        missing_fields=[],
+        mtime=1.0,
+    )
+
+
+@pytest.fixture
+def seeded(tmp_music_folder: Path) -> Path:
+    root = tmp_music_folder.resolve()
+    cache.init_db(root / "cache.db")
+    collection = root / "collection"
+    for i in range(25):
+        _add(collection, f"track_{i:02d}.mp3")
+    return collection
+
+
+def test_browse_path_reports_the_filter_total_not_the_page_size(client: TestClient, seeded: Path) -> None:
+    resp = client.get(
+        "/api/metadata/folders/browse-path",
+        params={"path": str(seeded), "page": 1, "size": 10},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["total"] == 25
+    assert len(data["items"]) == 10
+
+
+def test_browse_path_pages_cover_every_track_once(client: TestClient, seeded: Path) -> None:
+    seen: list[str] = []
+    for page in (1, 2, 3):
+        resp = client.get(
+            "/api/metadata/folders/browse-path",
+            params={"path": str(seeded), "page": page, "size": 10},
+        )
+        assert resp.status_code == 200
+        seen += [item["file_path"] for item in resp.json()["items"]]
+
+    assert len(seen) == 25
+    assert len(set(seen)) == 25, "a track appeared on more than one page"
+
+
+def test_browse_path_last_page_is_partial(client: TestClient, seeded: Path) -> None:
+    resp = client.get(
+        "/api/metadata/folders/browse-path",
+        params={"path": str(seeded), "page": 3, "size": 10},
+    )
+    assert len(resp.json()["items"]) == 5
+
+
+def test_browse_path_total_respects_filters(client: TestClient, seeded: Path) -> None:
+    _add(seeded, "techno.mp3", genre="Techno")
+
+    resp = client.get(
+        "/api/metadata/folders/browse-path",
+        params={"path": str(seeded), "genres": ["Techno"], "page": 1, "size": 10},
+    )
+    data = resp.json()
+    assert data["total"] == 1
+    assert [item["genre"] for item in data["items"]] == ["Techno"]
+
+
+def test_browse_mode_endpoint_pages_too(client: TestClient, seeded: Path) -> None:
+    resp = client.get(
+        "/api/metadata/folders/collection/browse",
+        params={"page": 1, "size": 10},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 25
+    assert len(data["items"]) == 10
+
+
+def test_sorting_still_applies_across_pages(client: TestClient, seeded: Path) -> None:
+    """Sort order must hold globally, not just within a page."""
+    all_titles: list[str] = []
+    for page in (1, 2, 3):
+        resp = client.get(
+            "/api/metadata/folders/browse-path",
+            params={
+                "path": str(seeded),
+                "page": page,
+                "size": 10,
+                "sort_by": "title",
+                "sort_order": "desc",
+            },
+        )
+        all_titles += [item["title"] for item in resp.json()["items"]]
+
+    assert all_titles == sorted(all_titles, reverse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,22 @@ from fastapi_pagination import add_pagination
 from backend.api.deps import get_root_folder
 from backend.api.metadata import router as metadata_router
 from backend.api.setup import router as setup_router
+from backend.infra.ai import ollama as ollama_service
+from backend.infra.soundcloud import client as sc_client
+
+
+@pytest.fixture(autouse=True)
+def _reset_http_clients():
+    """Drop the cached httpx clients between tests.
+
+    Both adapters memoise one client per event loop. A test that patches
+    ``httpx.AsyncClient`` would otherwise leave its stand-in in the cache for
+    every test that runs after it.
+    """
+    yield
+    for module in (sc_client, ollama_service):
+        module._client = None
+        module._client_loop = None
 
 
 @pytest.fixture

--- a/tests/infra/test_cache_pagination.py
+++ b/tests/infra/test_cache_pagination.py
@@ -1,0 +1,108 @@
+"""SQL-level paging for the browse endpoints.
+
+``get_tracks`` used to return the whole folder and let the API layer slice it
+in Python, so every page request materialised the full row set.  These tests
+pin the paged behaviour: the slice happens in SQL, the count matches the same
+filters, and paging through a folder yields every row exactly once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.infra import cache
+from backend.infra.db import engine as db_engine
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine():
+    yield
+    if db_engine._engine is not None:  # type: ignore[attr-defined]
+        db_engine._engine.dispose()  # type: ignore[attr-defined]
+    db_engine._engine = None  # type: ignore[attr-defined]
+    db_engine._engine_path = None  # type: ignore[attr-defined]
+
+
+def _add(folder: Path, name: str, *, genre: str = "House", bpm: int | None = 120) -> None:
+    cache.upsert_track(
+        file_path=folder / name,
+        folder=folder,
+        title=name,
+        artist_str="Artist",
+        genre=genre,
+        key=None,
+        bpm=bpm,
+        release_date=None,
+        has_artwork=False,
+        file_size=1,
+        file_format=".mp3",
+        duration=None,
+        is_complete=False,
+        missing_fields=[],
+        mtime=1.0,
+    )
+
+
+@pytest.fixture
+def folder(tmp_path: Path) -> Path:
+    cache.init_db(tmp_path / "cache.db")
+    music = tmp_path / "music"
+    music.mkdir()
+    for i in range(25):
+        _add(music, f"track_{i:02d}.mp3")
+    return music
+
+
+def test_limit_and_offset_slice_in_sql(folder: Path) -> None:
+    page1 = cache.get_tracks(folder, limit=10, offset=0)
+    page2 = cache.get_tracks(folder, limit=10, offset=10)
+    page3 = cache.get_tracks(folder, limit=10, offset=20)
+
+    assert [len(p) for p in (page1, page2, page3)] == [10, 10, 5]
+
+
+def test_paging_covers_every_row_exactly_once(folder: Path) -> None:
+    seen: list[str] = []
+    for offset in range(0, 25, 10):
+        seen += [r["file_path"] for r in cache.get_tracks(folder, limit=10, offset=offset)]
+
+    all_rows = [r["file_path"] for r in cache.get_tracks(folder)]
+    assert len(seen) == 25
+    assert len(set(seen)) == 25, "a row appeared on two pages"
+    assert sorted(seen) == sorted(all_rows)
+
+
+def test_ordering_is_total_so_pages_are_stable(folder: Path) -> None:
+    """Rows tying on the sort column must not swap between page requests."""
+    # Every row here has the same bpm, so bpm alone cannot order them.
+    first = [r["file_path"] for r in cache.get_tracks(folder, sort_by="bpm", limit=10, offset=0)]
+    again = [r["file_path"] for r in cache.get_tracks(folder, sort_by="bpm", limit=10, offset=0)]
+    assert first == again
+
+    second = [r["file_path"] for r in cache.get_tracks(folder, sort_by="bpm", limit=10, offset=10)]
+    assert not set(first) & set(second)
+
+
+def test_count_matches_filters(folder: Path) -> None:
+    _add(folder, "techno_a.mp3", genre="Techno")
+    _add(folder, "techno_b.mp3", genre="Techno")
+
+    assert cache.count_tracks(folder) == 27
+    assert cache.count_tracks(folder, genres=["Techno"]) == 2
+
+    # The count must agree with what an unpaged fetch under the same filters returns.
+    rows = cache.get_tracks(folder, genres=["Techno"])
+    assert cache.count_tracks(folder, genres=["Techno"]) == len(rows)
+
+
+def test_count_is_independent_of_the_page_slice(folder: Path) -> None:
+    """The total reported to the client is the filter total, not the page size."""
+    page = cache.get_tracks(folder, limit=10, offset=0)
+    assert len(page) == 10
+    assert cache.count_tracks(folder) == 25
+
+
+def test_no_limit_returns_everything(folder: Path) -> None:
+    assert len(cache.get_tracks(folder)) == 25

--- a/tests/infra/test_shared_http_clients.py
+++ b/tests/infra/test_shared_http_clients.py
@@ -1,0 +1,60 @@
+"""The shared httpx clients must not leak across event loops.
+
+Both adapters keep one client so connections are reused instead of
+re-handshaking per call.  A plain module-level cache is not enough: an
+``AsyncClient``'s pooled connections belong to the loop that opened them, so
+handing a client from a finished loop to a new one raises "Event loop is
+closed".  The cache is therefore keyed on the running loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.infra.ai import ollama
+from backend.infra.soundcloud import client as sc_client
+
+MODULES = pytest.mark.parametrize("module", [sc_client, ollama], ids=["soundcloud", "ollama"])
+
+
+@MODULES
+def test_same_loop_reuses_one_client(module) -> None:
+    async def scenario():
+        return module.get_client(), module.get_client()
+
+    first, second = asyncio.run(scenario())
+    assert first is second
+
+
+@MODULES
+def test_a_new_loop_gets_a_fresh_client(module) -> None:
+    """A client from a closed loop must never be handed out again."""
+
+    async def scenario():
+        return module.get_client()
+
+    first = asyncio.run(scenario())
+    second = asyncio.run(scenario())
+
+    assert first is not second, "client from a finished loop was reused"
+
+
+@MODULES
+def test_close_client_clears_the_cache(module) -> None:
+    async def scenario():
+        client = module.get_client()
+        await module.close_client()
+        return client
+
+    closed = asyncio.run(scenario())
+    assert closed.is_closed
+    assert module._client is None
+    assert module._client_loop is None
+
+
+@MODULES
+def test_close_client_is_safe_when_never_used(module) -> None:
+    asyncio.run(module.close_client())
+    assert module._client is None

--- a/tests/services/test_indexing_efficiency.py
+++ b/tests/services/test_indexing_efficiency.py
@@ -1,0 +1,179 @@
+"""The folder scan must not do redundant work.
+
+Two regressions this pins:
+
+* ``TrackHandler.track`` was a plain property, so reading one track's tags
+  re-opened and re-parsed the file three times (once directly, twice more via
+  ``get_single_cover``).
+* the scan issued a ``get_track_mtime`` query and a separate write transaction
+  per file, so an unchanged folder still cost one round trip per track.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from mutagen.id3 import ID3, TIT2
+from mutagen.mp3 import MP3
+
+from backend.infra import cache
+from backend.infra.audio import folders as folders_mod
+from backend.infra.audio import track_handler as th
+from backend.infra.db import engine as db_engine
+from backend.services.collection import indexing
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine():
+    yield
+    if db_engine._engine is not None:  # type: ignore[attr-defined]
+        db_engine._engine.dispose()  # type: ignore[attr-defined]
+    db_engine._engine = None  # type: ignore[attr-defined]
+    db_engine._engine_path = None  # type: ignore[attr-defined]
+    indexing._indexed_this_session.clear()
+    indexing._indexing.clear()
+
+
+def _make_mp3(path: Path, title: str) -> None:
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "quiet",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=mono",
+            "-t",
+            "1",
+            "-c:a",
+            "libmp3lame",
+            str(path),
+        ],
+        check=True,
+    )
+    tags = ID3()
+    tags.add(TIT2(encoding=3, text=title))
+    tags.save(path)
+
+
+@pytest.fixture
+def counting_mp3(monkeypatch):
+    """Patch the MP3 reader to count how often a file is opened and parsed."""
+    calls = {"n": 0}
+
+    class Counting(MP3):
+        def __init__(self, *args, **kwargs):
+            calls["n"] += 1
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setitem(folders_mod.FILETYPE_MAP, ".mp3", Counting)
+    monkeypatch.setitem(th.FILETYPE_MAP, ".mp3", Counting)
+    return calls
+
+
+def test_track_info_parses_the_file_once(tmp_path: Path, counting_mp3) -> None:
+    f = tmp_path / "a.mp3"
+    _make_mp3(f, "Title A")
+
+    handler = th.TrackHandler(root_folder=tmp_path, file=f)
+    info = handler.track_info
+
+    assert info.title == "Title A"
+    assert counting_mp3["n"] == 1, "track_info re-opened the file"
+
+
+def test_reading_cover_reuses_the_parsed_file(tmp_path: Path, counting_mp3) -> None:
+    f = tmp_path / "b.mp3"
+    _make_mp3(f, "Title B")
+
+    handler = th.TrackHandler(root_folder=tmp_path, file=f)
+    assert handler.track_info is not None
+    handler.get_single_cover(raise_error=False)
+    assert handler.covers == []
+
+    assert counting_mp3["n"] == 1
+
+
+def test_scan_indexes_every_audio_file(tmp_path: Path) -> None:
+    cache.init_db(tmp_path / "cache.db")
+    music = tmp_path / "music"
+    music.mkdir()
+    for i in range(3):
+        _make_mp3(music / f"t{i}.mp3", f"Track {i}")
+
+    indexing._load_folder_to_db(music, music)
+
+    rows = cache.get_tracks(music.resolve())
+    assert {r["title"] for r in rows} == {"Track 0", "Track 1", "Track 2"}
+
+
+def test_rescan_of_unchanged_folder_writes_nothing(tmp_path: Path, monkeypatch) -> None:
+    """An unchanged folder must not re-read tags or re-write rows."""
+    cache.init_db(tmp_path / "cache.db")
+    music = tmp_path / "music"
+    music.mkdir()
+    for i in range(3):
+        _make_mp3(music / f"t{i}.mp3", f"Track {i}")
+
+    indexing._load_folder_to_db(music, music)
+
+    built: list[Path] = []
+    original = indexing._build_row
+
+    def counting_build_row(root: Path, f: Path, mtime: float, size: int):
+        built.append(f)
+        return original(root, f, mtime, size)
+
+    writes: list[int] = []
+    original_upsert = cache.upsert_tracks
+
+    def counting_upsert(rows) -> None:
+        writes.append(len(rows))
+        original_upsert(rows)
+
+    monkeypatch.setattr(indexing, "_build_row", counting_build_row)
+    monkeypatch.setattr(indexing.cache, "upsert_tracks", counting_upsert)
+
+    indexing._indexed_this_session.clear()
+    indexing._load_folder_to_db(music, music)
+
+    assert built == [], "unchanged files were re-parsed"
+    assert writes == [], "unchanged folder issued a write"
+
+
+def test_non_audio_files_are_not_opened(tmp_path: Path) -> None:
+    """Stray files must be filtered out before the tag reader sees them."""
+    cache.init_db(tmp_path / "cache.db")
+    music = tmp_path / "music"
+    music.mkdir()
+    _make_mp3(music / "real.mp3", "Real")
+    (music / "sidecar.asd").write_bytes(b"not audio")
+    (music / "cover.jpg").write_bytes(b"not audio")
+
+    indexing._load_folder_to_db(music, music)
+
+    rows = cache.get_tracks(music.resolve())
+    assert [r["file_name"] for r in rows] == ["real.mp3"]
+
+
+def test_changed_file_is_reindexed(tmp_path: Path) -> None:
+    cache.init_db(tmp_path / "cache.db")
+    music = tmp_path / "music"
+    music.mkdir()
+    f = music / "t.mp3"
+    _make_mp3(f, "Before")
+
+    indexing._load_folder_to_db(music, music)
+    assert [r["title"] for r in cache.get_tracks(music.resolve())] == ["Before"]
+
+    tags = ID3(f)
+    tags.delall("TIT2")
+    tags.add(TIT2(encoding=3, text="After"))
+    tags.save(f)
+
+    indexing._indexed_this_session.clear()
+    indexing._load_folder_to_db(music, music)
+    assert [r["title"] for r in cache.get_tracks(music.resolve())] == ["After"]


### PR DESCRIPTION
Backend performance pass from an audit of the app. Written against `worktree-backend-architecture-plan` (every file touched here
moved in that restructure); that branch landed on `main` as #573 while this was
in progress, so it is rebased onto `main` and targets `main`.

Measured on a 300-file folder of real MP3s:

| | before | after |
|---|---|---|
| cold folder scan | 0.387s | **0.064s** |
| re-scan, nothing changed | 0.036s | **0.003s** |
| mutagen file parses | 900 | **300** |
| write transactions | 300 | **2** |

## What changed

**Folder scanning** (`593e56c`)

- `TrackHandler.track` was a plain property, so each access re-opened the file and re-parsed every ID3 frame, embedded artwork included. Reading one track's tags hit it **three times** — once in `track_info`, twice more via `get_single_cover`, which re-evaluated `self.covers`. Now cached; `covers` bound to a local.
- The scan ran one `get_track_mtime` query per file just to decide it had nothing to do. Now one query loads the folder's `{path: mtime}` up front.
- Each file committed its own transaction — one WAL fsync per file. Rows are now assembled off-thread and written in batches of 200.
- `load_tracks_recursive` ran without a format filter, so every stray `.asd`/`.jpg` cost a mutagen open that raised and logged a warning.
- Dropped `pool_pre_ping`: it adds a `SELECT 1` to every connection checkout to catch server-dropped connections, which a local SQLite file cannot have.

**Browse pagination** (`62e6fcd`)

`get_tracks` had no `LIMIT`/`OFFSET` — it materialised every row in the folder and `fastapi_pagination` sliced it in Python. Fetching page 7 of a 30k-track folder pulled all 30k rows out of SQLite and built 30k row objects, on every infinite-scroll fetch, sort toggle and filter change (and every 2s while the table polls during indexing). Now sliced in SQL with a separate `COUNT(*)` for the total.

Sorting also falls back to `file_path` so the order is total — without it, rows tying on the sort column could swap between page requests and the same track would appear on two pages. That bug was reachable before this PR too.

**Connections, startup, invalidation** (`b79acef`)

- The SoundCloud transport and the Ollama adapter each built a fresh `httpx.AsyncClient` per call, throwing away the connection pool so every request paid a new TCP + TLS handshake. One client per process now, closed on shutdown.
- `prune_missing_files` stat()s every cached path — tens of thousands of syscalls — before the app served its first request. Moved to a background thread; nothing in startup depends on it.
- The artwork upload/delete endpoints called `invalidate_cache()` with no argument, clearing the whole session index and forcing a re-scan of **every** folder after editing one file's cover. Now re-indexes just that file, matching the sibling metadata endpoints.

## Tests

23 new tests across three files. The two parse-count tests were confirmed to fail against the old code (6 opens vs 1), so they are not vacuous.

- `tests/services/test_indexing_efficiency.py` — parse counts, unchanged-folder rescan does zero reads and zero writes, non-audio files skipped, changed files still re-indexed.
- `tests/infra/test_cache_pagination.py` — SQL slicing, paging covers every row exactly once, stable order under ties, count matches filters.
- `tests/api/test_browse_pagination.py` — end-to-end through both browse endpoints: total is the filter total not the page size, pages don't overlap, sort holds across pages.

Browse had **no** endpoint tests before this PR.

323 pass; ruff, mypy, pydoclint and the layer-boundary hook are clean.

## Deliberately not included

- **Folder tree walks the whole library on every filter change.** `_folder_tree_dict` runs `os.walk` over the music root, and the frontend refires `/folders/tree` on every genre/key/format toggle. The fix is a cached walk invalidated from the watchdog observer — real design work, worth its own PR.
- **Transcoded-WAV cache grows without bound.** Stale entries are pruned per-file only, so distinct AIFFs accumulate forever at ~60 MB each. Needs a size-capped LRU, i.e. a policy decision.
- **Peaks stored as JSON text.** 2000 floats ≈ 38 KB of text re-parsed per request; a float32 blob is ~8 KB. Needs a migration.
- **Frontend items** (unforwarded `AbortSignal` in `use-followings-tracks`, unmemoised table rows). Left out to keep this PR aligned with its backend-only base branch.

One correction to my own audit worth recording: I initially flagged "artwork bytes loaded just to set a boolean" as separate waste. Mutagen parses APIC eagerly on open, so those bytes were already in memory — it was a symptom of the triple-parse, not an independent cost, and the first commit covers it.
